### PR TITLE
feat: dashboard, PA 에서 pagecount를 사용자가 임의로 설정할 수 있도록 함.

### DIFF
--- a/test-web/src/components/DataListView/DataListComp.js
+++ b/test-web/src/components/DataListView/DataListComp.js
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { Box } from '@mui/material';
+import { Box, FormControl, InputLabel, Select, MenuItem } from '@mui/material';
 import Spinner from 'react-bootstrap/Spinner';
 import DataList from './DataList';
 import Pagination from './Pagination';
@@ -17,9 +17,8 @@ const DataListComp = ({
   const [totalData, setTotalData] = useState(0);
   // 현재 페이지 번호
   const [currentPage, setCurrentPage] = useState(1);
-
-  // 한페이지당 보여줄 개수
-  const count = 6;
+  // 한 페이지당 보여줄 개수
+  const [count, setCount] = useState(5);
 
   // API fetch 데이터 전처리
   const processMeatDatas = (data) => {
@@ -66,12 +65,26 @@ const DataListComp = ({
           <Spinner animation="border" />
         </div>
         <Box sx={style.paginationBar}>
-          <Pagination
-            totalDatas={totalData}
-            count={count}
-            currentPage={currentPage}
-            setCurrentPage={setCurrentPage}
-          />
+          <div style={style.paginationContainer}>
+            <Pagination
+              totalDatas={totalData}
+              count={count}
+              currentPage={currentPage}
+              setCurrentPage={setCurrentPage}
+            />
+            <FormControl variant="outlined" size="small" sx={style.formControl}>
+              <InputLabel>Items per page</InputLabel>
+              <Select
+                value={count}
+                onChange={(e) => setCount(e.target.value)}
+                label="Items "
+              >
+                <MenuItem value={5}>5</MenuItem>
+                <MenuItem value={10}>10</MenuItem>
+                <MenuItem value={20}>20</MenuItem>
+              </Select>
+            </FormControl>
+          </div>
         </Box>
       </div>
     );
@@ -95,12 +108,26 @@ const DataListComp = ({
         )}
       </div>
       <Box sx={style.paginationBar}>
-        <Pagination
-          totalDatas={totalData}
-          count={count}
-          currentPage={currentPage}
-          setCurrentPage={setCurrentPage}
-        />
+        <div style={style.paginationContainer}>
+          <Pagination
+            totalDatas={totalData}
+            count={count}
+            currentPage={currentPage}
+            setCurrentPage={setCurrentPage}
+          />
+          <FormControl variant="outlined" size="small" sx={style.formControl}>
+            <InputLabel>Items per page</InputLabel>
+            <Select
+              value={count}
+              onChange={(e) => setCount(e.target.value)}
+              label="Items per page"
+            >
+              <MenuItem value={5}>5</MenuItem>
+              <MenuItem value={10}>10</MenuItem>
+              <MenuItem value={20}>20</MenuItem>
+            </Select>
+          </FormControl>
+        </div>
       </Box>
     </div>
   );
@@ -120,5 +147,14 @@ const style = {
     marginTop: '40px',
     width: '100%',
     justifyContent: 'center',
+  },
+  paginationContainer: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  formControl: {
+    minWidth: 120,
+    marginLeft: '20px',
   },
 };

--- a/test-web/src/components/DataListView/PADataListComp.js
+++ b/test-web/src/components/DataListView/PADataListComp.js
@@ -1,12 +1,12 @@
 import { useState, useEffect } from 'react';
-import { Box } from '@mui/material';
+import { Box, FormControl, InputLabel, Select, MenuItem } from '@mui/material';
 import DataList from './DataList';
 import Pagination from './Pagination';
 import Spinner from 'react-bootstrap/Spinner';
 import { usePredictedMeatListFetch } from '../../API/getPredictedMeatListSWR';
 
 // 데이터 예측 페이지 목록 컴포넌트
-const PADataListComp = ({ startDate, endDate }) => {
+const PADataListComp = ({ startDate, endDate, pageOffset }) => {
   // 고기 데이터 목록
   const [meatList, setMeatList] = useState([]);
   // 데이터 전체 개수
@@ -14,7 +14,7 @@ const PADataListComp = ({ startDate, endDate }) => {
   // 현재 페이지 번호
   const [currentPage, setCurrentPage] = useState(1);
   // 한페이지당 보여줄 개수
-  const count = 8;
+  const [count, setCount] = useState(5);
 
   // API fetch 데이터 전처리
   const processPAMeatDatas = (data) => {
@@ -67,12 +67,26 @@ const PADataListComp = ({ startDate, endDate }) => {
           <Spinner animation="border" />
         </div>
         <Box sx={style.paginationBar}>
-          <Pagination
-            totalDatas={totalData}
-            count={count}
-            currentPage={currentPage}
-            setCurrentPage={setCurrentPage}
-          />
+          <div style={style.paginationContainer}>
+            <Pagination
+              totalDatas={totalData}
+              count={count}
+              currentPage={currentPage}
+              setCurrentPage={setCurrentPage}
+            />
+            <FormControl variant="outlined" size="small" sx={style.formControl}>
+              <InputLabel>Items per page</InputLabel>
+              <Select
+                value={count}
+                onChange={(e) => setCount(e.target.value)}
+                label="Items "
+              >
+                <MenuItem value={5}>5</MenuItem>
+                <MenuItem value={10}>10</MenuItem>
+                <MenuItem value={20}>20</MenuItem>
+              </Select>
+            </FormControl>
+          </div>
         </Box>
       </div>
     );
@@ -91,17 +105,31 @@ const PADataListComp = ({ startDate, endDate }) => {
             count={count}
             startDate={startDate}
             endDate={endDate}
+            pageOffset={pageOffset}
           />
         )}
       </div>
-
       <Box sx={style.paginationBar}>
-        <Pagination
-          totalDatas={totalData}
-          count={count}
-          currentPage={currentPage}
-          setCurrentPage={setCurrentPage}
-        />
+        <div style={style.paginationContainer}>
+          <Pagination
+            totalDatas={totalData}
+            count={count}
+            currentPage={currentPage}
+            setCurrentPage={setCurrentPage}
+          />
+          <FormControl variant="outlined" size="small" sx={style.formControl}>
+            <InputLabel>Items per page</InputLabel>
+            <Select
+              value={count}
+              onChange={(e) => setCount(e.target.value)}
+              label="Items per page"
+            >
+              <MenuItem value={5}>5</MenuItem>
+              <MenuItem value={10}>10</MenuItem>
+              <MenuItem value={20}>20</MenuItem>
+            </Select>
+          </FormControl>
+        </div>
       </Box>
     </div>
   );
@@ -118,17 +146,18 @@ const style = {
     height: 'auto',
   },
   paginationBar: {
-    marginTop: '20px',
+    marginTop: '40px',
     width: '100%',
-    justifyContent: 'center',
-  },
-  PABtnContainer: {
     display: 'flex',
-    margin: '20px 0',
-    padding: '0px 100px',
-    justifyContent: 'start',
-    position: 'fixed',
-    bottom: '10px',
-    left: '50px',
+    justifyContent: 'right',
+  },
+  paginationContainer: {
+    display: 'flex',
+    justifyContent: 'right',
+    alignItems: 'center',
+  },
+  formControl: {
+    minWidth: 120,
+    marginLeft: '20px',
   },
 };

--- a/test-web/src/routes/PA.js
+++ b/test-web/src/routes/PA.js
@@ -28,6 +28,7 @@ function PA() {
   //const pageOffset = new URLSearchParams(searchParams).get('pageOffset');
   const queryStartDate = new URLSearchParams(searchParams).get('startDate');
   const queryEndDate = new URLSearchParams(searchParams).get('endDate');
+  const pageOffset = new URLSearchParams(searchParams).get('pageOffset');
 
   useEffect(() => {
     if (queryStartDate && queryEndDate) {
@@ -64,7 +65,11 @@ function PA() {
         <SearchFilterBar setStartDate={setStartDate} setEndDate={setEndDate} />
       </Box>
       {/**데이터 목록 */}
-      <PADataListComp startDate={startDate} endDate={endDate} />
+      <PADataListComp
+        startDate={startDate}
+        endDate={endDate}
+        pageOffset={pageOffset}
+      />
     </div>
   );
 }


### PR DESCRIPTION
<img width="2044" alt="image" src="https://github.com/deun115/Deeplant-Dev/assets/121757695/c11fcb2c-4eb6-491b-a2e7-44b5d1e83ff3">

<img width="2044" alt="image" src="https://github.com/deun115/Deeplant-Dev/assets/121757695/29cbe556-b7a5-435e-9a8e-5d963731f13a">


- Dashboard 와 PA 페이지에서 한 페이지에 보여지는 데이터의 개수를 사용자가 임의로 선택할 수 있도록 하였음.
- 기본은 5로 설정되어 있고, 5, 10, 20 중에서 하나를 선택하여 볼 수 있도록 함.