### PR TITLE
fix: 딥에이징 추가정보 처리육/가열육 데이터 입력 가능하도록 ui 수정

### DIFF
--- a/app/structure/lib/config/user_router.dart
+++ b/app/structure/lib/config/user_router.dart
@@ -284,24 +284,6 @@ class UserRouter {
                         child: const InsertionMeatInfoScreen(),
                       ),
                     ),
-                    // GoRoute(
-                    //   path: 'trace-editable',
-                    //   builder: (context, state) => ChangeNotifierProvider(
-                    //     create: (context) =>
-                    //         InsertionTraceNumViewModel(meatModel),
-                    //     child: const InsertionTraceNumScreen(),
-                    //   ),
-                    //   routes: [
-                    //     GoRoute(
-                    //       path: 'info-editable',
-                    //       builder: (context, state) => ChangeNotifierProvider(
-                    //         create: (context) =>
-                    //             InsertionMeatInfoViewModel(meatModel),
-                    //         child: const InsertionMeatInfoScreen(),
-                    //       ),
-                    //     ),
-                    //   ],
-                    // ),
                     GoRoute(
                       path: 'image-editable',
                       builder: (context, state) => ChangeNotifierProvider(
@@ -379,13 +361,13 @@ class UserRouter {
                               AddProcessedMeatMainScreen(meatModel: meatModel)),
                       routes: [
                         GoRoute(
-                            path: 'image',
-                            builder: (context, state) => ChangeNotifierProvider(
-                                  create: (context) =>
-                                      RegistrationMeatImageViewModel(
-                                          meatModel, userModel),
-                                  child: const RegistrationMeatImageScreen(),
-                                )),
+                          path: 'image',
+                          builder: (context, state) => ChangeNotifierProvider(
+                            create: (context) => RegistrationMeatImageViewModel(
+                                meatModel, userModel),
+                            child: const RegistrationMeatImageScreen(),
+                          ),
+                        ),
                         GoRoute(
                           path: 'eval',
                           builder: (context, state) => ChangeNotifierProvider(
@@ -395,11 +377,12 @@ class UserRouter {
                           ),
                         ),
                         GoRoute(
-                          path: 'heated-meat',
+                          path: 'heated-eval',
                           builder: (context, state) => ChangeNotifierProvider(
-                              create: (context) =>
-                                  HeatedMeatEvalViewModel(meatModel),
-                              child: const HeatedMeatEvaluation()),
+                            create: (context) =>
+                                HeatedMeatEvalViewModel(meatModel),
+                            child: const HeatedMeatEvaluation(),
+                          ),
                         ),
                         GoRoute(
                           path: 'tongue',

--- a/app/structure/lib/screen/data_management/researcher/add_processed_meat_main_screen.dart
+++ b/app/structure/lib/screen/data_management/researcher/add_processed_meat_main_screen.dart
@@ -3,17 +3,18 @@
 // 처리육(딥에이징) 추가 페이지(View) : Researcher
 //
 //
+
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:provider/provider.dart';
 import 'package:structure/components/custom_app_bar.dart';
 import 'package:structure/components/step_card.dart';
-import 'package:structure/main.dart';
 import 'package:structure/model/meat_model.dart';
 import 'package:structure/viewModel/data_management/researcher/add_processed_meat_view_model.dart';
 
 class AddProcessedMeatMainScreen extends StatefulWidget {
   final MeatModel meatModel;
+
   const AddProcessedMeatMainScreen({
     super.key,
     required this.meatModel,
@@ -39,40 +40,81 @@ class _AddProcessedMeatMainScreenState
         child: Column(
           children: [
             SizedBox(height: 48.h),
+
+            // 처리육 단면 촬영
             InkWell(
               onTap: () => context
                   .read<AddProcessedMeatViewModel>()
                   .clickedImage(context),
               child: StepCard(
                 mainText: '처리육 단면 촬영',
-                status: meatModel.deepAgedImageCompleted ? 1 : 2,
-                // isCompleted: meatModel.deepAgedImageCompleted,
-                // isBefore: false,
+                status: widget.meatModel.deepAgedImageCompleted ? 1 : 2,
                 imageUrl: 'assets/images/meat_image.png',
               ),
             ),
             SizedBox(height: 18.h),
+
+            // 처리육 관능평가
             InkWell(
-              onTap: () => widget.meatModel.deepAgedImageCompleted
-                  ? context
-                      .read<AddProcessedMeatViewModel>()
-                      .clickedProcessedEval(context)
-                  : null,
+              onTap: () => context
+                  .read<AddProcessedMeatViewModel>()
+                  .clickedEval(context),
               child: StepCard(
                 mainText: '처리육 관능평가',
-                status: widget.meatModel.deepAgedImageCompleted
-                    ? widget.meatModel.deepAgedFreshCompleted
-                        ? 1
-                        : 2
-                    : 0,
-                // isCompleted: widget.meatModel.deepAgedFreshCompleted,
-                // isBefore: !widget.meatModel.deepAgedImageCompleted,
+                status: widget.meatModel.deepAgedFreshCompleted ? 1 : 2,
                 imageUrl: 'assets/images/meat_eval.png',
               ),
             ),
-            SizedBox(
-              height: 18.h,
+            SizedBox(height: 18.h),
+
+            // 처리육 전자혀
+            InkWell(
+              onTap: () => context
+                  .read<AddProcessedMeatViewModel>()
+                  .clickedTongue(context),
+              child: StepCard(
+                mainText: '처리육 전자혀 데이터',
+                status: widget.meatModel.tongueCompleted ? 1 : 2,
+                imageUrl: 'assets/images/meat_tongue.png',
+              ),
             ),
+            SizedBox(height: 18.h),
+
+            // 처리육 실험
+            InkWell(
+              onTap: () =>
+                  context.read<AddProcessedMeatViewModel>().clickedLab(context),
+              child: StepCard(
+                mainText: '처리육 실험 데이터',
+                status: widget.meatModel.labCompleted ? 1 : 2,
+                imageUrl: 'assets/images/meat_lab.png',
+              ),
+            ),
+            SizedBox(height: 18.h),
+
+            // Divdier
+            Container(
+              margin: EdgeInsets.symmetric(horizontal: 16.w),
+              child: const Divider(
+                color: Color.fromARGB(255, 155, 155, 155),
+                thickness: 1,
+              ),
+            ),
+
+            // 가열육 단면 촬영
+            InkWell(
+              onTap: () => context
+                  .read<AddProcessedMeatViewModel>()
+                  .clickedImage(context),
+              child: StepCard(
+                mainText: '가열육 단면 촬영',
+                status: widget.meatModel.deepAgedImageCompleted ? 1 : 2,
+                imageUrl: 'assets/images/meat_image.png',
+              ),
+            ),
+            SizedBox(height: 18.h),
+
+            // 가열육 관능 평가
             InkWell(
               onTap: () => context
                   .read<AddProcessedMeatViewModel>()
@@ -80,37 +122,31 @@ class _AddProcessedMeatMainScreenState
               child: StepCard(
                 mainText: '가열육 관능평가',
                 status: widget.meatModel.heatedCompleted ? 1 : 2,
-                // isCompleted: widget.meatModel.heatedCompleted,
-                // isBefore: false,
                 imageUrl: 'assets/images/meat_eval.png',
               ),
             ),
-            SizedBox(
-              height: 18.h,
-            ),
+            SizedBox(height: 18.h),
+
+            // 가열육 전자혀
             InkWell(
               onTap: () => context
                   .read<AddProcessedMeatViewModel>()
                   .clickedTongue(context),
               child: StepCard(
-                mainText: '전자혀 데이터',
+                mainText: '가열육 전자혀 데이터',
                 status: widget.meatModel.tongueCompleted ? 1 : 2,
-                // isCompleted: widget.meatModel.tongueCompleted,
-                // isBefore: false,
                 imageUrl: 'assets/images/meat_tongue.png',
               ),
             ),
-            SizedBox(
-              height: 18.h,
-            ),
+            SizedBox(height: 18.h),
+
+            // 가열육 실험 데이터
             InkWell(
               onTap: () =>
                   context.read<AddProcessedMeatViewModel>().clickedLab(context),
               child: StepCard(
-                mainText: '실험 데이터',
+                mainText: '가열육 실험 데이터',
                 status: widget.meatModel.labCompleted ? 1 : 2,
-                // isCompleted: widget.meatModel.labCompleted,
-                // isBefore: false,
                 imageUrl: 'assets/images/meat_lab.png',
               ),
             ),

--- a/app/structure/lib/screen/data_management/researcher/approve_data_screen.dart
+++ b/app/structure/lib/screen/data_management/researcher/approve_data_screen.dart
@@ -16,7 +16,6 @@ import 'package:structure/components/loading_screen.dart';
 import 'package:structure/components/main_button.dart';
 import 'package:structure/components/main_text_field.dart';
 import 'package:structure/config/pallete.dart';
-import 'package:structure/config/userfuls.dart';
 import 'package:structure/viewModel/data_management/researcher/data_management_researcher_view_model.dart';
 
 class ApproveDataScreen extends StatefulWidget {

--- a/app/structure/lib/screen/data_management/researcher/insertion_lab_data_screen.dart
+++ b/app/structure/lib/screen/data_management/researcher/insertion_lab_data_screen.dart
@@ -11,7 +11,6 @@ import 'package:structure/components/custom_app_bar.dart';
 import 'package:structure/components/labdata_field.dart';
 import 'package:structure/components/loading_screen.dart';
 import 'package:structure/components/main_button.dart';
-import 'package:structure/components/tongue_field.dart';
 import 'package:structure/viewModel/data_management/researcher/insertion_lab_data_view_model.dart';
 
 class InsertionLabDataScreen extends StatefulWidget {

--- a/app/structure/lib/screen/meat_registration/freshmeat_eval_screen.dart
+++ b/app/structure/lib/screen/meat_registration/freshmeat_eval_screen.dart
@@ -47,7 +47,7 @@ class _FreshMeatEvalScreenState extends State<FreshMeatEvalScreen>
     return Scaffold(
       backgroundColor: Colors.white,
       appBar: CustomAppBar(
-        title: '신선육 관능평가',
+        title: context.read<FreshMeatEvalViewModel>().title,
         backButton: true,
         closeButton: false,
         backButtonOnPressed:

--- a/app/structure/lib/viewModel/data_management/researcher/add_processed_meat_view_model.dart
+++ b/app/structure/lib/viewModel/data_management/researcher/add_processed_meat_view_model.dart
@@ -9,22 +9,29 @@ import 'package:flutter/widgets.dart';
 import 'package:go_router/go_router.dart';
 
 class AddProcessedMeatViewModel with ChangeNotifier {
+  AddProcessedMeatViewModel();
+
+  /// 사진 촬영 페이지로 이동
   void clickedImage(BuildContext context) {
     context.go('/home/data-manage-researcher/add/processed-meat/image');
   }
 
-  void clickedProcessedEval(BuildContext context) {
+  /// 관능평가 페이지로 이동
+  void clickedEval(BuildContext context) {
     context.go('/home/data-manage-researcher/add/processed-meat/eval');
   }
 
+  /// 관능평가 페이지로 이동
   void clickedHeatedEval(BuildContext context) {
-    context.go('/home/data-manage-researcher/add/processed-meat/heated-meat');
+    context.go('/home/data-manage-researcher/add/processed-meat/heated-eval');
   }
 
+  /// 전자혀 페이지로 이동
   void clickedTongue(BuildContext context) {
     context.go('/home/data-manage-researcher/add/processed-meat/tongue');
   }
 
+  /// 실험실 데이터 페이지로 이동
   void clickedLab(BuildContext context) {
     context.go('/home/data-manage-researcher/add/processed-meat/lab');
   }

--- a/app/structure/lib/viewModel/data_management/researcher/data_management_researcher_view_model.dart
+++ b/app/structure/lib/viewModel/data_management/researcher/data_management_researcher_view_model.dart
@@ -18,7 +18,6 @@ class DataManagementHomeResearcherViewModel with ChangeNotifier {
   DataManagementHomeResearcherViewModel(this.meatModel, this.userModel) {
     _initialize();
   }
-  late BuildContext _context;
 
   // 초기 리스트
   List<Map<String, String>> numList = [];
@@ -421,9 +420,7 @@ class DataManagementHomeResearcherViewModel with ChangeNotifier {
       meatModel.reset();
       meatModel.fromJson(response);
       meatModel.seqno = 0;
-      print(meatModel);
-      _context = context;
-      _movePage();
+      if (context.mounted) context.go('/home/data-manage-researcher/add');
     } catch (e) {
       print("에러발생: $e");
     }
@@ -447,8 +444,7 @@ class DataManagementHomeResearcherViewModel with ChangeNotifier {
       meatModel.fromJson(response);
       meatModel.seqno = 0;
 
-      _context = context;
-      _movePageApprove();
+      if (context.mounted) context.go('/home/data-manage-researcher/approve');
     } catch (e) {
       print("에러발생: $e");
     }
@@ -469,13 +465,5 @@ class DataManagementHomeResearcherViewModel with ChangeNotifier {
         return id.contains(insertedText);
       }).toList();
     }
-  }
-
-  void _movePage() {
-    _context.go('/home/data-manage-researcher/add');
-  }
-
-  void _movePageApprove() {
-    _context.go('/home/data-manage-researcher/approve');
   }
 }

--- a/app/structure/lib/viewModel/meat_registration/freshmeat_eval_view_model.dart
+++ b/app/structure/lib/viewModel/meat_registration/freshmeat_eval_view_model.dart
@@ -37,7 +37,7 @@ class FreshMeatEvalViewModel with ChangeNotifier {
     print(meatModel);
     if (meatModel.seqno == 0) {
       // 원육
-      title = '신선육 관능평가';
+      title = '원육 관능평가';
       meatImage = meatModel.imagePath!;
       marbling = meatModel.freshmeat?["marbling"] ?? 0;
       color = meatModel.freshmeat?["color"] ?? 0;


### PR DESCRIPTION
- 딥에이징 페이지에서 추가정보 처리육/가열육 구분
- 각 고기에 대해 정보 입력 페이지로 연결되도록 ui 수정
- userRouter에서 명칭 수정 : heated-meat -> heated-eval

<img width="352" alt="스크린샷 2024-07-11 오후 4 55 32" src="https://github.com/deun115/Deeplant-Dev/assets/8970523/71661287-27d0-4974-9b84-94678d19d589">
