### PR TITLE
feat: dashboard, pa에 id를 통해서 육류 정보 받아오기 구현.

### DIFF
--- a/test-web/src/components/DataListView/DataList.js
+++ b/test-web/src/components/DataListView/DataList.js
@@ -204,6 +204,7 @@ function DataList({
 
           <TableBody>
             {meatList.map((content, index) => {
+              console.log("content:",content.name, "index:",index)
               const isItemSelected = isSelected(content);
               const labelId = `enhanced-table-checkbox-${index}`;
               return (

--- a/test-web/src/components/DataListView/DataListComp.js
+++ b/test-web/src/components/DataListView/DataListComp.js
@@ -39,6 +39,7 @@ const DataListComp = ({
     });
 
     setMeatList(meatData);
+    console.log(meatData)
   };
 
   // API fetch
@@ -93,6 +94,7 @@ const DataListComp = ({
 
   // 정상 데이터 로드 된 경우
   return (
+    
     <div>
       <div style={style.listContainer}>
         {meatList !== undefined && (

--- a/test-web/src/components/DataListView/DataSingle.js
+++ b/test-web/src/components/DataListView/DataSingle.js
@@ -1,0 +1,57 @@
+import { useState, useEffect } from 'react';
+import DataList from './DataList';
+
+
+// 데이터 목록 조회 페이지 컴포넌트
+const DataSingle = ({ startDate, endDate, data }) => {
+  // 현재 페이지 번호
+  const [currentPage, setCurrentPage] = useState(1);
+  // 한 페이지당 보여줄 개수
+  const [count, setCount] = useState(5);
+  let meatData = [data];
+  console.log("abc",meatData)
+
+  return (
+    <div>
+      <div style={style.listContainer}>
+        {meatData !== undefined && (
+          <DataList
+            meatList={meatData}
+            pageProp={'list'} // 육류 목록 페이지임을 명시
+            offset={currentPage - 1}
+            count={count}
+            startDate={startDate}
+            endDate={endDate}
+            pageOffset={0}
+          />
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default DataSingle;
+
+const style = {
+  listContainer: {
+    textAlign: 'center',
+    width: '100%',
+    paddingRight: '0px',
+    paddingBottom: '0',
+    height: 'auto',
+  },
+  paginationBar: {
+    marginTop: '40px',
+    width: '100%',
+    justifyContent: 'center',
+  },
+  paginationContainer: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  formControl: {
+    minWidth: 120,
+    marginLeft: '20px',
+  },
+};

--- a/test-web/src/components/DataListView/PADataListComp.js
+++ b/test-web/src/components/DataListView/PADataListComp.js
@@ -148,8 +148,7 @@ const style = {
   paginationBar: {
     marginTop: '40px',
     width: '100%',
-    display: 'flex',
-    justifyContent: 'right',
+    justifyContent: 'center',
   },
   paginationContainer: {
     display: 'flex',

--- a/test-web/src/components/DataListView/PASingle.js
+++ b/test-web/src/components/DataListView/PASingle.js
@@ -1,0 +1,56 @@
+import { useState, useEffect } from 'react';
+import DataList from './DataList';
+
+
+// 데이터 목록 조회 페이지 컴포넌트
+const PASingle = ({ startDate, endDate, data }) => {
+  // 현재 페이지 번호
+  const [currentPage, setCurrentPage] = useState(1);
+  // 한 페이지당 보여줄 개수
+  const [count, setCount] = useState(5);
+  let meatData = [data];
+
+  return (
+    <div>
+      <div style={style.listContainer}>
+        {meatData !== undefined && (
+          <DataList
+            meatList={meatData}
+            pageProp={'pa'} // 육류 목록 페이지임을 명시
+            offset={currentPage - 1}
+            count={count}
+            startDate={startDate}
+            endDate={endDate}
+            pageOffset={0}
+          />
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default PASingle;
+
+const style = {
+  listContainer: {
+    textAlign: 'center',
+    width: '100%',
+    paddingRight: '0px',
+    paddingBottom: '0',
+    height: 'auto',
+  },
+  paginationBar: {
+    marginTop: '40px',
+    width: '100%',
+    justifyContent: 'center',
+  },
+  paginationContainer: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  formControl: {
+    minWidth: 120,
+    marginLeft: '20px',
+  },
+};

--- a/test-web/src/components/DataListView/SearchById.js
+++ b/test-web/src/components/DataListView/SearchById.js
@@ -1,0 +1,71 @@
+import React, { useState } from 'react';
+import { apiIP } from '../../config';
+import { HiOutlineSearch } from "react-icons/hi";
+import { TextField, IconButton, Box } from '@mui/material';
+
+function SearchById({ onDataFetch, onValueChange }) {
+  const [id, setId] = useState('');
+
+  const handleChange = (e) => {
+    setId(e.target.value);
+  };
+
+  const handleSearch = async () => {
+    try {
+      const response = await fetch(`http://${apiIP}/meat/get/by-id?id=${id}`);
+      
+      if (!response.ok) {
+        throw new Error('Network response was not ok');
+      }
+      const data = await response.json();
+      onDataFetch(data);
+      onValueChange('single');
+      console.log(data)
+    } catch (error) {
+      console.error('Error fetching data:', error);
+      onDataFetch(null); // 에러 발생 시 데이터 초기화
+    }
+  };
+
+  return (
+    <Box 
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 1, // 간격을 추가하여 인풋과 버튼 사이에 여유 공간을 둡니다.
+        backgroundColor: '#f0f0f0', // 배경색을 설정합니다.
+        borderRadius: '4px', // 모서리를 둥글게 설정합니다.
+        padding: '5px', // 안쪽 여백을 설정합니다.
+      }}
+    >
+      <TextField 
+        type="number" 
+        value={id} 
+        onChange={handleChange} 
+        placeholder="ID"
+        variant="outlined" 
+        size="small" 
+        sx={{ 
+          flex: 1, // 인풋이 가능한 한 넓게 차지하도록 설정합니다.
+          backgroundColor: 'white', // 인풋의 배경색을 설정합니다.
+          borderRadius: '4px', // 인풋의 모서리를 둥글게 설정합니다.
+        }} 
+      />
+      <IconButton 
+        onClick={handleSearch} 
+        color="primary" 
+        sx={{ 
+          backgroundColor: '#115293', // 버튼의 배경색을 설정합니다.
+          color: 'white', // 버튼 아이콘의 색상을 설정합니다.
+          '&:hover': {
+            backgroundColor: 'Navy', // 호버 시 버튼의 배경색을 설정합니다.
+          }
+        }}
+      >
+        <HiOutlineSearch />
+      </IconButton>
+    </Box>
+  );
+}
+
+export default SearchById;

--- a/test-web/src/routes/Dashboard.js
+++ b/test-web/src/routes/Dashboard.js
@@ -17,11 +17,13 @@ import { TIME_ZONE } from '../config';
 // import icon
 import { FaBoxOpen } from 'react-icons/fa';
 import { useLocation } from 'react-router-dom';
+import SearchById from '../components/DataListView/SearchById';
+import DataSingle from '../components/DataListView/DataSingle';
 
 const navy = '#0F3659';
 
 function Dashboard() {
-  // 목록/ 통계/ 반려함 탭 메뉴
+  const [data, setData] = useState(null);
   const [value, setValue] = useState('list');
   const s = new Date();
   s.setDate(s.getDate() - 7);
@@ -44,6 +46,14 @@ function Dashboard() {
       setEndDate(queryEndDate);
     }
   }, [queryStartDate, queryEndDate]);
+
+  const handleDataFetch = (fetchedData) => {
+    setData(fetchedData);
+  };
+
+  const handleValueChange = (newValue) => {
+    setValue(newValue);
+  };
 
   return (
     <div
@@ -84,6 +94,7 @@ function Dashboard() {
             Dashboard
           </span>
         )}
+
         <div style={{ display: 'flex', justifyContent: 'end' }}>
           <Button
             style={
@@ -116,22 +127,35 @@ function Dashboard() {
           >
             목록
           </Button>
-          <Button
-            style={value === 'stat' ? styles.tabBtnCilcked : styles.tabBtn}
-            value="stat"
-            variant="outlined"
-            onClick={(e) => {
-              setValue(e.target.value);
-            }}
-          >
-            통계
-          </Button>
+          {value !== 'single' && (
+            <Button
+              style={value === 'stat' ? styles.tabBtnCilcked : styles.tabBtn}
+              value="stat"
+              variant="outlined"
+              onClick={(e) => {
+                setValue(e.target.value);
+              }}
+            >
+              통계
+            </Button>
+          )}
         </div>
       </Box>
 
       {/**검색필터, 엑셀  */}
       <Box sx={styles.fixed}>
-        <SearchFilterBar setStartDate={setStartDate} setEndDate={setEndDate} />
+        <Box
+          sx={{ display: 'flex', alignItems: 'center', gap: 2, flexGrow: 1 }}
+        >
+          <SearchFilterBar
+            setStartDate={setStartDate}
+            setEndDate={setEndDate}
+          />
+          <SearchById
+            onDataFetch={handleDataFetch}
+            onValueChange={handleValueChange}
+          />
+        </Box>
         <div
           style={{
             display: 'flex',
@@ -140,10 +164,12 @@ function Dashboard() {
             paddingRight: '85px',
           }}
         >
-          {value === 'list' && <ExcelController />}
+          {(value === 'list' || value === 'single') && <ExcelController />}
           {value === 'stat' && <StatsExport />}
         </div>
       </Box>
+
+      {value === 'single' && <DataSingle data={data} />}
 
       {value === 'list' && (
         <DataListComp
@@ -178,6 +204,7 @@ const styles = {
     borderRadius: '0',
     display: 'flex',
     justifyContent: 'space-between',
+    alignItems: 'center', // Add this line to vertically align items
     backgroundColor: 'white',
     margin: '10px 0px',
   },

--- a/test-web/src/routes/PA.js
+++ b/test-web/src/routes/PA.js
@@ -3,15 +3,26 @@ import SearchFilterBar from '../components/Search/SearchFilterBar';
 // 데이터 목록
 import PADataListComp from '../components/DataListView/PADataListComp';
 // mui
-import { Box } from '@mui/material';
+import { Box, Button } from '@mui/material';
 // import timezone
 import { TIME_ZONE } from '../config';
 import { useLocation } from 'react-router-dom';
+import SearchById from '../components/DataListView/SearchById';
+import PASingle from '../components/DataListView/PASingle';
 
 const navy = '#0F3659';
 
 // 예측 목록 페이지
 function PA() {
+  const handleDataFetch = (fetchedData) => {
+    setData(fetchedData);
+  };
+
+  const handleValueChange = (newValue) => {
+    setValue(newValue);
+  };
+  const [value, setValue] = useState('list')
+  const [data, setData] = useState(null)
   /**default 조회 날짜 : 현재 날짜 기준 일주일 전  */
   const s = new Date();
   s.setDate(s.getDate() - 7);
@@ -60,16 +71,45 @@ function PA() {
           Data prediction
         </span>
       </Box>
+          {/**이동 탭 (목록, 통계 , 반려) */}
+          <Box sx={styles.fixedTab}>
+        <div style={{ display: 'flex' }}>
+          <Button
+            style={value === 'list' ? styles.tabBtnCilcked : styles.tabBtn}
+            value="list"
+            variant="outlined"
+            onClick={(e) => {
+              setValue(e.target.value);
+            }}
+          >
+            목록
+          </Button>
+        </div>
+      </Box>
       {/**검색 필터 */}
       <Box sx={styles.fixed}>
-        <SearchFilterBar setStartDate={setStartDate} setEndDate={setEndDate} />
+        <Box
+          sx={{ display: 'flex', alignItems: 'center', gap: 2, flexGrow: 1 }}
+        >
+          <SearchFilterBar
+            setStartDate={setStartDate}
+            setEndDate={setEndDate}
+          />
+          <SearchById
+            onDataFetch={handleDataFetch}
+            onValueChange={handleValueChange}
+          />
+        </Box>
       </Box>
       {/**데이터 목록 */}
-      <PADataListComp
-        startDate={startDate}
-        endDate={endDate}
-        pageOffset={pageOffset}
-      />
+      {value === 'single' && <PASingle data={data} />}
+      {value === 'list' && (
+        <PADataListComp
+          startDate={startDate}
+          endDate={endDate}
+          pageOffset={pageOffset}
+        />
+      )}
     </div>
   );
 }
@@ -85,5 +125,23 @@ const styles = {
     margin: '10px 0px',
     borderBottom: 'solid rgba(0, 0, 0, 0.12)',
     borderBottomWidth: 'thin',
+  },
+  fixedTab: {
+    right: '0',
+    left: '0px',
+    borderRadius: '0',
+    display: 'flex',
+    justifyContent: 'space-between',
+    marginTop: '30px',
+    borderBottom: 'solid rgba(0, 0, 0, 0.12)',
+    borderBottomWidth: 'thin',
+  },
+  tabBtn: {
+    border: 'none',
+    color: navy,
+  },
+  tabBtnCilcked: {
+    border: `1px solid ${navy}`,
+    color: navy,
   },
 };


### PR DESCRIPTION
<img width="2044" alt="image" src="https://github.com/user-attachments/assets/bbe4f86b-e896-4dfa-bc48-14c074f498bf">

- Dashboard, PA 페이지에서 id를 기입하면 해당 육류 데이터를 찾아줌.
- id를 통해 하나의 육류 데이터를 찾으면 기간은 지정되지 않도록 하고, 통계가 의미 없으므로 통계를 볼 수 있는 버튼은 없앰.
- 현재 등록인, 등록타입, 소속은 나오지 않는데, 현재 "get/by-id' api를 사용하므로 정보를 받아오지 못함. 이후 api 수정으로 업데이트 해야함.
- 
