### PR TITLE
fix: status change api

### DIFF
--- a/test-web/src/API/updateDataStatus.js
+++ b/test-web/src/API/updateDataStatus.js
@@ -6,7 +6,7 @@ export default async function updateDataStatus(confirmVal, id, setStateChanged){
     try{
         const response = await fetch(
             //query parameter : confirmVal, id
-            `http://${apiIP}/meat/${confirmVal}?id=${id}`
+            `http://${apiIP}/meat/update/${confirmVal}?id=${id}`
         );
         setStateChanged(true);
 


### PR DESCRIPTION
<img width="1014" alt="image" src="https://github.com/deun115/Deeplant-Dev/assets/121757695/50bb1289-d8d8-45bb-9e94-40d5c2626b17">


기존에 /get/${confirm}으로 되어 있어서 get/update/로 가야하는 api를 받지 못했음. 프론트에서 /meat/update/${confirm}으로 수정하여 대기중인 육류 데이터에 대하여 반려, 승인 버튼으로 상태를 변경할 수 있도록 수정하였음.