### PR TITLE
hotfix: 육류 데이터 조회 시 filtering 에러 해결

### DIFF
--- a/test-backend/test-flask/api/get_api.py
+++ b/test-backend/test-flask/api/get_api.py
@@ -30,8 +30,10 @@ def getMeatData():
             db_session = current_app.db_session
             offset = request.args.get("offset")
             count = request.args.get("count")
+            start = request.args.get("start")
+            end = request.args.get("end")
             return (
-                get_range_meat_data(db_session, offset=offset, count=count)
+                get_range_meat_data(db_session, offset, count, start, end)
                 .get_json()
             )
 

--- a/test-backend/test-flask/db/db_controller.py
+++ b/test-backend/test-flask/db/db_controller.py
@@ -607,10 +607,10 @@ def get_range_meat_data(
     db_total_len = db_session.query(Meat).count()
     if start is not None and end is not None:
         query = query.filter(Meat.createdAt.between(start, end))
-        db_total_len = db_session.query.filter(
+        db_total_len = db_session.query(Meat).filter(
             Meat.createdAt.between(start, end)
         ).count()
-    query = query.offset(offset * count).limit(count)
+    query = query.offset(offset).limit(count)
 
     # 탐색
     meat_data = query.all()


### PR DESCRIPTION
- filtering의 기준이 되는 시작 날짜와 끝나는 날짜를 파라미터로 받아오지 않아서 필터링이 안되는 문제 발생
- start, end 날짜 받아오고 쿼리 필터에 적용