### PR TITLE
fix : 통계에 고기 종류, 등급 추가

### DIFF
--- a/test-web/src/components/Stats/Charts/BoxPlot/Sens_FreshMeat.js
+++ b/test-web/src/components/Stats/Charts/BoxPlot/Sens_FreshMeat.js
@@ -3,13 +3,18 @@ import React, { useEffect, useState } from 'react';
 import CircularProgress from '@mui/material/CircularProgress';
 import { apiIP } from '../../../../config';
 
-export default function Sens_FreshMeat({ startDate, endDate }) {
+export default function Sens_FreshMeat({
+  startDate,
+  endDate,
+  animalType,
+  grade,
+}) {
   const [chartData, setChartData] = useState([]);
   const fetchData = async () => {
     try {
       const response = await fetch(
         //`http://${apiIP}/meat/statistic?type=6&start=${startDate}&end=${endDate}`
-        `http://${apiIP}/meat/statistic/sensory-stats/fresh?start=${startDate}&end=${endDate}`
+        `http://${apiIP}/meat/statistic/sensory-stats/fresh?start=${startDate}&end=${endDate}&animalType=${animalType}&grade=${grade}`
       );
 
       if (!response.ok) {

--- a/test-web/src/components/Stats/Charts/BoxPlot/Sens_HeatedMeat.js
+++ b/test-web/src/components/Stats/Charts/BoxPlot/Sens_HeatedMeat.js
@@ -3,13 +3,18 @@ import React, { useEffect, useState } from 'react';
 import CircularProgress from '@mui/material/CircularProgress';
 import { apiIP } from '../../../../config';
 
-export default function Sens_HeatedMeat({ startDate, endDate }) {
+export default function Sens_HeatedMeat({
+  startDate,
+  endDate,
+  animalType,
+  grade,
+}) {
   const [chartData, setChartData] = useState([]);
 
   const fetchData = async () => {
     try {
       const response = await fetch(
-        `http://${apiIP}/meat/statistic/sensory-stats/heated-fresh?start=${startDate}&end=${endDate}`
+        `http://${apiIP}/meat/statistic/sensory-stats/heated-fresh?start=${startDate}&end=${endDate}&animalType=${animalType}&grade=${grade}`
       );
 
       if (!response.ok) {

--- a/test-web/src/components/Stats/Charts/BoxPlot/Sens_ProcMeat.js
+++ b/test-web/src/components/Stats/Charts/BoxPlot/Sens_ProcMeat.js
@@ -3,13 +3,18 @@ import React, { useEffect, useState } from 'react';
 import CircularProgress from '@mui/material/CircularProgress';
 import { apiIP } from '../../../../config';
 
-export default function Sens_ProcMeat({ startDate, endDate }) {
+export default function Sens_ProcMeat({
+  startDate,
+  endDate,
+  animalType,
+  grade,
+}) {
   const [chartData, setChartData] = useState([]);
 
   const fetchData = async () => {
     try {
       const response = await fetch(
-        `http://${apiIP}/meat/statistic/sensory-stats/processed?start=${startDate}&end=${endDate}`
+        `http://${apiIP}/meat/statistic/sensory-stats/processed?start=${startDate}&end=${endDate}&animalType=${animalType}&grade=${grade}`
       );
 
       if (!response.ok) {

--- a/test-web/src/components/Stats/Charts/BoxPlot/Taste_FreshMeat.js
+++ b/test-web/src/components/Stats/Charts/BoxPlot/Taste_FreshMeat.js
@@ -3,13 +3,18 @@ import React, { useEffect, useState } from 'react';
 import CircularProgress from '@mui/material/CircularProgress';
 import { apiIP } from '../../../../config';
 
-export default function Taste_FreshMeat({ startDate, endDate }) {
+export default function Taste_FreshMeat({
+  startDate,
+  endDate,
+  animalType,
+  grade,
+}) {
   const [chartData, setChartData] = useState([]); // Change initial state to null
 
   const fetchData = async () => {
     try {
       const response = await fetch(
-        `http://${apiIP}/meat/statistic/probexpt-stats/fresh?start=${startDate}&end=${endDate}`
+        `http://${apiIP}/meat/statistic/probexpt-stats/fresh?start=${startDate}&end=${endDate}&animalType=${animalType}&grade=${grade}`
       );
 
       if (!response.ok) {

--- a/test-web/src/components/Stats/Charts/BoxPlot/Taste_ProcMeat.js
+++ b/test-web/src/components/Stats/Charts/BoxPlot/Taste_ProcMeat.js
@@ -3,13 +3,18 @@ import React, { useEffect, useState } from 'react';
 import CircularProgress from '@mui/material/CircularProgress';
 import { apiIP } from '../../../../config';
 
-export default function Taste_ProcMeat({ startDate, endDate }) {
+export default function Taste_ProcMeat({
+  startDate,
+  endDate,
+  animalType,
+  grade,
+}) {
   const [chartData, setChartData] = useState([]);
 
   const fetchData = async () => {
     try {
       const response = await fetch(
-        `http://${apiIP}/meat/statistic/probexpt-stats/processed?start=${startDate}&end=${endDate}&seqno=1`
+        `http://${apiIP}/meat/statistic/probexpt-stats/processed?start=${startDate}&end=${endDate}&animalType=${animalType}&grade=${grade}&seqno=1`
       );
 
       if (!response.ok) {

--- a/test-web/src/components/Stats/Charts/Corr/Sens_Fresh_Corr.js
+++ b/test-web/src/components/Stats/Charts/Corr/Sens_Fresh_Corr.js
@@ -2,7 +2,12 @@ import React, { useEffect, useState } from 'react';
 import ApexCharts from 'react-apexcharts';
 import { apiIP } from '../../../../config';
 
-export default function Sense_Fresh_Corr({ startDate, endDate }) {
+export default function Sense_Fresh_Corr({
+  startDate,
+  endDate,
+  animalType,
+  grade,
+}) {
   const [chartData, setChartData] = useState({});
   const [prop, setProp] = useState([]);
 
@@ -10,7 +15,7 @@ export default function Sense_Fresh_Corr({ startDate, endDate }) {
     const fetchData = async () => {
       try {
         const response = await fetch(
-          `http://${apiIP}/meat/statistic/sensory-stats/fresh?start=${startDate}&end=${endDate}`
+          `http://${apiIP}/meat/statistic/sensory-stats/fresh?start=${startDate}&end=${endDate}&animalType=${animalType}&grade=${grade}`
         );
 
         if (!response.ok) {

--- a/test-web/src/components/Stats/Charts/Corr/Sens_Heated_Corr.js
+++ b/test-web/src/components/Stats/Charts/Corr/Sens_Heated_Corr.js
@@ -2,7 +2,12 @@ import React, { useEffect, useState } from 'react';
 import ApexCharts from 'react-apexcharts';
 import { apiIP } from '../../../../config';
 
-export default function Sense_Heated_Corr({ startDate, endDate }) {
+export default function Sense_Heated_Corr({
+  startDate,
+  endDate,
+  animalType,
+  grade,
+}) {
   const [chartData, setChartData] = useState({});
   const [prop, setProp] = useState([]);
 
@@ -10,7 +15,7 @@ export default function Sense_Heated_Corr({ startDate, endDate }) {
     const fetchData = async () => {
       try {
         const response = await fetch(
-          `http://${apiIP}/meat/statistic/sensory-stats/heated-fresh?start=${startDate}&end=${endDate}`
+          `http://${apiIP}/meat/statistic/sensory-stats/heated-fresh?start=${startDate}&end=${endDate}&animalType=${animalType}&grade=${grade}`
         );
 
         if (!response.ok) {

--- a/test-web/src/components/Stats/Charts/Corr/Sens_Proc_Corr.js
+++ b/test-web/src/components/Stats/Charts/Corr/Sens_Proc_Corr.js
@@ -2,7 +2,12 @@ import React, { useEffect, useState } from 'react';
 import ApexCharts from 'react-apexcharts';
 import { apiIP } from '../../../../config';
 
-export default function Sense_Proc_Corr({ startDate, endDate }) {
+export default function Sense_Proc_Corr({
+  startDate,
+  endDate,
+  animalType,
+  grade,
+}) {
   const [chartData, setChartData] = useState({});
   const [prop, setProp] = useState([]);
 
@@ -10,7 +15,7 @@ export default function Sense_Proc_Corr({ startDate, endDate }) {
     const fetchData = async () => {
       try {
         const response = await fetch(
-          `http://${apiIP}/meat/statistic/sensory-stats/processed?start=${startDate}&end=${endDate}`
+          `http://${apiIP}/meat/statistic/sensory-stats/processed?start=${startDate}&end=${endDate}&animalType=${animalType}&grade=${grade}`
         );
 
         if (!response.ok) {

--- a/test-web/src/components/Stats/Charts/Corr/Taste_Fresh_Corr.js
+++ b/test-web/src/components/Stats/Charts/Corr/Taste_Fresh_Corr.js
@@ -2,7 +2,12 @@ import React, { useEffect, useState } from 'react';
 import ApexCharts from 'react-apexcharts';
 import { apiIP } from '../../../../config';
 
-export default function Taste_Fresh_Corr({ startDate, endDate }) {
+export default function Taste_Fresh_Corr({
+  startDate,
+  endDate,
+  animalType,
+  grade,
+}) {
   const [chartData, setChartData] = useState({});
   const [prop, setProp] = useState([]);
 
@@ -10,7 +15,7 @@ export default function Taste_Fresh_Corr({ startDate, endDate }) {
     const fetchData = async () => {
       try {
         const response = await fetch(
-          `http://${apiIP}/meat/statistic/probexpt-stats/fresh?start=${startDate}&end=${endDate}`
+          `http://${apiIP}/meat/statistic/probexpt-stats/fresh?start=${startDate}&end=${endDate}&animalType=${animalType}&grade=${grade}`
         );
 
         if (!response.ok) {

--- a/test-web/src/components/Stats/Charts/Corr/Taste_Proc_Corr.js
+++ b/test-web/src/components/Stats/Charts/Corr/Taste_Proc_Corr.js
@@ -2,7 +2,12 @@ import React, { useEffect, useState } from 'react';
 import ApexCharts from 'react-apexcharts';
 import { apiIP } from '../../../../config';
 
-export default function Taste_Proc_Corr({ startDate, endDate }) {
+export default function Taste_Proc_Corr({
+  startDate,
+  endDate,
+  animalType,
+  grade,
+}) {
   const [chartData, setChartData] = useState({});
   const [prop, setProp] = useState([]);
 
@@ -10,7 +15,7 @@ export default function Taste_Proc_Corr({ startDate, endDate }) {
     const fetchData = async () => {
       try {
         const response = await fetch(
-          `http://${apiIP}/meat/statistic/probexpt-stats/processed?start=${startDate}&end=${endDate}&seqno=1`
+          `http://${apiIP}/meat/statistic/probexpt-stats/processed?start=${startDate}&end=${endDate}&animalType=${animalType}&grade=${grade}&seqno=1`
         );
 
         if (!response.ok) {

--- a/test-web/src/components/Stats/Charts/HeatMap/Sens_Fresh_Map.js
+++ b/test-web/src/components/Stats/Charts/HeatMap/Sens_Fresh_Map.js
@@ -2,7 +2,12 @@ import ApexCharts from 'react-apexcharts';
 import React, { useEffect, useState } from 'react';
 import { apiIP } from '../../../../config';
 
-export default function Sens_Fresh_Map({ startDate, endDate }) {
+export default function Sens_Fresh_Map({
+  startDate,
+  endDate,
+  animalType,
+  grade,
+}) {
   const [chartData, setChartData] = useState({});
   const [prop, setProp] = useState([]);
 
@@ -10,7 +15,7 @@ export default function Sens_Fresh_Map({ startDate, endDate }) {
     const fetchData = async () => {
       try {
         const response = await fetch(
-          `http://${apiIP}/meat/statistic/sensory-stats/fresh?start=${startDate}&end=${endDate}`
+          `http://${apiIP}/meat/statistic/sensory-stats/fresh?start=${startDate}&end=${endDate}&animalType=${animalType}&grade=${grade}`
         );
 
         if (!response.ok) {

--- a/test-web/src/components/Stats/Charts/HeatMap/Sens_Heated_Map.js
+++ b/test-web/src/components/Stats/Charts/HeatMap/Sens_Heated_Map.js
@@ -2,7 +2,12 @@ import ApexCharts from 'react-apexcharts';
 import React, { useEffect, useState } from 'react';
 import { apiIP } from '../../../../config';
 
-export default function Sens_Heated_Map({ startDate, endDate }) {
+export default function Sens_Heated_Map({
+  startDate,
+  endDate,
+  animalType,
+  grade,
+}) {
   const [chartData, setChartData] = useState({});
   const [prop, setProp] = useState([]);
 
@@ -10,7 +15,7 @@ export default function Sens_Heated_Map({ startDate, endDate }) {
     const fetchData = async () => {
       try {
         const response = await fetch(
-          `http://${apiIP}/meat/statistic/sensory-stats/heated-fresh?start=${startDate}&end=${endDate}`
+          `http://${apiIP}/meat/statistic/sensory-stats/heated-fresh?start=${startDate}&end=${endDate}&animalType=${animalType}&grade=${grade}`
         );
 
         if (!response.ok) {

--- a/test-web/src/components/Stats/Charts/HeatMap/Sens_Proc_Map.js
+++ b/test-web/src/components/Stats/Charts/HeatMap/Sens_Proc_Map.js
@@ -2,7 +2,12 @@ import ApexCharts from 'react-apexcharts';
 import React, { useEffect, useState } from 'react';
 import { apiIP } from '../../../../config';
 
-export default function Sens_Proc_Map({ startDate, endDate }) {
+export default function Sens_Proc_Map({
+  startDate,
+  endDate,
+  animalType,
+  grade,
+}) {
   const [chartData, setChartData] = useState({});
   const [prop, setProp] = useState([]);
 
@@ -10,7 +15,7 @@ export default function Sens_Proc_Map({ startDate, endDate }) {
     const fetchData = async () => {
       try {
         const response = await fetch(
-          `http://${apiIP}/meat/statistic/sensory-stats/processed?start=${startDate}&end=${endDate}`
+          `http://${apiIP}/meat/statistic/sensory-stats/processed?start=${startDate}&end=${endDate}&animalType=${animalType}&grade=${grade}`
         );
 
         if (!response.ok) {

--- a/test-web/src/components/Stats/Charts/HeatMap/Taste_Fresh_Map.js
+++ b/test-web/src/components/Stats/Charts/HeatMap/Taste_Fresh_Map.js
@@ -2,7 +2,12 @@ import ApexCharts from 'react-apexcharts';
 import React, { useEffect, useState } from 'react';
 import { apiIP } from '../../../../config';
 
-export default function Taste_Fresh_Map({ startDate, endDate }) {
+export default function Taste_Fresh_Map({
+  startDate,
+  endDate,
+  animalType,
+  grade,
+}) {
   const [chartData, setChartData] = useState({});
   const [prop, setProp] = useState([]);
 
@@ -10,7 +15,7 @@ export default function Taste_Fresh_Map({ startDate, endDate }) {
     const fetchData = async () => {
       try {
         const response = await fetch(
-          `http://${apiIP}/meat/statistic/probexpt-stats/fresh?start=${startDate}&end=${endDate}`
+          `http://${apiIP}/meat/statistic/probexpt-stats/fresh?start=${startDate}&end=${endDate}&animalType=${animalType}&grade=${grade}`
         );
 
         if (!response.ok) {

--- a/test-web/src/components/Stats/Charts/HeatMap/Taste_Proc_Map.js
+++ b/test-web/src/components/Stats/Charts/HeatMap/Taste_Proc_Map.js
@@ -2,7 +2,12 @@ import ApexCharts from 'react-apexcharts';
 import React, { useEffect, useState } from 'react';
 import { apiIP } from '../../../../config';
 
-export default function Taste_Proc_Map({ startDate, endDate }) {
+export default function Taste_Proc_Map({
+  startDate,
+  endDate,
+  animalType,
+  grade,
+}) {
   const [chartData, setChartData] = useState({});
   const [prop, setProp] = useState([]);
 
@@ -10,7 +15,7 @@ export default function Taste_Proc_Map({ startDate, endDate }) {
     const fetchData = async () => {
       try {
         const response = await fetch(
-          `http://${apiIP}/meat/statistic/probexpt-stats/processed?&start=${startDate}&end=${endDate}&seqno=1`
+          `http://${apiIP}/meat/statistic/probexpt-stats/processed?&start=${startDate}&end=${endDate}&animalType=${animalType}&grade=${grade}&seqno=1`
         );
 
         if (!response.ok) {

--- a/test-web/src/components/Stats/StatsTabs.js
+++ b/test-web/src/components/Stats/StatsTabs.js
@@ -1,11 +1,6 @@
 import { useState } from 'react';
 import PropTypes from 'prop-types';
 import { Tabs, Tab, Box, Button, useTheme } from '@mui/material';
-import BarGraph from './Charts/barGraph';
-import PieChart from './Charts/pieChart';
-import AreaChart from './Charts/BoxPlot/Sens_FreshMeat';
-import { IoBarChart, IoPieChart } from 'react-icons/io5';
-import Typography from '@mui/material/Typography';
 import * as React from 'react';
 import { Select, MenuItem } from '@mui/material';
 import Sens_FreshMeat from './Charts/BoxPlot/Sens_FreshMeat';
@@ -58,6 +53,12 @@ function a11yProps(index) {
 export default function StatsTabs({ startDate, endDate }) {
   const [value, setValue] = useState(0);
   const [slot, setSlot] = useState('week');
+  const [alignment, setAlignment] = useState('맛');
+  //const [gradeAlignment, setGradeAlignment] = useState('소');
+  const [secondary, setSecondary] = useState('원육');
+  const [animalType, setAnimalType] = useState('소');
+  const [grade, setGrade] = useState('1++');
+
   useEffect(() => {
     console.log('stat tab' + startDate, '-', endDate);
   }, [startDate, endDate]);
@@ -65,10 +66,6 @@ export default function StatsTabs({ startDate, endDate }) {
   const handleChange = (event, newValue) => {
     setValue(newValue);
   };
-
-  const [alignment, setAlignment] = React.useState('맛');
-  const [secondary, setSecondary] = React.useState('원육');
-
   const handleFirstChange = (event) => {
     setAlignment(event.target.value);
     setSecondary('원육'); // Initialize secondary to "원육"
@@ -76,6 +73,13 @@ export default function StatsTabs({ startDate, endDate }) {
 
   const handleSecondChange = (event) => {
     setSecondary(event.target.value);
+  };
+
+  const handleAnimalChange = (event) => {
+    setAnimalType(event.target.value);
+  };
+  const handleGradeChange = (event) => {
+    setGrade(event.target.value);
   };
 
   return (
@@ -127,51 +131,155 @@ export default function StatsTabs({ startDate, endDate }) {
                   <MenuItem value="가열육">가열육</MenuItem>
                 )}
               </Select>
+              <Select
+                labelId="animal-label"
+                id="animal"
+                value={animalType}
+                onChange={handleAnimalChange}
+                label="동물 종류"
+              >
+                <MenuItem value="소">소</MenuItem>
+                <MenuItem value="돼지">돼지</MenuItem>
+              </Select>
+              <Select
+                labelId="grade-label"
+                id="grade"
+                value={grade}
+                onChange={handleGradeChange}
+                label="등급"
+              >
+                <MenuItem value="all">전체</MenuItem>
+                {animalType === '소' && (
+                  <>
+                    <MenuItem value="1++">1++</MenuItem>
+                    <MenuItem value="1+">1+</MenuItem>
+                    <MenuItem value="1">1</MenuItem>
+                    <MenuItem value="2">2</MenuItem>
+                    <MenuItem value="3">3</MenuItem>
+                  </>
+                )}
+              </Select>
             </div>
           )}
         </Box>
       </Box>
+
       {/* BoxPlot(통계) */}
       <CustomTabPanel value={value} index={0}>
         {alignment === '관능' && secondary === '원육' ? (
-          <Sens_FreshMeat startDate={startDate} endDate={endDate} />
+          <Sens_FreshMeat
+            startDate={startDate}
+            endDate={endDate}
+            animalType={animalType}
+            grade={grade}
+          />
         ) : alignment === '관능' && secondary === '처리육' ? (
-          <Sens_ProcMeat startDate={startDate} endDate={endDate} />
+          <Sens_ProcMeat
+            startDate={startDate}
+            endDate={endDate}
+            animalType={animalType}
+            grade={grade}
+          />
         ) : alignment === '관능' && secondary === '가열육' ? (
-          <Sens_HeatedMeat startDate={startDate} endDate={endDate} />
+          <Sens_HeatedMeat
+            startDate={startDate}
+            endDate={endDate}
+            animalType={animalType}
+            grade={grade}
+          />
         ) : alignment === '맛' && secondary === '원육' ? (
-          <Taste_FreshMeat startDate={startDate} endDate={endDate} />
+          <Taste_FreshMeat
+            startDate={startDate}
+            endDate={endDate}
+            animalType={animalType}
+            grade={grade}
+          />
         ) : alignment === '맛' && secondary === '처리육' ? (
-          <Taste_ProcMeat startDate={startDate} endDate={endDate} />
+          <Taste_ProcMeat
+            startDate={startDate}
+            endDate={endDate}
+            animalType={animalType}
+            grade={grade}
+          />
         ) : null}
       </CustomTabPanel>
 
       {/* HeatMap(분포) */}
       <CustomTabPanel value={value} index={1}>
         {alignment === '관능' && secondary === '원육' ? (
-          <Sens_Fresh_Map startDate={startDate} endDate={endDate} />
+          <Sens_Fresh_Map
+            startDate={startDate}
+            endDate={endDate}
+            animalType={animalType}
+            grade={grade}
+          />
         ) : alignment === '관능' && secondary === '처리육' ? (
-          <Sens_Proc_Map startDate={startDate} endDate={endDate} />
+          <Sens_Proc_Map
+            startDate={startDate}
+            endDate={endDate}
+            animalType={animalType}
+            grade={grade}
+          />
         ) : alignment === '관능' && secondary === '가열육' ? (
-          <Sens_Heated_Map startDate={startDate} endDate={endDate} />
+          <Sens_Heated_Map
+            startDate={startDate}
+            endDate={endDate}
+            animalType={animalType}
+            grade={grade}
+          />
         ) : alignment === '맛' && secondary === '원육' ? (
-          <Taste_Fresh_Map startDate={startDate} endDate={endDate} />
+          <Taste_Fresh_Map
+            startDate={startDate}
+            endDate={endDate}
+            animalType={animalType}
+            grade={grade}
+          />
         ) : alignment === '맛' && secondary === '처리육' ? (
-          <Taste_Proc_Map startDate={startDate} endDate={endDate} />
+          <Taste_Proc_Map
+            startDate={startDate}
+            endDate={endDate}
+            animalType={animalType}
+            grade={grade}
+          />
         ) : null}
       </CustomTabPanel>
 
       <CustomTabPanel value={value} index={2}>
         {alignment === '관능' && secondary === '원육' ? (
-          <Sense_Fresh_Corr startDate={startDate} endDate={endDate} />
+          <Sense_Fresh_Corr
+            startDate={startDate}
+            endDate={endDate}
+            animalType={animalType}
+            grade={grade}
+          />
         ) : alignment === '관능' && secondary === '처리육' ? (
-          <Sense_Proc_Corr startDate={startDate} endDate={endDate} />
+          <Sense_Proc_Corr
+            startDate={startDate}
+            endDate={endDate}
+            animalType={animalType}
+            grade={grade}
+          />
         ) : alignment === '관능' && secondary === '가열육' ? (
-          <Sense_Heated_Corr startDate={startDate} endDate={endDate} />
+          <Sense_Heated_Corr
+            startDate={startDate}
+            endDate={endDate}
+            animalType={animalType}
+            grade={grade}
+          />
         ) : alignment === '맛' && secondary === '원육' ? (
-          <Taste_Fresh_Corr startDate={startDate} endDate={endDate} />
+          <Taste_Fresh_Corr
+            startDate={startDate}
+            endDate={endDate}
+            animalType={animalType}
+            grade={grade}
+          />
         ) : alignment === '맛' && secondary === '처리육' ? (
-          <Taste_Proc_Corr startDate={startDate} endDate={endDate} />
+          <Taste_Proc_Corr
+            startDate={startDate}
+            endDate={endDate}
+            animalType={animalType}
+            grade={grade}
+          />
         ) : null}
       </CustomTabPanel>
 


### PR DESCRIPTION
<img width="1210" alt="image" src="https://github.com/deun115/Deeplant-Dev/assets/121757695/f04067dd-6602-4c29-8c88-213dcb599b97">


- 통계 페이지에서 고기의 종류와 등급을 선택할 수 있도록 하였고 api를 보내는 코드에서 이 값들을 인자로 받아 db로부터 원하는 데이터를 받도록 한다.
- 소의 경우 등급을 선택하거나 전체 데이터를 불러올 수 있지만 돼지는 등급이 없기 때문에 전체 데이터만 불러 올 수 있으며 이때 값은 'all' 이다.
- 처리육, 실험실 데이터는 seqno 가 필요하다. 이는 미팅 후 향후 계획을 수정해야 하므로 일단 
`/meat/statistic/probexpt-stats/processed?start=${startDate}&end=${endDate}&animalType=${animalType}&grade=${grade}&seqno=1` 이렇게 넣기는 했지만 대기.