### PR TITLE
fix: statisic 부분 API 수정

### DIFF
--- a/test-web/src/components/Stats/Charts/BoxPlot/Sens_FreshMeat.js
+++ b/test-web/src/components/Stats/Charts/BoxPlot/Sens_FreshMeat.js
@@ -8,7 +8,8 @@ export default function Sens_FreshMeat({ startDate, endDate }) {
   const fetchData = async () => {
     try {
       const response = await fetch(
-        `http://${apiIP}/meat/statistic?type=6&start=${startDate}&end=${endDate}`
+        //`http://${apiIP}/meat/statistic?type=6&start=${startDate}&end=${endDate}`
+        `http://${apiIP}/meat/statistic/sensory-stats/fresh?start=${startDate}&end=${endDate}`
       );
 
       if (!response.ok) {

--- a/test-web/src/components/Stats/Charts/BoxPlot/Sens_HeatedMeat.js
+++ b/test-web/src/components/Stats/Charts/BoxPlot/Sens_HeatedMeat.js
@@ -9,7 +9,7 @@ export default function Sens_HeatedMeat({ startDate, endDate }) {
   const fetchData = async () => {
     try {
       const response = await fetch(
-        `http://${apiIP}/meat/statistic?type=8&start=${startDate}&end=${endDate}`
+        `http://${apiIP}/meat/statistic/sensory-stats/heated-fresh?start=${startDate}&end=${endDate}`
       );
 
       if (!response.ok) {

--- a/test-web/src/components/Stats/Charts/BoxPlot/Sens_ProcMeat.js
+++ b/test-web/src/components/Stats/Charts/BoxPlot/Sens_ProcMeat.js
@@ -9,7 +9,7 @@ export default function Sens_ProcMeat({ startDate, endDate }) {
   const fetchData = async () => {
     try {
       const response = await fetch(
-        `http://${apiIP}/meat/statistic?type=7&start=${startDate}&end=${endDate}`
+        `http://${apiIP}/meat/statistic/sensory-stats/processed?start=${startDate}&end=${endDate}`
       );
 
       if (!response.ok) {

--- a/test-web/src/components/Stats/Charts/BoxPlot/Taste_FreshMeat.js
+++ b/test-web/src/components/Stats/Charts/BoxPlot/Taste_FreshMeat.js
@@ -9,7 +9,7 @@ export default function Taste_FreshMeat({ startDate, endDate }) {
   const fetchData = async () => {
     try {
       const response = await fetch(
-        `http://${apiIP}/meat/statistic?type=4&start=${startDate}&end=${endDate}`
+        `http://${apiIP}/meat/statistic/probexpt-stats/fresh?start=${startDate}&end=${endDate}`
       );
 
       if (!response.ok) {

--- a/test-web/src/components/Stats/Charts/BoxPlot/Taste_ProcMeat.js
+++ b/test-web/src/components/Stats/Charts/BoxPlot/Taste_ProcMeat.js
@@ -9,7 +9,7 @@ export default function Taste_ProcMeat({ startDate, endDate }) {
   const fetchData = async () => {
     try {
       const response = await fetch(
-        `http://${apiIP}/meat/statistic?type=5&start=${startDate}&end=${endDate}`
+        `http://${apiIP}/meat/statistic/probexpt-stats/processed?start=${startDate}&end=${endDate}&seqno=1`
       );
 
       if (!response.ok) {

--- a/test-web/src/components/Stats/Charts/Corr/Sens_Fresh_Corr.js
+++ b/test-web/src/components/Stats/Charts/Corr/Sens_Fresh_Corr.js
@@ -10,7 +10,7 @@ export default function Sense_Fresh_Corr({ startDate, endDate }) {
     const fetchData = async () => {
       try {
         const response = await fetch(
-          `http://${apiIP}/meat/statistic?type=6&start=${startDate}&end=${endDate}`
+          `http://${apiIP}/meat/statistic/sensory-stats/fresh?start=${startDate}&end=${endDate}`
         );
 
         if (!response.ok) {

--- a/test-web/src/components/Stats/Charts/Corr/Sens_Heated_Corr.js
+++ b/test-web/src/components/Stats/Charts/Corr/Sens_Heated_Corr.js
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from "react";
 import ApexCharts from "react-apexcharts";
 import { apiIP } from "../../../../config";
 
-export default function Sense_Proc_Corr({ startDate, endDate }) {
+export default function Sense_Heated_Corr({ startDate, endDate }) {
   const [chartData, setChartData] = useState({});
   const [prop, setProp] = useState([]);
 
@@ -10,7 +10,7 @@ export default function Sense_Proc_Corr({ startDate, endDate }) {
     const fetchData = async () => {
       try {
         const response = await fetch(
-          `http://${apiIP}/meat/statistic?type=7&start=${startDate}&end=${endDate}`
+          `http://${apiIP}/meat/statistic/sensory-stats/heated-fresh?start=${startDate}&end=${endDate}`
         );
 
         if (!response.ok) {
@@ -95,7 +95,7 @@ export default function Sense_Proc_Corr({ startDate, endDate }) {
       categories: xCategories, // 4가지 요소로 구성된 배열을 사용
     },
     title: {
-      text: "처리육 관능데이터 상관관계",
+      text: "가열육 관능데이터 상관관계",
     },
     grid: {
       padding: {

--- a/test-web/src/components/Stats/Charts/Corr/Sens_Proc_Corr.js
+++ b/test-web/src/components/Stats/Charts/Corr/Sens_Proc_Corr.js
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from "react";
 import ApexCharts from "react-apexcharts";
 import { apiIP } from "../../../../config";
 
-export default function Sense_Heated_Corr({ startDate, endDate }) {
+export default function Sense_Proc_Corr({ startDate, endDate }) {
   const [chartData, setChartData] = useState({});
   const [prop, setProp] = useState([]);
 
@@ -10,7 +10,7 @@ export default function Sense_Heated_Corr({ startDate, endDate }) {
     const fetchData = async () => {
       try {
         const response = await fetch(
-          `http://${apiIP}/meat/statistic?type=8&start=${startDate}&end=${endDate}`
+          `http://${apiIP}/meat/statistic/sensory-stats/processed?start=${startDate}&end=${endDate}`
         );
 
         if (!response.ok) {
@@ -95,7 +95,7 @@ export default function Sense_Heated_Corr({ startDate, endDate }) {
       categories: xCategories, // 4가지 요소로 구성된 배열을 사용
     },
     title: {
-      text: "가열육 관능데이터 상관관계",
+      text: "처리육 관능데이터 상관관계",
     },
     grid: {
       padding: {

--- a/test-web/src/components/Stats/Charts/Corr/Taste_Fresh_Corr.js
+++ b/test-web/src/components/Stats/Charts/Corr/Taste_Fresh_Corr.js
@@ -10,7 +10,7 @@ export default function Taste_Fresh_Corr({ startDate, endDate }) {
     const fetchData = async () => {
       try {
         const response = await fetch(
-          `http://${apiIP}/meat/statistic?type=4&start=${startDate}&end=${endDate}`
+          `http://${apiIP}/meat/statistic/probexpt-stats/fresh?start=${startDate}&end=${endDate}`
         );
 
         if (!response.ok) {

--- a/test-web/src/components/Stats/Charts/Corr/Taste_Proc_Corr.js
+++ b/test-web/src/components/Stats/Charts/Corr/Taste_Proc_Corr.js
@@ -10,7 +10,7 @@ export default function Taste_Proc_Corr({ startDate, endDate }) {
     const fetchData = async () => {
       try {
         const response = await fetch(
-          `http://${apiIP}/meat/statistic?type=5&start=${startDate}&end=${endDate}`
+          `http://${apiIP}/meat/statistic/probexpt-stats/processed?start=${startDate}&end=${endDate}&seqno=1`
         );
 
         if (!response.ok) {

--- a/test-web/src/components/Stats/Charts/HeatMap/Sens_Fresh_Map.js
+++ b/test-web/src/components/Stats/Charts/HeatMap/Sens_Fresh_Map.js
@@ -11,7 +11,7 @@ export default function Sens_Fresh_Map({ startDate, endDate }) {
     const fetchData = async () => {
       try {
         const response = await fetch(
-          `http://${apiIP}/meat/statistic?type=6&start=${startDate}&end=${endDate}`
+          `http://${apiIP}/meat/statistic/sensory-stats/fresh?start=${startDate}&end=${endDate}`
         );
 
         if (!response.ok) {

--- a/test-web/src/components/Stats/Charts/HeatMap/Sens_Heated_Map.js
+++ b/test-web/src/components/Stats/Charts/HeatMap/Sens_Heated_Map.js
@@ -11,7 +11,7 @@ export default function Sens_Heated_Map({ startDate, endDate }) {
     const fetchData = async () => {
       try {
         const response = await fetch(
-          `http://${apiIP}/meat/statistic?type=8&start=${startDate}&end=${endDate}`
+          `http://${apiIP}/meat/statistic/sensory-stats/heated-fresh?start=${startDate}&end=${endDate}`
         );
 
         if (!response.ok) {

--- a/test-web/src/components/Stats/Charts/HeatMap/Sens_Proc_Map.js
+++ b/test-web/src/components/Stats/Charts/HeatMap/Sens_Proc_Map.js
@@ -10,7 +10,7 @@ export default function Sens_Proc_Map({ startDate, endDate }) {
     const fetchData = async () => {
       try {
         const response = await fetch(
-          `http://${apiIP}/meat/statistic?type=7&start=${startDate}&end=${endDate}`
+          `http://${apiIP}/meat/statistic/sensory-stats/processed?start=${startDate}&end=${endDate}`
         );
 
         if (!response.ok) {

--- a/test-web/src/components/Stats/Charts/HeatMap/Taste_Fresh_Map.js
+++ b/test-web/src/components/Stats/Charts/HeatMap/Taste_Fresh_Map.js
@@ -10,7 +10,7 @@ export default function Taste_Fresh_Map({ startDate, endDate }) {
     const fetchData = async () => {
       try {
         const response = await fetch(
-          `http://${apiIP}/meat/statistic?type=4&start=${startDate}&end=${endDate}`
+          `http://${apiIP}/meat/statistic/probexpt-stats/fresh?start=${startDate}&end=${endDate}`
         );
 
         if (!response.ok) {

--- a/test-web/src/components/Stats/Charts/HeatMap/Taste_Proc_Map.js
+++ b/test-web/src/components/Stats/Charts/HeatMap/Taste_Proc_Map.js
@@ -10,7 +10,7 @@ export default function Taste_Proc_Map({ startDate, endDate }) {
     const fetchData = async () => {
       try {
         const response = await fetch(
-          `http://${apiIP}/meat/statistic?type=5&start=${startDate}&end=${endDate}`
+          `http://${apiIP}/meat/statistic/probexpt-stats/processed?&start=${startDate}&end=${endDate}&seqno=1`
         );
 
         if (!response.ok) {

--- a/test-web/src/components/Stats/StatsTabs.js
+++ b/test-web/src/components/Stats/StatsTabs.js
@@ -21,9 +21,9 @@ import Taste_Time from "./Charts/Time/Taste_Time";
 import { useEffect } from "react";
 import Sens_Proc_Map from "./Charts/HeatMap/Sens_Proc_Map";
 import Taste_Fresh_Corr from "./Charts/Corr/Taste_Fresh_Corr";
-import Sense_Proc_Corr from "./Charts/Corr/Sense_Proc_Corr";
-import Sense_Heated_Corr from "./Charts/Corr/Sense_Heated_Corr";
-import Sense_Fresh_Corr from "./Charts/Corr/Sense_Fresh_Corr";
+import Sense_Proc_Corr from "./Charts/Corr/Sens_Proc_Corr";
+import Sense_Heated_Corr from "./Charts/Corr/Sens_Heated_Corr";
+import Sense_Fresh_Corr from "./Charts/Corr/Sens_Fresh_Corr";
 import Taste_Proc_Corr from "./Charts/Corr/Taste_Proc_Corr";
 function CustomTabPanel(props) {
   const { children, value, index, ...other } = props;


### PR DESCRIPTION
- statistic 파트의 api가 프론트 백이 다름. 이를 백엔드에 맞게 수정하였음.
- 맛 처리육 데이터에서 seqno가 필요하고 이를 회차에 맞게 정보를 가져온 뒤 통계자료를 뿌려야 하는데 그 부분이 구현이 안되어있음. 일단 seqno=1로 하였음.
- 시계열 부분이 어떤 데이터를 받아서 어떤 방식으로 뿌려주는건지 확실치 않아 수정하지 않았음.