### PR TITLE
feat: 로딩UI수정

### DIFF
--- a/app/structure/lib/components/loading_screen.dart
+++ b/app/structure/lib/components/loading_screen.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/material.dart';
+import 'package:structure/config/pallete.dart';
+
+class LoadingScreen extends StatelessWidget {
+  const LoadingScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const CircularProgressIndicator(
+      color: Palette.loadingIcon,
+    );
+  }
+}

--- a/app/structure/lib/config/labels.dart
+++ b/app/structure/lib/config/labels.dart
@@ -1,0 +1,7 @@
+class Labels {
+  //비밀번호
+  static const pwdErrorStr = "대소문자, 숫자, 특수문자를 포함해 10자 이상으로 입력하세요!";
+  static const pwdPattern =
+      r'^(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[0-9])(?=.*?[!@#$%^&*()\-_=+{};:,<.>]).{10,}$';
+  static const pwdNotSame = "비밀번호가 일치하지 않습니다.";
+}

--- a/app/structure/lib/config/pallete.dart
+++ b/app/structure/lib/config/pallete.dart
@@ -53,59 +53,167 @@ class Palette {
   static const Color notCompleteBg = Color(0xffffebeb);
 
   static const Color starIcon = Color(0xffffe871);
-
+  static const Color loadingIcon = Color(0xff38c55f);
   // Text Style Palette
   static TextStyle h1 = TextStyle(fontSize: 50.sp, fontWeight: FontWeight.w700);
   static TextStyle h2 = TextStyle(fontSize: 40.sp, fontWeight: FontWeight.w700);
   static TextStyle h3 = TextStyle(fontSize: 36.sp, fontWeight: FontWeight.w700);
-  static TextStyle h3Green = TextStyle(fontSize: 36.sp, fontWeight: FontWeight.w700, color: const Color(0xff38c55f));
+  static TextStyle h3Green = TextStyle(
+      fontSize: 36.sp,
+      fontWeight: FontWeight.w700,
+      color: const Color(0xff38c55f));
   static TextStyle h4 = TextStyle(fontSize: 30.sp, fontWeight: FontWeight.w600);
-  static TextStyle h4Grey = TextStyle(fontSize: 30.sp, fontWeight: FontWeight.w600, color: const Color(0xff4a4a4a));
+  static TextStyle h4Grey = TextStyle(
+      fontSize: 30.sp,
+      fontWeight: FontWeight.w600,
+      color: const Color(0xff4a4a4a));
   static TextStyle h5 = TextStyle(fontSize: 24.sp, fontWeight: FontWeight.w400);
-  static TextStyle h5White = TextStyle(fontSize: 24.sp, fontWeight: FontWeight.w400, color: const Color(0xffffffff));
-  static TextStyle h5Grey = TextStyle(fontSize: 24.sp, fontWeight: FontWeight.w400, color: const Color(0xff848484));
-  static TextStyle h5LightGrey = TextStyle(fontSize: 24.sp, fontWeight: FontWeight.w400, color: const Color(0xff9f9f9f));
+  static TextStyle h5White = TextStyle(
+      fontSize: 24.sp,
+      fontWeight: FontWeight.w400,
+      color: const Color(0xffffffff));
+  static TextStyle h5Grey = TextStyle(
+      fontSize: 24.sp,
+      fontWeight: FontWeight.w400,
+      color: const Color(0xff848484));
+  static TextStyle h5LightGrey = TextStyle(
+      fontSize: 24.sp,
+      fontWeight: FontWeight.w400,
+      color: const Color(0xff9f9f9f));
 
-  static TextStyle mainBtnTitle = TextStyle(fontSize: 36.sp, fontWeight: FontWeight.w500, color: const Color(0xffffffff));
+  static TextStyle mainBtnTitle = TextStyle(
+      fontSize: 36.sp,
+      fontWeight: FontWeight.w500,
+      color: const Color(0xffffffff));
 
-  static TextStyle fieldTitle = TextStyle(fontSize: 24.sp, fontWeight: FontWeight.w600, color: const Color(0xff4a4a4a));
-  static TextStyle fieldContent = TextStyle(fontSize: 30.sp, fontWeight: FontWeight.w400);
-  static TextStyle fieldContentGreen = TextStyle(fontSize: 30.sp, fontWeight: FontWeight.w600, color: const Color(0xff38c55f));
-  static TextStyle fieldPlaceHolder = TextStyle(fontSize: 30.sp, fontWeight: FontWeight.w400, color: const Color(0xff9f9f9f));
-  static TextStyle fieldPlaceHolderWhite = TextStyle(fontSize: 30.sp, fontWeight: FontWeight.w400, color: const Color(0xffffffff));
-  static TextStyle fieldDetail = TextStyle(fontSize: 20.sp, fontWeight: FontWeight.w400, color: const Color(0xff9f9f9f));
-  static TextStyle fieldAlert = TextStyle(fontSize: 20.sp, fontWeight: FontWeight.w400, color: const Color(0xfff34e4e));
-  static TextStyle userInfoIndex = TextStyle(fontSize: 24.sp, fontWeight: FontWeight.w600);
-  static TextStyle userInfoTitle = TextStyle(fontSize: 20.sp, fontWeight: FontWeight.w600, color: const Color(0xff9f9f9f));
-  static TextStyle userInfoContent = TextStyle(fontSize: 24.sp, fontWeight: FontWeight.w400, color: const Color(0xff4a4a4a));
-  static TextStyle userLevelText = TextStyle(fontSize: 16.sp, fontWeight: FontWeight.w600, color: const Color(0xff816cff));
+  static TextStyle fieldTitle = TextStyle(
+      fontSize: 24.sp,
+      fontWeight: FontWeight.w600,
+      color: const Color(0xff4a4a4a));
+  static TextStyle fieldContent =
+      TextStyle(fontSize: 30.sp, fontWeight: FontWeight.w400);
+  static TextStyle fieldContentGreen = TextStyle(
+      fontSize: 30.sp,
+      fontWeight: FontWeight.w600,
+      color: const Color(0xff38c55f));
+  static TextStyle fieldPlaceHolder = TextStyle(
+      fontSize: 30.sp,
+      fontWeight: FontWeight.w400,
+      color: const Color(0xff9f9f9f));
+  static TextStyle fieldPlaceHolderWhite = TextStyle(
+      fontSize: 30.sp,
+      fontWeight: FontWeight.w400,
+      color: const Color(0xffffffff));
+  static TextStyle fieldDetail = TextStyle(
+      fontSize: 20.sp,
+      fontWeight: FontWeight.w400,
+      color: const Color(0xff9f9f9f));
+  static TextStyle fieldAlert = TextStyle(
+      fontSize: 20.sp,
+      fontWeight: FontWeight.w400,
+      color: const Color(0xfff34e4e));
+  static TextStyle userInfoIndex =
+      TextStyle(fontSize: 24.sp, fontWeight: FontWeight.w600);
+  static TextStyle userInfoTitle = TextStyle(
+      fontSize: 20.sp,
+      fontWeight: FontWeight.w600,
+      color: const Color(0xff9f9f9f));
+  static TextStyle userInfoContent = TextStyle(
+      fontSize: 24.sp,
+      fontWeight: FontWeight.w400,
+      color: const Color(0xff4a4a4a));
+  static TextStyle userLevelText = TextStyle(
+      fontSize: 16.sp,
+      fontWeight: FontWeight.w600,
+      color: const Color(0xff816cff));
 
-  static TextStyle appBarTitle = TextStyle(fontSize: 30.sp, fontWeight: FontWeight.w600, color: const Color(0xff4a4a4a));
+  static TextStyle appBarTitle = TextStyle(
+      fontSize: 30.sp,
+      fontWeight: FontWeight.w600,
+      color: const Color(0xff4a4a4a));
 
-  static TextStyle popupContent = TextStyle(fontSize: 32.sp, fontWeight: FontWeight.w400);
-  static TextStyle popupBtn = TextStyle(fontSize: 24.sp, fontWeight: FontWeight.w400, color: const Color(0xff38c55f));
-  static TextStyle dialogContentBold = TextStyle(fontSize: 30.sp, fontWeight: FontWeight.w600);
-  static TextStyle dialogContentSmall = TextStyle(fontSize: 24.sp, fontWeight: FontWeight.w600, color: const Color(0xff9f9f9f));
-  static TextStyle dialogLeftBtnTitle = TextStyle(fontSize: 30.sp, fontWeight: FontWeight.w600, color: const Color(0xff4a4a4a));
-  static TextStyle dialogRightBtnTitle = TextStyle(fontSize: 30.sp, fontWeight: FontWeight.w600);
+  static TextStyle popupContent =
+      TextStyle(fontSize: 32.sp, fontWeight: FontWeight.w400);
+  static TextStyle popupBtn = TextStyle(
+      fontSize: 24.sp,
+      fontWeight: FontWeight.w400,
+      color: const Color(0xff38c55f));
+  static TextStyle dialogContentBold =
+      TextStyle(fontSize: 30.sp, fontWeight: FontWeight.w600);
+  static TextStyle dialogContentSmall = TextStyle(
+      fontSize: 24.sp,
+      fontWeight: FontWeight.w600,
+      color: const Color(0xff9f9f9f));
+  static TextStyle dialogLeftBtnTitle = TextStyle(
+      fontSize: 30.sp,
+      fontWeight: FontWeight.w600,
+      color: const Color(0xff4a4a4a));
+  static TextStyle dialogRightBtnTitle =
+      TextStyle(fontSize: 30.sp, fontWeight: FontWeight.w600);
 
-  static TextStyle completeText = TextStyle(fontSize: 20.sp, fontWeight: FontWeight.w700, color: const Color(0xff38c55f));
-  static TextStyle notCompleteText = TextStyle(fontSize: 20.sp, fontWeight: FontWeight.w700, color: const Color(0xffff4949));
-  static TextStyle editableText = TextStyle(fontSize: 20.sp, fontWeight: FontWeight.w700, color: const Color(0xffffffff));
-  static TextStyle notEditableText = TextStyle(fontSize: 20.sp, fontWeight: FontWeight.w700, color: const Color(0xff9f9f9f));
-  static TextStyle seqNoText = TextStyle(fontSize: 20.sp, fontWeight: FontWeight.w600, color: const Color(0xff816cff));
-  static TextStyle completeTextLarge = TextStyle(fontSize: 24.sp, fontWeight: FontWeight.w600, color: const Color(0xff38c55f));
-  static TextStyle notCompleteTextLarge = TextStyle(fontSize: 24.sp, fontWeight: FontWeight.w600, color: const Color(0xffff4949));
+  static TextStyle completeText = TextStyle(
+      fontSize: 20.sp,
+      fontWeight: FontWeight.w700,
+      color: const Color(0xff38c55f));
+  static TextStyle notCompleteText = TextStyle(
+      fontSize: 20.sp,
+      fontWeight: FontWeight.w700,
+      color: const Color(0xffff4949));
+  static TextStyle editableText = TextStyle(
+      fontSize: 20.sp,
+      fontWeight: FontWeight.w700,
+      color: const Color(0xffffffff));
+  static TextStyle notEditableText = TextStyle(
+      fontSize: 20.sp,
+      fontWeight: FontWeight.w700,
+      color: const Color(0xff9f9f9f));
+  static TextStyle seqNoText = TextStyle(
+      fontSize: 20.sp,
+      fontWeight: FontWeight.w600,
+      color: const Color(0xff816cff));
+  static TextStyle completeTextLarge = TextStyle(
+      fontSize: 24.sp,
+      fontWeight: FontWeight.w600,
+      color: const Color(0xff38c55f));
+  static TextStyle notCompleteTextLarge = TextStyle(
+      fontSize: 24.sp,
+      fontWeight: FontWeight.w600,
+      color: const Color(0xffff4949));
 
-  static TextStyle mngNum = TextStyle(fontSize: 45.sp, fontWeight: FontWeight.w700);
-  static TextStyle dataListBar = TextStyle(fontSize: 20.sp, fontWeight: FontWeight.w500, color: const Color(0xff6d6c6c));
-  static TextStyle dataListMngNum = TextStyle(fontSize: 24.sp, fontWeight: FontWeight.w400, color: const Color(0xff4a4a4a));
-  static TextStyle dataListdate = TextStyle(fontSize: 20.sp, fontWeight: FontWeight.w400, color: const Color(0xff9f9f9f));
-  static TextStyle dataListUserId = TextStyle(fontSize: 20.sp, fontWeight: FontWeight.w400, color: const Color(0xff9f9f9f));
+  static TextStyle mngNum =
+      TextStyle(fontSize: 45.sp, fontWeight: FontWeight.w700);
+  static TextStyle dataListBar = TextStyle(
+      fontSize: 20.sp,
+      fontWeight: FontWeight.w500,
+      color: const Color(0xff6d6c6c));
+  static TextStyle dataListMngNum = TextStyle(
+      fontSize: 24.sp,
+      fontWeight: FontWeight.w400,
+      color: const Color(0xff4a4a4a));
+  static TextStyle dataListdate = TextStyle(
+      fontSize: 20.sp,
+      fontWeight: FontWeight.w400,
+      color: const Color(0xff9f9f9f));
+  static TextStyle dataListUserId = TextStyle(
+      fontSize: 20.sp,
+      fontWeight: FontWeight.w400,
+      color: const Color(0xff9f9f9f));
 
-  static TextStyle dDayText = TextStyle(fontSize: 10.sp, fontWeight: FontWeight.w600, color: const Color(0xff816cff));
+  static TextStyle dDayText = TextStyle(
+      fontSize: 10.sp,
+      fontWeight: FontWeight.w600,
+      color: const Color(0xff816cff));
 
-  static TextStyle filterTitle = TextStyle(fontSize: 20.sp, fontWeight: FontWeight.w600, color: const Color(0xff4a4a4a));
-  static TextStyle filterContent = TextStyle(fontSize: 24.sp, fontWeight: FontWeight.w400, color: const Color(0xff9f9f9f));
-  static TextStyle filterContentGreen = TextStyle(fontSize: 24.sp, fontWeight: FontWeight.w400, color: const Color(0xff38c55f));
+  static TextStyle filterTitle = TextStyle(
+      fontSize: 20.sp,
+      fontWeight: FontWeight.w600,
+      color: const Color(0xff4a4a4a));
+  static TextStyle filterContent = TextStyle(
+      fontSize: 24.sp,
+      fontWeight: FontWeight.w400,
+      color: const Color(0xff9f9f9f));
+  static TextStyle filterContentGreen = TextStyle(
+      fontSize: 24.sp,
+      fontWeight: FontWeight.w400,
+      color: const Color(0xff38c55f));
 }

--- a/app/structure/lib/dataSource/remote_data_source.dart
+++ b/app/structure/lib/dataSource/remote_data_source.dart
@@ -45,7 +45,7 @@ class RemoteDataSource {
 
   /// 유저 중복검사 (GET)
   static Future<dynamic> dupliCheck(String userId) async {
-    dynamic response = await _getApi('user/id-check?userId=$userId');
+    dynamic response = await _getApi('user/duplicate_check?userId=$userId');
     return response;
   }
 

--- a/app/structure/lib/screen/data_management/normal/data_management_home_screen.dart
+++ b/app/structure/lib/screen/data_management/normal/data_management_home_screen.dart
@@ -11,6 +11,7 @@ import 'package:structure/components/custom_app_bar.dart';
 import 'package:structure/components/custom_table_bar.dart';
 import 'package:structure/components/custom_table_calendar.dart';
 import 'package:structure/components/list_card.dart';
+import 'package:structure/components/loading_screen.dart';
 import 'package:structure/components/main_button.dart';
 import 'package:structure/components/main_text_field.dart';
 import 'package:structure/config/pallete.dart';
@@ -169,7 +170,7 @@ class _DataManagementHomeScreenState extends State<DataManagementHomeScreen> {
                 ),
                 context.watch<DataManagementHomeViewModel>().isLoading
                     ? const Center(
-                        child: CircularProgressIndicator(),
+                        child: LoadingScreen(),
                       )
                     : Container(),
               ],

--- a/app/structure/lib/screen/data_management/normal/not_editable/insertion_meat_image_not_editable_screen.dart
+++ b/app/structure/lib/screen/data_management/normal/not_editable/insertion_meat_image_not_editable_screen.dart
@@ -8,6 +8,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:provider/provider.dart';
 import 'package:structure/components/custom_app_bar.dart';
+import 'package:structure/components/loading_screen.dart';
 import 'package:structure/components/main_button.dart';
 import 'package:structure/config/pallete.dart';
 import 'package:structure/viewModel/data_management/normal/not_editable/insertion_meat_image_not_editable_view_model.dart';
@@ -149,7 +150,7 @@ class InsertionMeatImageNotEditableScreen extends StatelessWidget {
           ),
           context.watch<InsertionMeatImageNotEditableViewModel>().isLoading
               ? const Center(
-                  child: CircularProgressIndicator(),
+                  child: LoadingScreen(),
                 )
               : Container(),
         ],

--- a/app/structure/lib/screen/data_management/researcher/data_add_home_screen.dart
+++ b/app/structure/lib/screen/data_management/researcher/data_add_home_screen.dart
@@ -10,6 +10,7 @@ import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:provider/provider.dart';
 import 'package:structure/components/custom_app_bar.dart';
 import 'package:structure/components/deep_aging_card.dart';
+import 'package:structure/components/loading_screen.dart';
 import 'package:structure/config/pallete.dart';
 import 'package:structure/viewModel/data_management/researcher/data_add_home_view_model.dart';
 
@@ -162,7 +163,7 @@ class _DataAddHomeState extends State<DataAddHome> {
                 height: 450.h,
                 // 딥에이징 추가 데이터 입력 (DeepAgingCard 컴포넌트 사용) - 클릭 | 삭제 시 대응되는 함수 호출
                 child: context.watch<DataAddHomeViewModel>().isLoading
-                    ? const Center(child: CircularProgressIndicator())
+                    ? const Center(child: LoadingScreen())
                     : ListView.builder(
                         itemCount: context
                             .read<DataAddHomeViewModel>()

--- a/app/structure/lib/screen/data_management/researcher/data_management_home_researcher_screen.dart
+++ b/app/structure/lib/screen/data_management/researcher/data_management_home_researcher_screen.dart
@@ -11,6 +11,7 @@ import 'package:structure/components/custom_app_bar.dart';
 import 'package:structure/components/custom_table_bar.dart';
 import 'package:structure/components/custom_table_calendar.dart';
 import 'package:structure/components/list_card.dart';
+import 'package:structure/components/loading_screen.dart';
 import 'package:structure/components/main_button.dart';
 import 'package:structure/components/main_text_field.dart';
 import 'package:structure/config/pallete.dart';
@@ -171,7 +172,7 @@ class _DataManagementHomeResearcherScreenState
             ),
             context.watch<DataManagementHomeResearcherViewModel>().isLoading
                 ? const Center(
-                    child: CircularProgressIndicator(),
+                    child: LoadingScreen(),
                   )
                 : Container(),
           ],

--- a/app/structure/lib/screen/data_management/researcher/heatedmeat_eval_screen.dart
+++ b/app/structure/lib/screen/data_management/researcher/heatedmeat_eval_screen.dart
@@ -8,6 +8,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:provider/provider.dart';
 import 'package:structure/components/custom_app_bar.dart';
+import 'package:structure/components/loading_screen.dart';
 import 'package:structure/components/main_button.dart';
 import 'package:structure/components/part_eval.dart';
 import 'package:structure/viewModel/data_management/researcher/heatedmeat_eval_view_model.dart';
@@ -118,7 +119,7 @@ class _HeatedMeatEvaluation extends State<HeatedMeatEvaluation>
               ],
             ),
             context.watch<HeatedMeatEvalViewModel>().isLoading
-                ? const CircularProgressIndicator()
+                ? const LoadingScreen()
                 : Container()
           ],
         ),

--- a/app/structure/lib/screen/data_management/researcher/insertion_lab_data_screen.dart
+++ b/app/structure/lib/screen/data_management/researcher/insertion_lab_data_screen.dart
@@ -9,6 +9,7 @@ import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:provider/provider.dart';
 import 'package:structure/components/custom_app_bar.dart';
 import 'package:structure/components/labdata_field.dart';
+import 'package:structure/components/loading_screen.dart';
 import 'package:structure/components/main_button.dart';
 import 'package:structure/viewModel/data_management/researcher/insertion_lab_data_view_model.dart';
 
@@ -119,7 +120,7 @@ class _InsertionLabDataScreenState extends State<InsertionLabDataScreen> {
                 ],
               ),
               context.watch<InsertionLabDataViewModel>().isLoading
-                  ? const CircularProgressIndicator()
+                  ? const LoadingScreen()
                   : Container()
             ],
           ),

--- a/app/structure/lib/screen/data_management/researcher/insertion_tongue_data_screen.dart
+++ b/app/structure/lib/screen/data_management/researcher/insertion_tongue_data_screen.dart
@@ -8,6 +8,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:provider/provider.dart';
 import 'package:structure/components/custom_app_bar.dart';
+import 'package:structure/components/loading_screen.dart';
 import 'package:structure/components/main_button.dart';
 import 'package:structure/components/tongue_field.dart';
 import 'package:structure/viewModel/data_management/researcher/insertion_tongue_data_view_model.dart';
@@ -97,7 +98,7 @@ class _InsertionTongueDataScreenState extends State<InsertionTongueDataScreen> {
                 ],
               ),
               context.watch<InsertionTongueDataViewModel>().isLoading
-                  ? const CircularProgressIndicator()
+                  ? const LoadingScreen()
                   : Container()
             ],
           ),

--- a/app/structure/lib/screen/meat_registration/meat_registration_screen.dart
+++ b/app/structure/lib/screen/meat_registration/meat_registration_screen.dart
@@ -8,6 +8,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:provider/provider.dart';
 import 'package:structure/components/custom_app_bar.dart';
+import 'package:structure/components/loading_screen.dart';
 import 'package:structure/components/step_card.dart';
 import 'package:structure/config/pallete.dart';
 import 'package:structure/model/meat_model.dart';
@@ -43,7 +44,7 @@ class _MeatRegistrationScreenState extends State<MeatRegistrationScreen> {
       ),
       body: Center(
         child: context.watch<MeatRegistrationViewModel>().isLoading
-            ? const CircularProgressIndicator()
+            ? const LoadingScreen()
             : Column(
                 children: [
                   SizedBox(

--- a/app/structure/lib/screen/meat_registration/registration_meat_image_screen.dart
+++ b/app/structure/lib/screen/meat_registration/registration_meat_image_screen.dart
@@ -11,6 +11,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:provider/provider.dart';
 import 'package:structure/components/custom_app_bar.dart';
+import 'package:structure/components/loading_screen.dart';
 import 'package:structure/components/main_button.dart';
 import 'package:structure/config/pallete.dart';
 import 'package:structure/viewModel/meat_registration/registration_meat_image_view_model.dart';
@@ -239,7 +240,7 @@ class RegistrationMeatImageScreen extends StatelessWidget {
           // 로딩 화면
           context.watch<RegistrationMeatImageViewModel>().isLoading
               ? const Center(
-                  child: CircularProgressIndicator(),
+                  child: LoadingScreen(),
                 )
               : Container(),
         ],

--- a/app/structure/lib/screen/my_page/change_password_screen.dart
+++ b/app/structure/lib/screen/my_page/change_password_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:provider/provider.dart';
 import 'package:structure/components/custom_app_bar.dart';
+import 'package:structure/components/loading_screen.dart';
 import 'package:structure/components/main_button.dart';
 import 'package:structure/components/main_input_field.dart';
 import 'package:structure/config/pallete.dart';
@@ -113,7 +114,7 @@ class _ChangePasswordScreenState extends State<ChangePasswordScreen> {
           ),
           context.watch<ChangePasswordViewModel>().isLoading
               ? const Center(
-                  child: CircularProgressIndicator(),
+                  child: LoadingScreen(),
                 )
               : Container(),
         ],

--- a/app/structure/lib/screen/my_page/user_detail_screen.dart
+++ b/app/structure/lib/screen/my_page/user_detail_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:provider/provider.dart';
 import 'package:structure/components/custom_app_bar.dart';
+import 'package:structure/components/loading_screen.dart';
 import 'package:structure/components/main_button.dart';
 import 'package:structure/components/main_input_field.dart';
 import 'package:structure/config/pallete.dart';
@@ -154,7 +155,7 @@ class UserDetailScreen extends StatelessWidget {
               ],
             ),
             context.watch<UserDetailViewModel>().isLoading
-                ? const Center(child: CircularProgressIndicator())
+                ? const Center(child: LoadingScreen())
                 : Container(),
           ],
         ),

--- a/app/structure/lib/screen/sign_in/sign_in_screen.dart
+++ b/app/structure/lib/screen/sign_in/sign_in_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
+import 'package:structure/components/loading_screen.dart';
 import 'package:structure/components/main_button.dart';
 import 'package:structure/components/main_input_field.dart';
 import 'package:structure/config/pallete.dart';
@@ -151,7 +152,7 @@ class _SignInScreenState extends State<SignInScreen> {
             Center(
               child: // 데이터를 처리하는 동안 로딩 위젯 보여주기
                   context.watch<SignInViewModel>().isLoading
-                      ? const CircularProgressIndicator()
+                      ? const LoadingScreen()
                       : Container(),
             ),
           ],

--- a/app/structure/lib/screen/sign_up/insertion_user_detail_screen.dart
+++ b/app/structure/lib/screen/sign_up/insertion_user_detail_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:provider/provider.dart';
 import 'package:structure/components/custom_app_bar.dart';
+import 'package:structure/components/loading_screen.dart';
 import 'package:structure/components/main_button.dart';
 import 'package:structure/components/main_input_field.dart';
 import 'package:structure/config/pallete.dart';
@@ -157,7 +158,7 @@ class _InsertionUserDetailScreenState extends State<InsertionUserDetailScreen> {
             ),
             context.watch<InsertionUserDetailViewModel>().isLoading
                 ? const Center(
-                    child: CircularProgressIndicator(),
+                    child: LoadingScreen(),
                   )
                 : Container()
           ],

--- a/app/structure/lib/screen/sign_up/insertion_user_info_screen.dart
+++ b/app/structure/lib/screen/sign_up/insertion_user_info_screen.dart
@@ -7,6 +7,7 @@ import 'package:structure/components/main_button.dart';
 import 'package:structure/components/main_input_field.dart';
 import 'package:structure/config/pallete.dart';
 import 'package:structure/viewModel/sign_up/insertion_user_info_view_model.dart';
+import 'package:structure/components/loading_screen.dart';
 
 class InsertionUserInfoScreen extends StatefulWidget {
   const InsertionUserInfoScreen({super.key});
@@ -28,289 +29,304 @@ class _InsertionUserInfoScreenState extends State<InsertionUserInfoScreen> {
       ),
       body: GestureDetector(
         onTap: () => FocusScope.of(context).unfocus(),
-        child: SingleChildScrollView(
-          child: Form(
-            key: context.read<InsertionUserInfoViewModel>().formKey,
-            child: Column(
-              children: [
-                Column(
-                  crossAxisAlignment: CrossAxisAlignment.center,
+        child: Stack(
+          children: [
+            SingleChildScrollView(
+              child: Form(
+                key: context.read<InsertionUserInfoViewModel>().formKey,
+                child: Column(
                   children: [
-                    SizedBox(
-                      height: 30.h,
-                    ),
-                    Container(
-                      margin: EdgeInsets.only(left: 40.w),
-                      alignment: Alignment.centerLeft,
-                      child: Text(
-                        '이름',
-                        style: Palette.fieldTitle,
-                      ),
-                    ),
-                    SizedBox(
-                      height: 8.h,
-                    ),
-                    MainInputField(
-                      mode: 1,
-                      width: 640.w,
-                      controller:
-                          context.read<InsertionUserInfoViewModel>().name,
-                    ),
-                    SizedBox(
-                      height: 30.h,
-                    ),
-                    Container(
-                      margin: EdgeInsets.only(left: 40.w),
-                      alignment: Alignment.centerLeft,
-                      child: Text(
-                        '이메일',
-                        style: Palette.fieldTitle,
-                      ),
-                    ),
-                    SizedBox(
-                      height: 8.h,
-                    ),
-                    Stack(
+                    Column(
+                      crossAxisAlignment: CrossAxisAlignment.center,
                       children: [
-                        // 이메일 입력 필드
+                        SizedBox(
+                          height: 30.h,
+                        ),
+                        Container(
+                          margin: EdgeInsets.only(left: 40.w),
+                          alignment: Alignment.centerLeft,
+                          child: Text(
+                            '이름',
+                            style: Palette.fieldTitle,
+                          ),
+                        ),
+                        SizedBox(
+                          height: 8.h,
+                        ),
+                        MainInputField(
+                          mode: 1,
+                          width: 640.w,
+                          controller:
+                              context.read<InsertionUserInfoViewModel>().name,
+                        ),
+                        SizedBox(
+                          height: 30.h,
+                        ),
+                        Container(
+                          margin: EdgeInsets.only(left: 40.w),
+                          alignment: Alignment.centerLeft,
+                          child: Text(
+                            '이메일',
+                            style: Palette.fieldTitle,
+                          ),
+                        ),
+                        SizedBox(
+                          height: 8.h,
+                        ),
+                        Stack(
+                          children: [
+                            // 이메일 입력 필드
+                            MainInputField(
+                              formKey: context
+                                  .read<InsertionUserInfoViewModel>()
+                                  .formKey,
+                              mode: 1,
+                              width: 640.w,
+                              controller: context
+                                  .read<InsertionUserInfoViewModel>()
+                                  .email,
+                              validateFunc: (value) => context
+                                  .read<InsertionUserInfoViewModel>()
+                                  .idValidate(value),
+                              onChangeFunc: (value) => context
+                                  .read<InsertionUserInfoViewModel>()
+                                  .onChangeEmail(value),
+                              contentPadding:
+                                  EdgeInsets.only(left: 30.w, right: 200.w),
+                            ),
+                            // 중복확인 버튼
+                            Positioned(
+                              right: 30.w,
+                              child: TextButton(
+                                onPressed: context
+                                        .watch<InsertionUserInfoViewModel>()
+                                        .isUnique
+                                    ? null
+                                    : () => context
+                                            .read<InsertionUserInfoViewModel>()
+                                            .isValidId
+                                        ? context
+                                            .read<InsertionUserInfoViewModel>()
+                                            .dupliCheck(context)
+                                        : null,
+                                child: context
+                                        .read<InsertionUserInfoViewModel>()
+                                        .isUnique
+                                    ? const Icon(
+                                        Icons.check,
+                                        color: Palette.mainBtnAtvBg,
+                                      )
+                                    : Text(
+                                        '중복확인',
+                                        style: Palette.fieldContent
+                                            .copyWith(color: Colors.black),
+                                      ),
+                              ),
+                            ),
+                          ],
+                        ),
+                        SizedBox(
+                          height: 30.h,
+                        ),
+                        Container(
+                          margin: EdgeInsets.only(left: 40.w),
+                          alignment: Alignment.centerLeft,
+                          child: Text(
+                            '비밀번호',
+                            style: Palette.fieldTitle,
+                          ),
+                        ),
+                        SizedBox(
+                          height: 8.h,
+                        ),
+                        // 비밀번호 입력 필드
                         MainInputField(
                           formKey: context
                               .read<InsertionUserInfoViewModel>()
                               .formKey,
                           mode: 1,
+                          obscureText: true,
                           width: 640.w,
-                          controller:
-                              context.read<InsertionUserInfoViewModel>().email,
+                          controller: context
+                              .read<InsertionUserInfoViewModel>()
+                              .password,
                           validateFunc: (value) => context
                               .read<InsertionUserInfoViewModel>()
-                              .idValidate(value),
-                          onChangeFunc: (value) => context
-                              .read<InsertionUserInfoViewModel>()
-                              .onChangeEmail(value),
-                          contentPadding:
-                              EdgeInsets.only(left: 30.w, right: 200.w),
+                              .pwValidate(value),
+                          hintText: '영문 대/소문자+숫자+특수문자',
                         ),
-                        // 중복확인 버튼
-                        Positioned(
-                          right: 30.w,
-                          child: TextButton(
-                            onPressed: context
-                                    .watch<InsertionUserInfoViewModel>()
-                                    .isUnique
-                                ? null
-                                : () => context
-                                        .read<InsertionUserInfoViewModel>()
-                                        .isValidId
-                                    ? context
-                                        .read<InsertionUserInfoViewModel>()
-                                        .dupliCheck(context)
-                                    : null,
-                            child: context
-                                    .read<InsertionUserInfoViewModel>()
-                                    .isUnique
-                                ? const Icon(
-                                    Icons.check,
-                                    color: Palette.mainBtnAtvBg,
-                                  )
-                                : Text(
-                                    '중복확인',
-                                    style: Palette.fieldContent
-                                        .copyWith(color: Colors.black),
-                                  ),
-                          ),
+                        SizedBox(
+                          height: 16.h,
+                        ),
+                        MainInputField(
+                          formKey: context
+                              .read<InsertionUserInfoViewModel>()
+                              .formKey,
+                          mode: 1,
+                          obscureText: true,
+                          width: 640.w,
+                          controller: context
+                              .read<InsertionUserInfoViewModel>()
+                              .cPassword,
+                          validateFunc: (value) => context
+                              .read<InsertionUserInfoViewModel>()
+                              .cPwValidate(value),
+                          hintText: '비밀번호 확인',
                         ),
                       ],
                     ),
                     SizedBox(
-                      height: 30.h,
+                      height: 32.h,
                     ),
                     Container(
-                      margin: EdgeInsets.only(left: 40.w),
-                      alignment: Alignment.centerLeft,
-                      child: Text(
-                        '패스워드',
-                        style: Palette.fieldTitle,
+                      decoration: BoxDecoration(
+                          border: Border.all(
+                            color: Palette.fieldBorder,
+                          ),
+                          borderRadius: BorderRadius.circular(15.sp)),
+                      width: 640.h,
+                      child: Column(children: [
+                        Row(
+                          children: [
+                            Checkbox(
+                              value: context
+                                  .watch<InsertionUserInfoViewModel>()
+                                  .isChecked1,
+                              onChanged: (value) => context
+                                  .read<InsertionUserInfoViewModel>()
+                                  .clicked1stCheckBox(value),
+                              shape: RoundedRectangleBorder(
+                                borderRadius: BorderRadius.circular(10),
+                              ),
+                              activeColor: Palette.mainBtnAtvBg,
+                              checkColor: Colors.white,
+                            ),
+                            Text(
+                              '약관 전체 동의',
+                              style: Palette.h5,
+                            ),
+                          ],
+                        ),
+                        SizedBox(
+                          width: 640.w,
+                          child: const Divider(
+                            height: 0,
+                          ),
+                        ),
+                        Row(
+                          children: [
+                            Checkbox(
+                              value: context
+                                  .watch<InsertionUserInfoViewModel>()
+                                  .isChecked2,
+                              onChanged: (value) => context
+                                  .read<InsertionUserInfoViewModel>()
+                                  .clicked2ndCheckBox(value),
+                              shape: RoundedRectangleBorder(
+                                borderRadius: BorderRadius.circular(10),
+                              ),
+                              activeColor: Palette.mainBtnAtvBg,
+                              checkColor: Colors.white,
+                            ),
+                            Text(
+                              '(필수) 개인정보 수집/제공 동의',
+                              style: Palette.h5,
+                            ),
+                            const Spacer(),
+                            InkWell(
+                              onTap: () => showTermsPopup(context),
+                              child: Container(
+                                margin: EdgeInsets.only(right: 24.w),
+                                child: Icon(
+                                  Icons.arrow_forward_ios,
+                                  size: 20.sp,
+                                ),
+                              ),
+                            )
+                          ],
+                        ),
+                        Row(
+                          children: [
+                            Checkbox(
+                              value: context
+                                  .watch<InsertionUserInfoViewModel>()
+                                  .isChecked3,
+                              onChanged: (value) => context
+                                  .read<InsertionUserInfoViewModel>()
+                                  .clicked3rdCheckBox(value),
+                              shape: RoundedRectangleBorder(
+                                borderRadius: BorderRadius.circular(10),
+                              ),
+                              activeColor: Palette.mainBtnAtvBg,
+                              checkColor: Colors.white,
+                            ),
+                            Text(
+                              '(필수) 제 3자 정보 제공 동의',
+                              style: Palette.h5,
+                            ),
+                            const Spacer(),
+                            InkWell(
+                              onTap: () => showTermsPopup(context),
+                              child: Container(
+                                margin: EdgeInsets.only(right: 24.w),
+                                child: Icon(
+                                  Icons.arrow_forward_ios,
+                                  size: 20.sp,
+                                ),
+                              ),
+                            )
+                          ],
+                        ),
+                        Row(
+                          children: [
+                            Checkbox(
+                              value: context
+                                  .watch<InsertionUserInfoViewModel>()
+                                  .isChecked4,
+                              onChanged: (value) => context
+                                  .read<InsertionUserInfoViewModel>()
+                                  .clicked4thCheckBox(value),
+                              shape: RoundedRectangleBorder(
+                                borderRadius: BorderRadius.circular(10),
+                              ),
+                              activeColor: Palette.mainBtnAtvBg,
+                              checkColor: Colors.white,
+                            ),
+                            Text(
+                              '(선택) 알림받기',
+                              style: Palette.h5,
+                            ),
+                          ],
+                        ),
+                      ]),
+                    ),
+                    Container(
+                      margin: EdgeInsets.symmetric(vertical: 40.h),
+                      child: MainButton(
+                        mode: 1,
+                        onPressed: context
+                                .read<InsertionUserInfoViewModel>()
+                                .isAllChecked()
+                            ? () => context
+                                .read<InsertionUserInfoViewModel>()
+                                .clickedNextButton(context)
+                            : null,
+                        text: '다음',
+                        width: 640.w,
+                        height: 96.h,
                       ),
-                    ),
-                    SizedBox(
-                      height: 8.h,
-                    ),
-                    // 패스워드 입력 필드
-                    MainInputField(
-                      formKey:
-                          context.read<InsertionUserInfoViewModel>().formKey,
-                      mode: 1,
-                      obscureText: true,
-                      width: 640.w,
-                      controller:
-                          context.read<InsertionUserInfoViewModel>().password,
-                      validateFunc: (value) => context
-                          .read<InsertionUserInfoViewModel>()
-                          .pwValidate(value),
-                      hintText: '영문 대/소문자+숫자+특수문자',
-                    ),
-                    SizedBox(
-                      height: 16.h,
-                    ),
-                    MainInputField(
-                      formKey:
-                          context.read<InsertionUserInfoViewModel>().formKey,
-                      mode: 1,
-                      obscureText: true,
-                      width: 640.w,
-                      controller:
-                          context.read<InsertionUserInfoViewModel>().cPassword,
-                      validateFunc: (value) => context
-                          .read<InsertionUserInfoViewModel>()
-                          .cPwValidate(value),
-                      hintText: '패스워드 확인',
                     ),
                   ],
                 ),
-                SizedBox(
-                  height: 32.h,
-                ),
-                Container(
-                  decoration: BoxDecoration(
-                      border: Border.all(
-                        color: Palette.fieldBorder,
-                      ),
-                      borderRadius: BorderRadius.circular(15.sp)),
-                  width: 640.h,
-                  child: Column(children: [
-                    Row(
-                      children: [
-                        Checkbox(
-                          value: context
-                              .watch<InsertionUserInfoViewModel>()
-                              .isChecked1,
-                          onChanged: (value) => context
-                              .read<InsertionUserInfoViewModel>()
-                              .clicked1stCheckBox(value),
-                          shape: RoundedRectangleBorder(
-                            borderRadius: BorderRadius.circular(10),
-                          ),
-                          activeColor: Palette.mainBtnAtvBg,
-                          checkColor: Colors.white,
-                        ),
-                        Text(
-                          '약관 전체 동의',
-                          style: Palette.h5,
-                        ),
-                      ],
-                    ),
-                    SizedBox(
-                      width: 640.w,
-                      child: const Divider(
-                        height: 0,
-                      ),
-                    ),
-                    Row(
-                      children: [
-                        Checkbox(
-                          value: context
-                              .watch<InsertionUserInfoViewModel>()
-                              .isChecked2,
-                          onChanged: (value) => context
-                              .read<InsertionUserInfoViewModel>()
-                              .clicked2ndCheckBox(value),
-                          shape: RoundedRectangleBorder(
-                            borderRadius: BorderRadius.circular(10),
-                          ),
-                          activeColor: Palette.mainBtnAtvBg,
-                          checkColor: Colors.white,
-                        ),
-                        Text(
-                          '(필수) 개인정보 수집/제공 동의',
-                          style: Palette.h5,
-                        ),
-                        const Spacer(),
-                        InkWell(
-                          onTap: () => showTermsPopup(context),
-                          child: Container(
-                            margin: EdgeInsets.only(right: 24.w),
-                            child: Icon(
-                              Icons.arrow_forward_ios,
-                              size: 20.sp,
-                            ),
-                          ),
-                        )
-                      ],
-                    ),
-                    Row(
-                      children: [
-                        Checkbox(
-                          value: context
-                              .watch<InsertionUserInfoViewModel>()
-                              .isChecked3,
-                          onChanged: (value) => context
-                              .read<InsertionUserInfoViewModel>()
-                              .clicked3rdCheckBox(value),
-                          shape: RoundedRectangleBorder(
-                            borderRadius: BorderRadius.circular(10),
-                          ),
-                          activeColor: Palette.mainBtnAtvBg,
-                          checkColor: Colors.white,
-                        ),
-                        Text(
-                          '(필수) 제 3자 정보 제공 동의',
-                          style: Palette.h5,
-                        ),
-                        const Spacer(),
-                        InkWell(
-                          onTap: () => showTermsPopup(context),
-                          child: Container(
-                            margin: EdgeInsets.only(right: 24.w),
-                            child: Icon(
-                              Icons.arrow_forward_ios,
-                              size: 20.sp,
-                            ),
-                          ),
-                        )
-                      ],
-                    ),
-                    Row(
-                      children: [
-                        Checkbox(
-                          value: context
-                              .watch<InsertionUserInfoViewModel>()
-                              .isChecked4,
-                          onChanged: (value) => context
-                              .read<InsertionUserInfoViewModel>()
-                              .clicked4thCheckBox(value),
-                          shape: RoundedRectangleBorder(
-                            borderRadius: BorderRadius.circular(10),
-                          ),
-                          activeColor: Palette.mainBtnAtvBg,
-                          checkColor: Colors.white,
-                        ),
-                        Text(
-                          '(선택) 알림받기',
-                          style: Palette.h5,
-                        ),
-                      ],
-                    ),
-                  ]),
-                ),
-                Container(
-                  margin: EdgeInsets.symmetric(vertical: 40.h),
-                  child: MainButton(
-                    mode: 1,
-                    onPressed: context
-                            .read<InsertionUserInfoViewModel>()
-                            .isAllChecked()
-                        ? () => context
-                            .read<InsertionUserInfoViewModel>()
-                            .clickedNextButton(context)
-                        : null,
-                    text: '다음',
-                    width: 640.w,
-                    height: 96.h,
-                  ),
-                ),
-              ],
+              ),
             ),
-          ),
+            Center(
+              child: // 데이터를 처리하는 동안 로딩 위젯 보여주기
+                  context.watch<InsertionUserInfoViewModel>().emailCheckLoading
+                      ? const LoadingScreen()
+                      : Container(),
+            ),
+          ],
         ),
       ),
     );

--- a/app/structure/lib/viewModel/my_page/change_password_view_model.dart
+++ b/app/structure/lib/viewModel/my_page/change_password_view_model.dart
@@ -6,6 +6,7 @@ import 'package:structure/components/custom_pop_up.dart';
 import 'package:structure/config/pallete.dart';
 import 'package:structure/dataSource/remote_data_source.dart';
 import 'package:structure/model/user_model.dart';
+import 'package:structure/config/labels.dart';
 
 class ChangePasswordViewModel with ChangeNotifier {
   UserModel userModel;
@@ -40,7 +41,7 @@ class ChangePasswordViewModel with ChangeNotifier {
     final bool isValid = _validatePassword(value!);
     if (value.isNotEmpty && !isValid) {
       _isValidNewPw = false;
-      return '영문, 숫자, 특수문자를 모두 포함해 10자 이상으로 구성해주세요.';
+      return Labels.pwdErrorStr;
     } else if (value.isEmpty) {
       _isValidNewPw = false;
       return null;
@@ -55,7 +56,7 @@ class ChangePasswordViewModel with ChangeNotifier {
     // 비어있지 않고 비밀번호와 같지 않을 때, 빨간 에러 메시지
     if (value!.isNotEmpty && value != newPW.text) {
       _isValidCPw = false;
-      return '비밀번호가 일치하지 않습니다.';
+      return Labels.pwdNotSame;
     } else if (value.isEmpty) {
       _isValidCPw = false;
       return null;

--- a/app/structure/lib/viewModel/sign_up/insertion_user_info_view_model.dart
+++ b/app/structure/lib/viewModel/sign_up/insertion_user_info_view_model.dart
@@ -5,6 +5,7 @@ import 'package:structure/components/custom_pop_up.dart';
 import 'package:structure/main.dart';
 import 'package:structure/dataSource/remote_data_source.dart';
 import 'package:structure/model/user_model.dart';
+import 'package:structure/config/labels.dart';
 
 class InsertionUserInfoViewModel with ChangeNotifier {
   InsertionUserInfoViewModel(UserModel userModel) {
@@ -37,7 +38,10 @@ class InsertionUserInfoViewModel with ChangeNotifier {
   bool isChecked4 = false;
   bool isRequiredChecked = false;
 
-  // 아이디 유효성 검사
+  //이메일 중복 확인 로딩 여부 확인 변수
+  bool emailCheckLoading = false;
+
+  /// 아이디 유효성 검사
   String? idValidate(String? value) {
     // 비어있지 않고 이메일 형식에 맞지 않을 때, 빨간 예외 메시지
     final bool isValid = EmailValidator.validate(value!);
@@ -59,7 +63,7 @@ class InsertionUserInfoViewModel with ChangeNotifier {
     final bool isValid = validatePassword(value!);
     if (value.isNotEmpty && !isValid) {
       isValidPw = false;
-      return '영문, 숫자, 특수문자를 모두 포함해 10자 이상으로 구성해주세요.';
+      return Labels.pwdErrorStr;
     } else if (value.isEmpty) {
       isValidPw = false;
       return null;
@@ -74,7 +78,7 @@ class InsertionUserInfoViewModel with ChangeNotifier {
     // 비어있지 않고 비밀번호와 같지 않을 때, 빨간 에러 메시지
     if (value!.isNotEmpty && value != password.text) {
       isValidCPw = false;
-      return '비밀번호가 일치하지 않습니다.';
+      return Labels.pwdNotSame;
     } else if (value.isEmpty) {
       isValidCPw = false;
       return null;
@@ -110,14 +114,21 @@ class InsertionUserInfoViewModel with ChangeNotifier {
 
   // 이메일 중복 검사
   Future<void> dupliCheck(BuildContext context) async {
+    //이메일 중복 검사 로딩중인 상태
+    emailCheckLoading = true;
+    notifyListeners();
+
     dynamic isDuplicated = await RemoteDataSource.dupliCheck(email.text);
 
     if (isDuplicated != null) {
       isUnique = true;
+      emailCheckLoading = false;
       notifyListeners();
     } else {
       isUnique = false;
+      emailCheckLoading = false;
       notifyListeners();
+
       // popup 창 띄우기
       if (context.mounted) showDuplicateEmailPopup(context);
     }


### PR DESCRIPTION
회원가입시 비밀번호 오류 문구 수정 → config/labels.dart 추가, 모두 labels에서 가져오도록 변경
로그인 화면에서 "패스워드" -> "비밀번호"로 수정
모든 로딩 화면을 component/loading_screen.dart로 이어지도록 수정
로딩 색 -> 초록으로 수정
이메일 중복 확인 대기 상태 loading_screen으로 넣어서 UI 추가
키보드 올라와 있을 때도이메일 중복 확인 버튼 작동하도록 수정
 
