### PR TITLE
feat: create new db_model

### DIFF
--- a/test-backend/test-flask/api/user_api.py
+++ b/test-backend/test-flask/api/user_api.py
@@ -83,7 +83,6 @@ def login_user():
                     "userId": user.userId,
                     "createdAt": user.createdAt,
                     "updatedAt": user.updatedAt,
-                    "password": user.password,
                     "name": user.name,
                     "company": user.company,
                     "jobTitle": user.jobTitle,

--- a/test-backend/test-flask/api/user_api.py
+++ b/test-backend/test-flask/api/user_api.py
@@ -1,7 +1,7 @@
 import logging
 
 from flask import Blueprint, jsonify, request, current_app
-from db.db_model import User
+from db.db_model_ver1 import User
 from db.db_controller import create_user, get_user, _get_users_by_type, update_user
 import hashlib
 import firebase_admin
@@ -46,7 +46,6 @@ def read_user_list():
                 "createdAt": user.createdAt,
                 "updatedAt": user.updatedAt,
                 "loginAt": user.loginAt,
-                "password": user.password,
                 "name": user.name,
                 "company": user.company,
                 "jobTitle": user.jobTitle,

--- a/test-backend/test-flask/app.py
+++ b/test-backend/test-flask/app.py
@@ -9,7 +9,8 @@ import os
 
 from flask_sqlalchemy import SQLAlchemy
 
-from db.db_model import User, initialize_db
+# from db.db_model import User, initialize_db
+from db.db_model_ver1 import initialize_db
 from utils import logger
 import firebase_admin
 from firebase_admin import credentials, auth

--- a/test-backend/test-flask/db/db_model_ver1.py
+++ b/test-backend/test-flask/db/db_model_ver1.py
@@ -1,0 +1,536 @@
+# DB Model Config File
+from sqlalchemy import (
+    Column,
+    Integer,
+    String,
+    DateTime,
+    ForeignKey,
+    Float,
+    PrimaryKeyConstraint,
+    ForeignKeyConstraint,
+    Boolean,
+    CheckConstraint, create_engine,
+)
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import relationship, scoped_session, sessionmaker
+
+from utils import *
+
+Base = declarative_base()
+
+
+def initialize_db(app):
+    try:
+        # 1. DB Engine 생성
+        engine = create_engine(app.config["SQLALCHEMY_DATABASE_URI"])
+        # 2. 생성한 DB 엔진에 세션 연결
+        db_session = scoped_session(
+            sessionmaker(autocommit=False, autoflush=False, bind=engine)
+        )
+        # 3. Default 쿼리 설정
+        Base.query = db_session.query_property()
+        # 4. 모든 테이블 생성
+        Base.metadata.create_all(bind=engine)
+        # 5. DB 초기 데이터 설정
+        load_initial_data(db_session)
+
+        # db_session을 current_app에 추가
+        app.db_session = db_session
+
+        app.logger.info("Database connected successfully.")
+    except Exception as e:
+        app.logger.error(f"Error connecting to the database: {e}")
+        raise
+    else:
+        print("Connect DB OKAY")
+    # 6. db_session을 반환해 DB 세션 관리
+    return db_session
+
+
+# SET UP CONTROLLER
+def load_initial_data(db_session):
+    """
+    초기 데이터 셋업 function
+    """
+    # 1. Specie
+    for id, specie in enumerate(species):
+        if not SpeciesInfo.query.get(id):
+            temp = SpeciesInfo(id=id, value=specie)  # 0: Cattle, 1: Pig
+            db_session.add(temp)
+    db_session.commit()
+
+    # 2. Cattle
+    for id, large in enumerate(cattleLarge):
+        for s_id, small in enumerate(cattleSmall[id]):
+            index = calId(id, s_id, CATTLE)
+            if not CategoryInfo.query.get(index):
+                temp = CategoryInfo(
+                    id=index,
+                    speciesId=CATTLE,
+                    primalValue=large,
+                    secondaryValue=small,
+                )
+                db_session.add(temp)
+    db_session.commit()
+
+    # 3. Pig
+    for id, large in enumerate(pigLarge):
+        for s_id, small in enumerate(pigSmall[id]):
+            index = calId(id, s_id, PIG)
+            if not CategoryInfo.query.get(index):
+                temp = CategoryInfo(
+                    id=index,
+                    speciesId=PIG,
+                    primalValue=large,
+                    secondaryValue=small,
+                )
+                db_session.add(temp)
+    db_session.commit()
+
+    # 4. UserType
+    for id, Type in usrType.items():
+        if not UserTypeInfo.query.get(id):
+            temp = UserTypeInfo(id=id, name=Type)
+            db_session.add(temp)
+    db_session.commit()
+
+    # 5. GradeNum
+    for id, Type in gradeNum.items():
+        if not GradeInfo.query.get(id):
+            temp = GradeInfo(id=id, value=Type)
+            db_session.add(temp)
+    db_session.commit()
+
+    # 6. SexType
+    for id, Type in sexType.items():
+        if not SexInfo.query.get(id):
+            temp = SexInfo(id=id, value=Type)
+            db_session.add(temp)
+    db_session.commit()
+
+    # 7. StatusType
+    for id, Type in statusType.items():
+        if not StatusInfo.query.get(id):
+            temp = StatusInfo(id=id, value=Type)
+            db_session.add(temp)
+    db_session.commit()
+    
+    # 8. User
+    default_user = User.query.get(default_user_id)
+
+    if not default_user:
+        current_date = datetime.now().strftime('%Y-%m-%d')
+        temp = User(
+            userId=default_user_id,
+            createdAt=current_date,
+            name='deeplant',
+            type=default_user_type,
+            updatedAt=None,
+            loginAt=None,
+            company=None,
+            jobTitle=None,
+            homeAddr=None,
+            alarm=False
+        )
+        db_session.add(temp)
+    db_session.commit()
+
+
+# Texonomy Table
+class SpeciesInfo(Base):
+    __tablename__ = "species_info"
+    id = Column(Integer, primary_key=True)  # 종 ID
+    value = Column(String(255))  # 종명(ex. cattle, pig)
+    categories = relationship("CategoryInfo", backref="species_info")
+
+
+class CategoryInfo(Base):
+    __tablename__ = "category_info"
+    id = Column(Integer, primary_key=True)  # 카테고리 ID
+    speciesId = Column(Integer, ForeignKey("species_info.id"))
+    primalValue = Column(String(255), nullable=False)
+    secondaryValue = Column(String(255), nullable=False)
+    meats = relationship("Meat", backref="category_info")
+
+
+class GradeInfo(Base):
+    """
+    0: 1++
+    1: 1+
+    2: 1
+    3: 2
+    4: 3
+    5: None(Null)
+    """
+
+    __tablename__ = "grade_info"
+    id = Column(Integer, primary_key=True)  # 등급 ID
+    value = Column(String(255))  # 등급
+    meats = relationship("Meat", backref="grade_info")
+    aiSensoryEvals = relationship("AI_SensoryEval", backref="grade_info")
+
+
+class SexInfo(Base):
+    """
+    0: 수
+    1: 암
+    2: 거세
+    3: null
+    """
+
+    __tablename__ = "sex_info"
+    id = Column(Integer, primary_key=True)  # 성별 ID
+    value = Column(String(255))  # 성별 값
+    meats = relationship("Meat", backref="sex_info")
+
+
+class StatusInfo(Base):
+    """
+    0: 대기중
+    1: 반려
+    2: 승인
+    """
+
+    __tablename__ = "status_info"
+    id = Column(Integer, primary_key=True)  # 승인 ID
+    value = Column(String(255))  # 승인 정보
+    meats = relationship("Meat", backref="status_info")
+
+
+class UserTypeInfo(Base):
+    """
+    0: Normal
+    1: Researcher
+    2: Manager
+    3: None
+    """
+
+    __tablename__ = "userType_info"
+    id = Column(Integer, primary_key=True)
+    name = Column(String(255))
+    users = relationship("User", backref="userType_info")
+    
+    
+class User(Base):
+    __tablename__ = "user"
+    userId = Column(String(255), primary_key=True) # 유저 ID(이메일)
+    createdAt = Column(DateTime, nullable=False) # 유저 ID 생성 시간
+    updatedAt = Column(DateTime) # 최신의 유저 정보 수정 시간
+    loginAt = Column(DateTime) # 유저 로그인 시간
+    name = Column(String(255), nullable=False) # 유저명
+    company = Column(String(255))  # 직장명
+    jobTitle = Column(String(255))  # 직위명
+    homeAddr = Column(String(255))  # 유저 주소
+    alarm = Column(Boolean, default=False)  # 유저 알람 허용 여부
+    type = Column(Integer, nullable=False)  # 유저 타입 ID
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["type"], ["userType_info.id"],
+            onupdate="CASCADE"
+        ),
+    )
+    
+    meats = relationship("Meat", backref="user")
+    sensoryEvals = relationship("SensoryEval", backref="user")
+    heatedmeatSensoryEvals = relationship("HeatedmeatSensoryEval", backref="user")
+    probexptDatas = relationship("ProbexptData", backref="user")
+
+
+class Meat(Base):
+    __tablename__ = "meat"
+    # 1. 기본 정보
+    id = Column(String(255), primary_key=True)  # 육류 관리번호
+    userId = Column(String(255), 
+                    ForeignKey("user.userId"), 
+                    nullable=False, 
+                    default=default_user_id)  # 생성한 유저 ID
+    sexType = Column(Integer, ForeignKey("sex_info.id"))  # 성별 ID
+    categoryId = Column(
+        Integer, ForeignKey("category_info.id"), nullable=False
+    )  # 육종 ID
+    gradeNum = Column(Integer, ForeignKey("grade_info.id"))  # 등급 ID
+    statusType = Column(Integer, ForeignKey("status_info.id"), default=0)  # 승인 여부 ID
+
+    # 2. 육류 Open API 정보
+    createdAt = Column(DateTime, nullable=False)  # 육류 관리번호 생성 시간
+    traceNum = Column(String(255), nullable=False)  # 이력번호(혹은 묶은 번호)
+    farmAddr = Column(String(255))  # 농장 주소
+    farmerNm = Column(String(255))  # 농장주 이름
+    butcheryYmd = Column(DateTime, nullable=False)  # 도축 일자
+    birthYmd = Column(DateTime)  # 출생일자
+
+    # 3. 이미지 Path
+    imagePath = Column(String(255))  # QR 이미지 S3 경로
+    
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["userId"], ["user.userId"],
+            ondelete="SET DEFAULT",
+            onupdate="CASCADE"
+        ),
+        ForeignKeyConstraint(
+            ["sexType"], ["sex_info.id"],
+            onupdate="CASCADE"
+        ),
+        ForeignKeyConstraint(
+            ["categoryId"], ["category_info.id"],
+            onupdate="CASCADE"
+        ),
+        ForeignKeyConstraint(
+            ["gradeNum"], ["grade_info.id"],
+            onupdate="CASCADE"
+        ),
+        ForeignKeyConstraint(
+            ["statusType"], ["status_info.id"],
+            onupdate="CASCADE"
+        ),
+    )
+    deepAgingInfos = relationship("DeepAgingInfo", backref="meat")
+
+
+class DeepAgingInfo(Base):
+    __tablename__ = "deepAging_info"
+    
+    # 1. 복합키 설정
+    id = Column(
+        String(255),
+        ForeignKey("meat.id"),
+        primary_key=True,
+    )  # 육류 관리번호
+    seqno = Column(Integer, primary_key=True)  # 가공 횟수
+    __table_args__ = (
+        PrimaryKeyConstraint("id", "seqno"),
+        ForeignKeyConstraint(
+            ["id"], ["meat.id"],
+            ondelete="CASCADE",
+            onupdate="CASCADE"
+        ),
+    )
+
+    # 2. 딥에이징 데이터
+    date = Column(DateTime, nullable=False)  # 딥에이징 실시 날짜
+    minute = Column(Integer, nullable=False)  # 딥에이징 진행 시간 (분)
+    
+    heatedmeatSensoryEvals = relationship("HeatedmeatSensoryEval", backref="deepAging_info")
+    sensoryEvals = relationship("SensoryEval", backref="deepAging_info")
+    probexptDatas = relationship("ProbexptData", backref="deepAging_info")
+
+    
+class SensoryEval(Base):
+    __tablename__ = "sensory_eval"
+
+    # 1. 복합키 설정
+    id = Column(
+        String(255),
+        ForeignKey("meat.id"),
+        primary_key=True,
+    )  # 육류 관리번호
+    seqno = Column(Integer, primary_key=True)  # 가공 횟수
+
+    # 2. 관능검사 메타 데이터
+    createdAt = Column(DateTime, nullable=False)  # 관능검사 생성 시간
+    userId = Column(
+        String(255), ForeignKey("user.userId"), nullable=False
+    )  # 관능검사 생성한 유저 ID
+    period = Column(Integer, nullable=False)  # 도축일로부터 경과된 시간
+    imagePath = Column(String(255))  # 관능검사 이미지 경로
+
+    # 3. 관능검사 측정 데이터
+    marbling = Column(Float)
+    color = Column(Float)
+    texture = Column(Float)
+    surfaceMoisture = Column(Float)
+    overall = Column(Float)
+    
+    __table_args__ = (
+        PrimaryKeyConstraint("id", "seqno"),
+        ForeignKeyConstraint(
+            ["id", "seqno"], ["deepAging_info.id", "deepAging_info.seqno"],
+            ondelete="CASCADE",
+            onupdate="CASCADE"
+        ),
+        ForeignKeyConstraint(
+            ["userId"], ["user.userId"],
+            ondelete="SET DEFAULT",
+            onupdate="CASCADE"
+        ),
+        CheckConstraint('"period" >= 0', name="check_period_non_negative"),
+        CheckConstraint('"marbling" >= 1 AND "marbling" <= 10', name="check_marbling_range"),
+        CheckConstraint('"color" >= 1 AND "color" <= 10', name="check_color_range"),
+        CheckConstraint('"texture" >= 1 AND "texture" <= 10', name="check_texture_range"),
+        CheckConstraint('"surfaceMoisture" >= 1 AND "surfaceMoisture" <= 10', name="check_surfaceMoisture_range"),
+        CheckConstraint('"overall" >= 1 AND "overall" <= 10', name="check_overall_range"),
+    )
+    
+    aiSensoryEvals = relationship("AI_SensoryEval", backref="sensory_eval")
+    
+    
+class AI_SensoryEval(Base):
+    __tablename__ = "ai_sensory_eval"
+    # 1. 복합키 설정
+    id = Column(String(255), primary_key=True)
+    seqno = Column(Integer, primary_key=True)
+
+    # 2. AI 관능검사 메타 데이터
+    createdAt = Column(DateTime, nullable=False)
+    xai_imagePath = Column(String(255))  # 예측 관능검사 이미지 경로
+    xai_gradeNum = Column(Integer, ForeignKey("grade_info.id"))  # 예측 등급
+    xai_gradeNum_imagePath = Column(String(255))  # 예측 등급 image path
+
+    # 3. 관능검사 AI 예측 데이터
+    marbling = Column(Float)
+    color = Column(Float)
+    texture = Column(Float)
+    surfaceMoisture = Column(Float)
+    overall = Column(Float)
+    
+    __table_args__ = (
+        PrimaryKeyConstraint("id", "seqno"),
+        ForeignKeyConstraint(
+            ["id", "seqno"], ["sensory_eval.id", "sensory_eval.seqno"],
+            ondelete="CASCADE",
+            onupdate="CASCADE"
+        ),
+        ForeignKeyConstraint(
+            ["xai_gradeNum"], ["grade_info.id"],
+            onupdate="CASCADE"
+        ),
+        CheckConstraint('"marbling" >= 1 AND "marbling" <= 10', name="check_marbling_range"),
+        CheckConstraint('"color" >= 1 AND "color" <= 10', name="check_color_range"),
+        CheckConstraint('"texture" >= 1 AND "texture" <= 10', name="check_texture_range"),
+        CheckConstraint('"surfaceMoisture" >= 1 AND "surfaceMoisture" <= 10', name="check_surfaceMoisture_range"),
+        CheckConstraint('"overall" >= 1 AND "overall" <= 10', name="check_overall_range"),
+    )
+    
+
+class HeatedmeatSensoryEval(Base):
+    __tablename__ = "heatedmeat_sensory_eval"
+    # 1. 복합키 설정
+    id = Column(String(255), primary_key=True)
+    seqno = Column(Integer, primary_key=True)
+
+    # 2. 관능검사 메타 데이터
+    createdAt = Column(DateTime, nullable=False)
+    userId = Column(String(255), 
+                    nullable=False, 
+                    default=default_user_id)
+    period = Column(Integer, nullable=False)  # 도축일로부터 경과된 시간
+    imagePath = Column(String(255), nullable=True)  # 가열육 관능검사 이미지 경로
+
+    # 3. 관능검사 측정 데이터
+    flavor = Column(Float, nullable=True)
+    juiciness = Column(Float, nullable=True)
+    tenderness = Column(Float, nullable=True)
+    umami = Column(Float, nullable=True)
+    palatability = Column(Float, nullable=True)
+    
+    __table_args__ = (
+        PrimaryKeyConstraint("id", "seqno"),
+        ForeignKeyConstraint(
+            ["id", "seqno"], 
+            ["deepAging_info.id", "deepAging_info.seqno"],
+            ondelete='CASCADE', 
+            onupdate='CASCADE'
+        ),
+        ForeignKeyConstraint(
+            ["userId"], 
+            ["user.userId"], 
+            ondelete='SET DEFAULT', 
+            onupdate='CASCADE'
+        ),
+        CheckConstraint('"period" >= 0', name="check_period_value"),
+        CheckConstraint('"flavor" >= 1 and "flavor" <= 10', name="check_flavor_stat"),
+        CheckConstraint('"juiciness" >= 1 and "juiciness" <= 10', name="check_juiciness_stat"),
+        CheckConstraint('"tenderness" >= 1 and "tenderness" <= 10', name="check_tenderness_stat"),
+        CheckConstraint('"umami" >= 1 and "umami" <= 10', name="check_umami_stat"),
+        CheckConstraint('"palatability" >= 1 and "palatability" <= 10', name="check_palatability_stat")
+    )
+    
+    aiHeatedmeatSensoryEvals = relationship("AI_HeatedmeatSensoryEval", backref="heatedmeat_sensory_eval")
+
+
+class AI_HeatedmeatSensoryEval(Base):
+    __tablename__ = "ai_heatedmeat_sensory_eval"
+    # 1. 복합키 설정
+    id = Column(String(255), primary_key=True)
+    seqno = Column(Integer, primary_key=True)
+
+    # 2. AI 관능검사 메타 데이터
+    createdAt = Column(DateTime, nullable=False)
+    xai_imagePath = Column(String(255), nullable=True)  # 예측 관능검사 이미지 경로
+
+    # 3. 관능검사 AI 예측 데이터
+    flavor = Column(Float, nullable=True)
+    juiciness = Column(Float, nullable=True)
+    tenderness = Column(Float, nullable=True)
+    umami = Column(Float, nullable=True)
+    palatability = Column(Float, nullable=True)
+    
+    __table_args__ = (
+        PrimaryKeyConstraint("id", "seqno"),
+        ForeignKeyConstraint(
+            ["id", "seqno"], 
+            ["heatedmeat_sensory_eval.id", "heatedmeat_sensory_eval.seqno"], 
+            ondelete='CASCADE', 
+            onupdate='CASCADE'
+        ),
+        CheckConstraint('"flavor" >= 1 and "flavor" <= 10', name="check_flavor_stat"),
+        CheckConstraint('"juiciness" >= 1 and "juiciness" <= 10', name="check_juiciness_stat"),
+        CheckConstraint('"tenderness" >= 1 and "tenderness" <= 10', name="check_tenderness_stat"),
+        CheckConstraint('"umami" >= 1 and "umami" <= 10', name="check_umami_stat"),
+        CheckConstraint('"palatability" >= 1 and "palatability" <= 10', name="check_palatability_stat")
+    )
+
+
+class ProbexptData(Base):
+    __tablename__ = "probexpt_data"
+    # 1. 복합키 설정
+    id = Column(String(255), primary_key=True)
+    seqno = Column(Integer, primary_key=True)
+    isHeated = Column(Boolean, primary_key=True)
+
+    # 2. 연구실 메타 데이터
+    updatedAt = Column(DateTime, nullable=True)
+    userId = Column(String(255), 
+                    nullable=False, 
+                    default=default_user_id)
+    period = Column(Integer, nullable=True)
+
+    # 3. 실험 데이터
+    L = Column(Float, nullable=True)
+    a = Column(Float, nullable=True)
+    b = Column(Float, nullable=True)
+    DL = Column(Float, nullable=True)
+    CL = Column(Float, nullable=True)
+    RW = Column(Float, nullable=True)
+    ph = Column(Float, nullable=True)
+    WBSF = Column(Float, nullable=True)
+    cardepsin_activity = Column(Float, nullable=True)
+    MFI = Column(Float, nullable=True)
+    Collagen = Column(Float, nullable=True)
+
+    # 4. 전자혀 데이터
+    sourness = Column(Float, nullable=True)
+    bitterness = Column(Float, nullable=True)
+    umami = Column(Float, nullable=True)
+    richness = Column(Float, nullable=True) 
+    
+    __table_args__ = (
+        PrimaryKeyConstraint("id", "seqno", "isHeated"),
+        ForeignKeyConstraint(
+            ["id", "seqno"], 
+            ["deepAging_info.id", "deepAging_info.seqno"], 
+            ondelete='CASCADE', 
+            onupdate='CASCADE'
+        ),
+        ForeignKeyConstraint(
+            ['userId'],
+            ['user.userId'],
+            ondelete='SET DEFAULT',
+            onupdate='CASCADE'
+        ),
+        CheckConstraint('"period" >= 0', name="check_period_value"),
+        CheckConstraint('"DL" >= 0 AND "DL" <= 100', name="check_DL_percentage"),
+        CheckConstraint('"CL" >= 0 AND "CL" <= 100', name="check_CL_percentage"),
+        CheckConstraint('"RW" >= 0 AND "RW" <= 100', name="check_RW_percentage"),
+    )

--- a/test-backend/test-flask/db/db_model_ver1.py
+++ b/test-backend/test-flask/db/db_model_ver1.py
@@ -221,12 +221,12 @@ class User(Base):
     company = Column(String(255))  # 직장명
     jobTitle = Column(String(255))  # 직위명
     homeAddr = Column(String(255))  # 유저 주소
-    alarm = Column(Boolean, default=False)  # 유저 알람 허용 여부
+    alarm = Column(Boolean, nullable=False)  # 유저 알람 허용 여부
     type = Column(Integer, nullable=False)  # 유저 타입 ID
     __table_args__ = (
         ForeignKeyConstraint(
             ["type"], ["userType_info.id"],
-            onupdate="CASCADE"
+            onupdate='CASCADE'
         ),
     )
     
@@ -240,13 +240,20 @@ class Meat(Base):
     __tablename__ = "meat"
     # 1. 기본 정보
     id = Column(String(255), primary_key=True)  # 육류 관리번호
-    userId = Column(String(255), 
-                    nullable=False, 
-                    default=default_user_id)  # 생성한 유저 ID
+    userId = Column(
+        String(255), 
+        nullable=False, 
+        default=True,
+        server_default=default_user_id
+    )  # 생성한 유저 ID
     sexType = Column(Integer)  # 성별 ID
     categoryId = Column(Integer, nullable=False)  # 육종 ID
     gradeNum = Column(Integer)  # 등급 ID
-    statusType = Column(Integer, default=0)  # 승인 여부 ID
+    statusType = Column(
+        Integer, 
+        default=True,
+        server_default='0'
+    )  # 승인 여부 ID
 
     # 2. 육류 Open API 정보
     createdAt = Column(DateTime, nullable=False)  # 육류 관리번호 생성 시간
@@ -262,24 +269,24 @@ class Meat(Base):
     __table_args__ = (
         ForeignKeyConstraint(
             ["userId"], ["user.userId"],
-            ondelete="SET DEFAULT",
-            onupdate="CASCADE"
+            ondelete='SET DEFAULT',
+            onupdate='CASCADE'
         ),
         ForeignKeyConstraint(
             ["sexType"], ["sex_info.id"],
-            onupdate="CASCADE"
+            onupdate='CASCADE'
         ),
         ForeignKeyConstraint(
             ["categoryId"], ["category_info.id"],
-            onupdate="CASCADE"
+            onupdate='CASCADE'
         ),
         ForeignKeyConstraint(
             ["gradeNum"], ["grade_info.id"],
-            onupdate="CASCADE"
+            onupdate='CASCADE'
         ),
         ForeignKeyConstraint(
             ["statusType"], ["status_info.id"],
-            onupdate="CASCADE"
+            onupdate='CASCADE'
         ),
     )
     deepAgingInfos = relationship("DeepAgingInfo", backref="meat")
@@ -289,17 +296,14 @@ class DeepAgingInfo(Base):
     __tablename__ = "deepAging_info"
     
     # 1. 복합키 설정
-    id = Column(
-        String(255),
-        primary_key=True,
-    )  # 육류 관리번호
+    id = Column(String(255), primary_key=True)  # 육류 관리번호
     seqno = Column(Integer, primary_key=True)  # 가공 횟수
     __table_args__ = (
         PrimaryKeyConstraint("id", "seqno"),
         ForeignKeyConstraint(
             ["id"], ["meat.id"],
-            ondelete="CASCADE",
-            onupdate="CASCADE"
+            ondelete='CASCADE',
+            onupdate='CASCADE'
         ),
     )
 
@@ -316,16 +320,16 @@ class SensoryEval(Base):
     __tablename__ = "sensory_eval"
 
     # 1. 복합키 설정
-    id = Column(
-        String(255),
-        primary_key=True,
-    )  # 육류 관리번호
+    id = Column(String(255), primary_key=True)  # 육류 관리번호
     seqno = Column(Integer, primary_key=True)  # 가공 횟수
 
     # 2. 관능검사 메타 데이터
     createdAt = Column(DateTime, nullable=False)  # 관능검사 생성 시간
     userId = Column(
-        String(255), nullable=False
+        String(255), 
+        nullable=False,
+        default=True,
+        server_default=default_user_id
     )  # 관능검사 생성한 유저 ID
     period = Column(Integer, nullable=False)  # 도축일로부터 경과된 시간
     imagePath = Column(String(255))  # 관능검사 이미지 경로
@@ -341,13 +345,13 @@ class SensoryEval(Base):
         PrimaryKeyConstraint("id", "seqno"),
         ForeignKeyConstraint(
             ["id", "seqno"], ["deepAging_info.id", "deepAging_info.seqno"],
-            ondelete="CASCADE",
-            onupdate="CASCADE"
+            ondelete='CASCADE',
+            onupdate='CASCADE'
         ),
         ForeignKeyConstraint(
             ["userId"], ["user.userId"],
-            ondelete="SET DEFAULT",
-            onupdate="CASCADE"
+            ondelete='SET DEFAULT',
+            onupdate='CASCADE'
         ),
         CheckConstraint('"period" >= 0', name="check_period_non_negative"),
         CheckConstraint('"marbling" >= 1 AND "marbling" <= 10', name="check_marbling_range"),
@@ -383,12 +387,12 @@ class AI_SensoryEval(Base):
         PrimaryKeyConstraint("id", "seqno"),
         ForeignKeyConstraint(
             ["id", "seqno"], ["sensory_eval.id", "sensory_eval.seqno"],
-            ondelete="CASCADE",
-            onupdate="CASCADE"
+            ondelete='CASCADE',
+            onupdate='CASCADE'
         ),
         ForeignKeyConstraint(
             ["xai_gradeNum"], ["grade_info.id"],
-            onupdate="CASCADE"
+            onupdate='CASCADE'
         ),
         CheckConstraint('"marbling" >= 1 AND "marbling" <= 10', name="check_marbling_range"),
         CheckConstraint('"color" >= 1 AND "color" <= 10', name="check_color_range"),
@@ -406,30 +410,31 @@ class HeatedmeatSensoryEval(Base):
 
     # 2. 관능검사 메타 데이터
     createdAt = Column(DateTime, nullable=False)
-    userId = Column(String(255), 
-                    nullable=False, 
-                    default=default_user_id)
+    userId = Column(
+        String(255), 
+        nullable=False, 
+        default=True,
+        server_default=default_user_id
+    )
     period = Column(Integer, nullable=False)  # 도축일로부터 경과된 시간
-    imagePath = Column(String(255), nullable=True)  # 가열육 관능검사 이미지 경로
+    imagePath = Column(String(255))  # 가열육 관능검사 이미지 경로
 
     # 3. 관능검사 측정 데이터
-    flavor = Column(Float, nullable=True)
-    juiciness = Column(Float, nullable=True)
-    tenderness = Column(Float, nullable=True)
-    umami = Column(Float, nullable=True)
-    palatability = Column(Float, nullable=True)
+    flavor = Column(Float)
+    juiciness = Column(Float)
+    tenderness = Column(Float)
+    umami = Column(Float)
+    palatability = Column(Float)
     
     __table_args__ = (
         PrimaryKeyConstraint("id", "seqno"),
         ForeignKeyConstraint(
-            ["id", "seqno"], 
-            ["deepAging_info.id", "deepAging_info.seqno"],
+            ["id", "seqno"], ["deepAging_info.id", "deepAging_info.seqno"],
             ondelete='CASCADE', 
             onupdate='CASCADE'
         ),
         ForeignKeyConstraint(
-            ["userId"], 
-            ["user.userId"], 
+            ["userId"], ["user.userId"], 
             ondelete='SET DEFAULT', 
             onupdate='CASCADE'
         ),
@@ -452,20 +457,19 @@ class AI_HeatedmeatSensoryEval(Base):
 
     # 2. AI 관능검사 메타 데이터
     createdAt = Column(DateTime, nullable=False)
-    xai_imagePath = Column(String(255), nullable=True)  # 예측 관능검사 이미지 경로
+    xai_imagePath = Column(String(255))  # 예측 관능검사 이미지 경로
 
     # 3. 관능검사 AI 예측 데이터
-    flavor = Column(Float, nullable=True)
-    juiciness = Column(Float, nullable=True)
-    tenderness = Column(Float, nullable=True)
-    umami = Column(Float, nullable=True)
-    palatability = Column(Float, nullable=True)
+    flavor = Column(Float)
+    juiciness = Column(Float)
+    tenderness = Column(Float)
+    umami = Column(Float)
+    palatability = Column(Float)
     
     __table_args__ = (
         PrimaryKeyConstraint("id", "seqno"),
         ForeignKeyConstraint(
-            ["id", "seqno"], 
-            ["heatedmeat_sensory_eval.id", "heatedmeat_sensory_eval.seqno"], 
+            ["id", "seqno"], ["heatedmeat_sensory_eval.id", "heatedmeat_sensory_eval.seqno"], 
             ondelete='CASCADE', 
             onupdate='CASCADE'
         ),
@@ -485,42 +489,43 @@ class ProbexptData(Base):
     isHeated = Column(Boolean, primary_key=True)
 
     # 2. 연구실 메타 데이터
-    updatedAt = Column(DateTime, nullable=True)
-    userId = Column(String(255), 
-                    nullable=False, 
-                    default=default_user_id)
-    period = Column(Integer, nullable=True)
+    updatedAt = Column(DateTime)
+    userId = Column(
+        String(255), 
+        nullable=False, 
+        default=True,
+        server_default=default_user_id
+    )
+    period = Column(Integer, nullable=False)
 
     # 3. 실험 데이터
-    L = Column(Float, nullable=True)
-    a = Column(Float, nullable=True)
-    b = Column(Float, nullable=True)
-    DL = Column(Float, nullable=True)
-    CL = Column(Float, nullable=True)
-    RW = Column(Float, nullable=True)
-    ph = Column(Float, nullable=True)
-    WBSF = Column(Float, nullable=True)
-    cardepsin_activity = Column(Float, nullable=True)
-    MFI = Column(Float, nullable=True)
-    Collagen = Column(Float, nullable=True)
+    L = Column(Float)
+    a = Column(Float)
+    b = Column(Float)
+    DL = Column(Float)
+    CL = Column(Float)
+    RW = Column(Float)
+    ph = Column(Float)
+    WBSF = Column(Float)
+    cardepsin_activity = Column(Float)
+    MFI = Column(Float)
+    Collagen = Column(Float)
 
     # 4. 전자혀 데이터
-    sourness = Column(Float, nullable=True)
-    bitterness = Column(Float, nullable=True)
-    umami = Column(Float, nullable=True)
-    richness = Column(Float, nullable=True) 
+    sourness = Column(Float)
+    bitterness = Column(Float)
+    umami = Column(Float)
+    richness = Column(Float) 
     
     __table_args__ = (
         PrimaryKeyConstraint("id", "seqno", "isHeated"),
         ForeignKeyConstraint(
-            ["id", "seqno"], 
-            ["deepAging_info.id", "deepAging_info.seqno"], 
+            ["id", "seqno"], ["deepAging_info.id", "deepAging_info.seqno"], 
             ondelete='CASCADE', 
             onupdate='CASCADE'
         ),
         ForeignKeyConstraint(
-            ['userId'],
-            ['user.userId'],
+            ['userId'],['user.userId'],
             ondelete='SET DEFAULT',
             onupdate='CASCADE'
         ),

--- a/test-backend/test-flask/db/db_model_ver1.py
+++ b/test-backend/test-flask/db/db_model_ver1.py
@@ -241,15 +241,12 @@ class Meat(Base):
     # 1. 기본 정보
     id = Column(String(255), primary_key=True)  # 육류 관리번호
     userId = Column(String(255), 
-                    ForeignKey("user.userId"), 
                     nullable=False, 
                     default=default_user_id)  # 생성한 유저 ID
-    sexType = Column(Integer, ForeignKey("sex_info.id"))  # 성별 ID
-    categoryId = Column(
-        Integer, ForeignKey("category_info.id"), nullable=False
-    )  # 육종 ID
-    gradeNum = Column(Integer, ForeignKey("grade_info.id"))  # 등급 ID
-    statusType = Column(Integer, ForeignKey("status_info.id"), default=0)  # 승인 여부 ID
+    sexType = Column(Integer)  # 성별 ID
+    categoryId = Column(Integer, nullable=False)  # 육종 ID
+    gradeNum = Column(Integer)  # 등급 ID
+    statusType = Column(Integer, default=0)  # 승인 여부 ID
 
     # 2. 육류 Open API 정보
     createdAt = Column(DateTime, nullable=False)  # 육류 관리번호 생성 시간
@@ -294,7 +291,6 @@ class DeepAgingInfo(Base):
     # 1. 복합키 설정
     id = Column(
         String(255),
-        ForeignKey("meat.id"),
         primary_key=True,
     )  # 육류 관리번호
     seqno = Column(Integer, primary_key=True)  # 가공 횟수
@@ -322,7 +318,6 @@ class SensoryEval(Base):
     # 1. 복합키 설정
     id = Column(
         String(255),
-        ForeignKey("meat.id"),
         primary_key=True,
     )  # 육류 관리번호
     seqno = Column(Integer, primary_key=True)  # 가공 횟수
@@ -330,7 +325,7 @@ class SensoryEval(Base):
     # 2. 관능검사 메타 데이터
     createdAt = Column(DateTime, nullable=False)  # 관능검사 생성 시간
     userId = Column(
-        String(255), ForeignKey("user.userId"), nullable=False
+        String(255), nullable=False
     )  # 관능검사 생성한 유저 ID
     period = Column(Integer, nullable=False)  # 도축일로부터 경과된 시간
     imagePath = Column(String(255))  # 관능검사 이미지 경로
@@ -374,7 +369,7 @@ class AI_SensoryEval(Base):
     # 2. AI 관능검사 메타 데이터
     createdAt = Column(DateTime, nullable=False)
     xai_imagePath = Column(String(255))  # 예측 관능검사 이미지 경로
-    xai_gradeNum = Column(Integer, ForeignKey("grade_info.id"))  # 예측 등급
+    xai_gradeNum = Column(Integer)  # 예측 등급
     xai_gradeNum_imagePath = Column(String(255))  # 예측 등급 image path
 
     # 3. 관능검사 AI 예측 데이터

--- a/test-backend/test-flask/utils.py
+++ b/test-backend/test-flask/utils.py
@@ -132,6 +132,8 @@ gradeNum = {0: "1++", 1: "1+", 2: "1", 3: "2", 4: "3", 5: None}
 statusType = {0: "대기중", 1: "반려", 2: "승인"}
 CATTLE = 0
 PIG = 1
+default_user_id = 'deeplant@example.com'
+default_user_type = 2
 
 
 def safe_float(val):


### PR DESCRIPTION
## 추가한 점
- 기존의 `meat` ← `sensory_eval`에서 `meat` ← `deepAging_info` 로 참조관계 변경
  - `deepAging_info`가 각각 `sensory_eval`, `heatedmeat_sensory_eval` (이하 1:1), `probexpt_data`(1:M)으로 참조
  - `meat`가 삭제/갱신될 경우 해당 `meat.id`를 가지는 관련 데이터를 CASCADE로 삭제/갱신
  - 특정 `meat` 데이터를 등록한 `user` 정보가 삭제될 경우, 해당하는 `userId`를 가지는 데이터들의 `userId`를 default 값으로 갱신
    - Default `userId`를 설정하기 위해 db의 initial data로 default 값을 보유하는 `user` 데이터 추가
  - 기본적인 로그인 테스트를 위해 `user/login` API의 ResDTO에서 password만 임시 삭제 (추가 업데이트 필요)
- 더 이상 `user` 테이블에서 `password`를 저장하지 않습니다!
## 수정한 점
- 테이블의 참조관계 등의 중복된 제약조건을 유발하는 코드 제거
- 기존의 default 설정이 db에 제대로 반영되지 않는 에러를 수정
- `user`의 `alarm` 속성의 nullable 설정이 올바르지 않던 것을 수정