### PR TITLE
fix: 딥에이징 중간 데이터도 삭제 가능하도록 수정;

### DIFF
--- a/app/structure/lib/components/custom_dialog.dart
+++ b/app/structure/lib/components/custom_dialog.dart
@@ -43,13 +43,13 @@ void showDataRegisterDialog(
   );
 }
 
-void showDatanotCompleteDialog(
+void showDataNotCompleteDialog(
     BuildContext context, VoidCallback? leftFunc, VoidCallback? rightFunc) {
   showCustomDialog(
     context,
     null,
-    '아직 입력되지 않은 정보가 있습니다. \n 저장하시겠습니까?',
-    '',
+    '아직 입력되지 않은 정보가 있습니다.',
+    '저장하시겠습니까?',
     '취소',
     '확인',
     null,

--- a/app/structure/lib/components/deep_aging_card.dart
+++ b/app/structure/lib/components/deep_aging_card.dart
@@ -23,7 +23,6 @@ class DeepAgingCard extends StatelessWidget {
   final int minute;
   final String butcheryDate;
   final bool completed;
-  final bool isLast;
   final VoidCallback onTap;
   final VoidCallback? delete;
   const DeepAgingCard({
@@ -32,7 +31,6 @@ class DeepAgingCard extends StatelessWidget {
     required this.minute,
     required this.butcheryDate,
     required this.completed,
-    required this.isLast,
     required this.onTap,
     this.delete,
   });
@@ -47,12 +45,9 @@ class DeepAgingCard extends StatelessWidget {
             onPressed: onTap,
             style: OutlinedButton.styleFrom(
               shape: RoundedRectangleBorder(
-                borderRadius:
-                    BorderRadius.circular(15), // Makes the border rectangular
+                borderRadius: BorderRadius.circular(15),
               ),
-              side: const BorderSide(
-                color: Color(0xFFEAEAEA),
-              ),
+              side: const BorderSide(color: Color(0xFFEAEAEA)),
             ),
             child: Padding(
               padding: EdgeInsets.symmetric(vertical: 15.h),
@@ -73,33 +68,25 @@ class DeepAgingCard extends StatelessWidget {
                               ),
                               width: 84.w,
                               height: 32.h,
-                              child: Center(
-                                child: Text(deepAgingNum),
-                              ),
+                              child: Center(child: Text(deepAgingNum)),
                             ),
-                            SizedBox(
-                              width: 10.w,
-                            ),
+                            SizedBox(width: 10.w),
                             Text(butcheryDate, style: Palette.h5Grey),
                           ],
                         ),
-                        SizedBox(
-                          height: 15.h,
-                        ),
+                        SizedBox(height: 15.h),
                         Text(
                           '$minute분',
                           style: TextStyle(
-                              fontSize: 36.sp,
-                              fontWeight: FontWeight.w700,
-                              color: Colors.black),
+                            fontSize: 36.sp,
+                            fontWeight: FontWeight.w700,
+                            color: Colors.black,
+                          ),
                         ),
                       ],
                     ),
                   ),
-                  VerticalDivider(
-                    thickness: 1,
-                    color: Colors.grey[300],
-                  ),
+                  VerticalDivider(thickness: 1, color: Colors.grey[300]),
                   SizedBox(
                     width: 160.w,
                     child: Column(
@@ -107,9 +94,7 @@ class DeepAgingCard extends StatelessWidget {
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
                         Text('추가정보 입력', style: Palette.h5LightGrey),
-                        SizedBox(
-                          height: 15.h,
-                        ),
+                        SizedBox(height: 15.h),
                         Text(
                           completed ? '완료' : '미완료',
                           style: TextStyle(
@@ -128,20 +113,18 @@ class DeepAgingCard extends StatelessWidget {
             ),
           ),
         ),
-        isLast == true
-            ? Positioned(
-                top: -5.h,
-                right: -10.w,
-                child: IconButton(
-                  onPressed: delete,
-                  icon: Icon(
-                    Icons.delete,
-                    size: 30.sp,
-                    color: Palette.greyTextColor,
-                  ),
-                ),
-              )
-            : Container(),
+        Positioned(
+          top: -5.h,
+          right: -10.w,
+          child: IconButton(
+            onPressed: delete,
+            icon: Icon(
+              Icons.delete,
+              size: 30.sp,
+              color: Palette.greyTextColor,
+            ),
+          ),
+        )
       ],
     );
   }

--- a/app/structure/lib/screen/data_management/researcher/add_processed_meat_main_screen.dart
+++ b/app/structure/lib/screen/data_management/researcher/add_processed_meat_main_screen.dart
@@ -37,10 +37,10 @@ class _AddProcessedMeatMainScreenState
         backButton: true,
         closeButton: false,
       ),
-      body: Center(
+      body: SingleChildScrollView(
         child: Column(
           children: [
-            SizedBox(height: 48.h),
+            SizedBox(height: 40.h),
 
             // 처리육 단면 촬영
             InkWell(
@@ -151,7 +151,8 @@ class _AddProcessedMeatMainScreenState
                 imageUrl: 'assets/images/meat_lab.png',
               ),
             ),
-            const Spacer(),
+            SizedBox(height: 40.h),
+
             Container(
               margin: EdgeInsets.only(bottom: 40.h),
               child: MainButton(

--- a/app/structure/lib/screen/data_management/researcher/add_raw_meat_main_screen.dart
+++ b/app/structure/lib/screen/data_management/researcher/add_raw_meat_main_screen.dart
@@ -10,7 +10,6 @@ import 'package:provider/provider.dart';
 import 'package:structure/components/custom_app_bar.dart';
 import 'package:structure/components/step_card.dart';
 import 'package:structure/model/meat_model.dart';
-import 'package:structure/viewModel/data_management/normal/edit_meat_data_view_model.dart';
 import 'package:structure/viewModel/data_management/researcher/add_raw_meat_view_model.dart';
 
 class StepFreshMeat extends StatelessWidget {

--- a/app/structure/lib/screen/data_management/researcher/data_add_home_screen.dart
+++ b/app/structure/lib/screen/data_management/researcher/data_add_home_screen.dart
@@ -35,26 +35,23 @@ class _DataAddHomeState extends State<DataAddHome> {
         child: Container(
           margin: EdgeInsets.symmetric(horizontal: 50.w),
           child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              SizedBox(
-                height: 25.h,
-              ),
+              SizedBox(height: 25.h),
+              // 원육
               Row(
                 mainAxisAlignment: MainAxisAlignment.spaceBetween,
                 children: [
-                  Text(
-                    '원육',
-                    style: Palette.h3,
-                  ),
+                  Text('원육', style: Palette.h3),
                   Text(
                     context.read<DataAddHomeViewModel>().userName,
                     style: Palette.h5,
                   ),
                 ],
               ),
-              SizedBox(
-                height: 15.w,
-              ),
+              SizedBox(height: 15.h),
+
+              // 원육 추가데이터
               SizedBox(
                 height: 133.h,
                 // 원육에 대한 추가데이터.
@@ -64,8 +61,7 @@ class _DataAddHomeState extends State<DataAddHome> {
                       .clickedRawMeat(context),
                   style: OutlinedButton.styleFrom(
                     shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(
-                          15), // Makes the border rectangular
+                      borderRadius: BorderRadius.circular(15),
                     ),
                     side: const BorderSide(
                       color: Color(0xFFEAEAEA),
@@ -81,14 +77,15 @@ class _DataAddHomeState extends State<DataAddHome> {
                             mainAxisAlignment: MainAxisAlignment.center,
                             crossAxisAlignment: CrossAxisAlignment.start,
                             children: [
+                              // 도축 날짜
                               Text(
                                   context
                                       .read<DataAddHomeViewModel>()
                                       .butcheryDate,
                                   style: Palette.h5Grey),
-                              SizedBox(
-                                height: 15.h,
-                              ),
+                              SizedBox(height: 15.h),
+
+                              // 종 > 부위
                               Text(
                                 "${context.read<DataAddHomeViewModel>().species} > ${context.read<DataAddHomeViewModel>().secondary}",
                                 style: TextStyle(
@@ -99,10 +96,9 @@ class _DataAddHomeState extends State<DataAddHome> {
                             ],
                           ),
                         ),
-                        VerticalDivider(
-                          thickness: 1,
-                          color: Colors.grey[300],
-                        ),
+                        VerticalDivider(thickness: 1, color: Colors.grey[300]),
+
+                        // 추가정보 입력
                         SizedBox(
                           width: 150.w,
                           child: Column(
@@ -110,9 +106,8 @@ class _DataAddHomeState extends State<DataAddHome> {
                             crossAxisAlignment: CrossAxisAlignment.start,
                             children: [
                               Text('추가정보 입력', style: Palette.h5LightGrey),
-                              SizedBox(
-                                height: 15.h,
-                              ),
+                              SizedBox(height: 15.h),
+
                               // 원육 데이터의 모든 데이터 입력 확인.
                               Text(
                                 context
@@ -140,34 +135,22 @@ class _DataAddHomeState extends State<DataAddHome> {
                   ),
                 ),
               ),
-              SizedBox(
-                height: 40.h,
-              ),
+              SizedBox(height: 40.h),
+
               const Divider(
                 height: 0,
                 thickness: 10,
                 color: Color.fromARGB(255, 250, 250, 250),
               ),
-              SizedBox(
-                height: 20.h,
-              ),
-              Row(
-                children: [
-                  Text('처리육', style: Palette.h3),
-                ],
-              ),
-              SizedBox(
-                height: 15.h,
-              ),
-              Row(
-                children: [
-                  Text('딥에이징 데이터', style: Palette.h4),
-                  const Spacer(),
-                ],
-              ),
-              SizedBox(
-                height: 20.h,
-              ),
+              SizedBox(height: 20.h),
+
+              // 처리육, 딥에이징 데이터 텍스트
+              Text('처리육', style: Palette.h3),
+              SizedBox(height: 15.h),
+              Text('딥에이징 데이터', style: Palette.h4),
+              SizedBox(height: 20.h),
+
+              // 딥에이징 리스트
               SizedBox(
                 height: 450.h,
                 // 딥에이징 추가 데이터 입력 (DeepAgingCard 컴포넌트 사용) - 클릭 | 삭제 시 대응되는 함수 호출
@@ -199,21 +182,12 @@ class _DataAddHomeState extends State<DataAddHome> {
                                   .read<DataAddHomeViewModel>()
                                   .meatModel
                                   .deepAgingData![index]["complete"],
-                              isLast: index ==
-                                      context
-                                              .read<DataAddHomeViewModel>()
-                                              .meatModel
-                                              .deepAgingData!
-                                              .length -
-                                          1
-                                  ? true
-                                  : false,
                               onTap: () async => context
                                   .read<DataAddHomeViewModel>()
                                   .clickedProcessedMeat(index, context),
                               delete: () async => context
                                   .read<DataAddHomeViewModel>()
-                                  .deleteList(index + 1),
+                                  .deleteList(index),
                             ),
                           );
                         },

--- a/app/structure/lib/screen/meat_registration/freshmeat_eval_screen.dart
+++ b/app/structure/lib/screen/meat_registration/freshmeat_eval_screen.dart
@@ -253,10 +253,7 @@ class _FreshMeatEvalScreenState extends State<FreshMeatEvalScreen>
                                 }
                               : null,
                       text:
-                          context.read<FreshMeatEvalViewModel>().meatModel.id !=
-                                  null
-                              ? '수정사항 저장'
-                              : '완료',
+                          context.read<FreshMeatEvalViewModel>().saveBtnText(),
                       width: 658.w,
                       height: 104.h,
                       mode: 1,

--- a/app/structure/lib/viewModel/data_management/researcher/add_processed_meat_view_model.dart
+++ b/app/structure/lib/viewModel/data_management/researcher/add_processed_meat_view_model.dart
@@ -12,7 +12,7 @@ import 'package:structure/components/custom_dialog.dart';
 
 class AddProcessedMeatViewModel with ChangeNotifier {
   bool popup = true;
-  
+
   void clickedImage(BuildContext context) {
     context.go('/home/data-manage-researcher/add/processed-meat/image');
   }
@@ -48,7 +48,7 @@ class AddProcessedMeatViewModel with ChangeNotifier {
         context.go('/home/data-manage-researcher/add');
       });
     } else {
-      showDatanotCompleteDialog(context, null, () {
+      showDataNotCompleteDialog(context, null, () {
         context.go('/home/data-manage-researcher/add');
       });
     }

--- a/app/structure/lib/viewModel/data_management/researcher/data_add_home_view_model.dart
+++ b/app/structure/lib/viewModel/data_management/researcher/data_add_home_view_model.dart
@@ -52,12 +52,14 @@ class DataAddHomeViewModel with ChangeNotifier {
     isLoading = true;
     notifyListeners();
     try {
+      int deepAgeIdx = int.parse(
+          meatModel.deepAgingData![idx]["deepAgingNum"].split('회')[0]);
       dynamic response =
-          await RemoteDataSource.deleteDeepAging(meatModel.id!, idx);
+          await RemoteDataSource.deleteDeepAging(meatModel.id!, deepAgeIdx);
       if (response == null) {
         throw Error();
       } else {
-        meatModel.deepAgingData!.removeLast();
+        meatModel.deepAgingData!.removeAt(idx);
       }
     } catch (e) {
       print("에러발생: $e");

--- a/app/structure/lib/viewModel/meat_registration/freshmeat_eval_view_model.dart
+++ b/app/structure/lib/viewModel/meat_registration/freshmeat_eval_view_model.dart
@@ -66,6 +66,16 @@ class FreshMeatEvalViewModel with ChangeNotifier {
     notifyListeners();
   }
 
+  /// 저장 버튼 텍스트
+  String saveBtnText() {
+    if (meatModel.seqno == 0) {
+      // 원육
+      return meatModel.id != null ? '수정사항 저장' : '완료';
+    } else {
+      return '저장';
+    }
+  }
+
   /// 뒤로가기 버튼
   VoidCallback? backBtnPressed(BuildContext context) {
     return () => showExitDialog(context);

--- a/app/structure/lib/viewModel/meat_registration/registration_meat_image_view_model.dart
+++ b/app/structure/lib/viewModel/meat_registration/registration_meat_image_view_model.dart
@@ -178,6 +178,7 @@ class RegistrationMeatImageViewModel with ChangeNotifier {
       if (meatModel.seqno == 0) {
         // 원육
         meatModel.imagePath = imagePath;
+        print('adsfasdfads: ${imagePath}');
         meatModel.freshmeat ??= {};
         meatModel.freshmeat!['userId'] = meatModel.userId;
         meatModel.freshmeat!['createdAt'] = Usefuls.getCurrentDate();


### PR DESCRIPTION
- 딥에이징 중간 데이터 삭제 가능하도록 수정
- 백엔드 수정 후 정상적으로 작동하는지 확인 필요
<img width="200" alt="스크린샷 2024-07-12 오전 11 53 03" src="https://github.com/user-attachments/assets/1de8e867-364f-46e4-bb1b-6b552009b532">

- 딥에이징 추가정보 입력 페이지 overflow 문제 해결
- freshMeatEvalScreen에서  딥에이징 데이터 입력이면 '저장'으로 표시되도록 수정
<img width="200" alt="스크린샷 2024-07-12 오전 11 56 42" src="https://github.com/user-attachments/assets/a03e89c7-6750-4fb0-8120-625f48f77cd7">
