### PR TITLE
hotfix: 원육의 세가지 항목 중 한가지라도 DB에 존재하지 않을 경우 user name을 반환하지 않는 에러 수정

### DIFF
--- a/test-backend/test-flask/api/get_api.py
+++ b/test-backend/test-flask/api/get_api.py
@@ -61,6 +61,10 @@ def getMeatDataById():
                 user = get_user(db_session, result["userId"])["name"]
                 result["name"] = user
                 for k, v in result["rawmeat"].items():
+                    if v is not None:
+                        userId = v["userId"]
+                        user = get_user(db_session, userId)["name"]
+                        v["name"] = user
                     try:
                         result["rawmeat_data_complete"] = (
                             all(
@@ -78,9 +82,6 @@ def getMeatDataById():
                                 for k, v in result["rawmeat"]["sensory_eval"].items()
                             )
                         )
-                        userId = v["userId"]
-                        user = get_user(db_session, userId)["name"]
-                        v["name"] = user
                     except:
                         result["rawmeat_data_complete"] = False
 


### PR DESCRIPTION
- 관능, 가열 후 관능, 실험실 데이터 중 하나가 null로 넘어오더라도 user name이 response에 포함되도록 코드 수정