### PR TITLE
fix: DELETE deep-aging API 수정

### DIFF
--- a/test-backend/test-flask/api/delete_api.py
+++ b/test-backend/test-flask/api/delete_api.py
@@ -18,12 +18,11 @@ def deleteTotalMeatData():
         if request.method == "DELETE":
             db_session = current_app.db_session
             s3_conn = current_app.s3_conn
-            firebase_conn = current_app.firestore_conn
             id_list = request.get_json().get("id")
             if id_list:
                 for id in id_list:
                     result = _deleteSpecificMeatData(
-                        db_session, s3_conn, firebase_conn, id
+                        db_session, s3_conn, id
                     )
                 return jsonify({"delete_success": id_list}), 200
             else:
@@ -65,18 +64,17 @@ def deleteTotalMeatData():
 #         )
 
 # 특정 딥에이징 이력 삭제
-@delete_api.route("/deep-aging", methods=["GET", "POST"])
+@delete_api.route("/deep-aging", methods=["GET", "DELETE"])
 def deleteDeepAgingData():
     try:
-        if request.method == "GET":
+        if request.method == "DELETE":
             db_session = current_app.db_session
             s3_conn = current_app.s3_conn
-            firebase_conn = current_app.firebase_conn
             id = safe_str(request.args.get("id"))
             seqno = safe_str(request.args.get("seqno"))
             if id and seqno:
                 return _deleteSpecificDeepAgingData(
-                    db_session, s3_conn, firebase_conn, id, seqno
+                    db_session, s3_conn, id, seqno
                 )
             else:
                 return jsonify("No id parameter"), 401

--- a/test-backend/test-flask/db/db_controller.py
+++ b/test-backend/test-flask/db/db_controller.py
@@ -1038,7 +1038,7 @@ def create_AI_SensoryEval(db_session, meat_data: dict, seqno: int, id: str):
     return new_SensoryEval
 
 
-def _deleteSpecificMeatData(db_session, s3_conn, firebase_conn, id):
+def _deleteSpecificMeatData(db_session, s3_conn, id):
     # 1. 육류 DB 체크
     meat = db_session.query(Meat).filter_by(id=id).one()
     if meat is None:
@@ -1076,7 +1076,7 @@ def _deleteSpecificMeatData(db_session, s3_conn, firebase_conn, id):
         raise e
 
 
-def _deleteSpecificDeepAgingData(db_session, s3_conn, firebase_conn, id, seqno):
+def _deleteSpecificDeepAgingData(db_session, s3_conn, id, seqno):
     # 1. 육류 DB 체크
     meat = db_session.query(Meat).get(id)
 


### PR DESCRIPTION
- delete 기능 중 특정 회차의 딥에이징 데이터를 삭제하는 api의 메소드를 delete로 수정
- delete 기능에서 사용하지 않는 firebase의 연결 정보(firestore_conn) 삭제함
: firebase의 사진들은 백업 용도로 지우지 않기로 결정