### PR TITLE
fix:신규유저추가 오류 해결

### DIFF
--- a/test-web/src/components/User/UserList.js
+++ b/test-web/src/components/User/UserList.js
@@ -34,19 +34,19 @@ function UserList() {
     window.location.reload();
   };
   const handleRegisterShow = () => setRegisterShow(true);
+  const UserInfo = JSON.parse(localStorage.getItem("UserInfo"));
 
   const handleUserDelete = async (userId) => {
     try {
       const auth = getAuth();
-      const user = auth.currentUser;
-      console.log(user.email);
+      console.log(UserInfo.userId);
       console.log(userId);
-      if (!user) {
+      if (!UserInfo.userId) {  
         showSnackbar("로그인이 필요합니다.", "error");
         return;
       }
 
-      if (user.email === userId) {
+      if (UserInfo.userId === userId) {
         showSnackbar(
           "자신의 계정은 삭제할 수 없습니다. 회원탈퇴는 프로필 페이지에서 가능합니다.",
           "error"

--- a/test-web/src/components/User/UserRegister.js
+++ b/test-web/src/components/User/UserRegister.js
@@ -34,7 +34,7 @@ function UserRegister({ handleClose }) {
   };
 
   const isNameValid = (name) => {
-    const nameRegex = /^[가-힣]+$/;
+    const nameRegex = /^[가-힣a-zA-Z]+$/;
     return nameRegex.test(name);
   };
 

--- a/test-web/src/routes/Profile.js
+++ b/test-web/src/routes/Profile.js
@@ -36,10 +36,9 @@ export default function Profile() {
   const deleteself = async () => {
     try {
       const auth = getAuth();
-      const user = auth.currentUser;
 
       const response = await fetch(
-        `http://${apiIP}/user/delete?userId=${user.email}`
+        `http://${apiIP}/user/delete?userId=${UserInfo.userId}`
       );
 
       if (response.ok) {


### PR DESCRIPTION
신규유저추가를 했을 때 firebase의 auth.currentUser가 생성한 신규 유저로 되어 회원 탈퇴나 다른 유저 삭제시 오류가 나던 문제를 회원 탈퇴나 유저 삭제시 UserInfo에서 현재 유저의 이메일을 불러오는 식으로 고쳤음.

신규 유저 추가에서 이름을 입력할 때 영어도 입력되게 수정