### PR TITLE
fix: 대시보드 통계탭 오류 해결 및 수정

### DIFF
--- a/test-web/src/components/Charts/PieChart/pieChart.js
+++ b/test-web/src/components/Charts/PieChart/pieChart.js
@@ -27,7 +27,7 @@ const PieChart = ({ subheader, chartColors, startDate, endDate, ...other }) => {
       width: 0, // 선의 두께를 0으로 설정
       colors: [theme.palette.background.paper],
     }, // Stroke colors for the chart.
-    legend: { floating: true, horizontalAlign: 'center' }, // Legend configuration.
+    legend: { floating: true, horizontalAlign: 'center', top: -20 }, // Legend configuration.
     dataLabels: { enabled: true, dropShadow: { enabled: true } }, // Data label configuration
     tooltip: {
       fillSeriesColor: true, // Whether to fill the tooltip with series color.
@@ -39,7 +39,17 @@ const PieChart = ({ subheader, chartColors, startDate, endDate, ...other }) => {
       },
     },
     plotOptions: {
-      pie: { donut: { labels: { show: true } } }, // Plot options for a donut chart. (가운데 설명 표시)
+      pie: {
+        donut: {
+          labels: {
+            show: true,
+            name: {
+              show: true,
+              offsetY: -20, // 이름 위치를 위로 조정
+            },
+          },
+        },
+      },
     },
   });
 

--- a/test-web/src/components/Charts/PieChart/pieChart.js
+++ b/test-web/src/components/Charts/PieChart/pieChart.js
@@ -53,17 +53,31 @@ const PieChart = ({ subheader, chartColors, startDate, endDate, ...other }) => {
     },
   });
 
-  // fetch한 JSON 데이터에서 필요한 값 parsing 및 chartSeries에 저장
-  const processPieData = (data) => {
-    setChartSeries([
-      data['total_counts']['raw'],
-      data['total_counts']['processed'],
-    ]);
-  };
-
   // pie chart 데이터 API fetch
   const { data, isLoading, isError } = usePieChartFetch(startDate, endDate);
   console.log('pie chart fetch 결과:', data);
+
+  // fetch한 JSON 데이터에서 필요한 값 parsing 및 chartSeries에 저장
+  // 렌더링 시 데이터 받지 못하면 -1, -1
+  const processPieData = (data) => {
+    if (
+      data &&
+      'total_counts' in data &&
+      'raw' in data.total_counts &&
+      'processed' in data.total_counts
+    ) {
+      const raw = data.total_counts.raw;
+      const processed = data.total_counts.processed;
+
+      setChartSeries([
+        !Number.isNaN(raw) ? raw : -1,
+        !Number.isNaN(processed) ? processed : -1,
+      ]);
+    } else {
+      console.log('Invalid data structure:', data);
+      setChartSeries([-1, -1]); // Default to [-1, -1] if data is invalid
+    }
+  };
 
   // fetch한 데이터 parsing 함수 호출
   useEffect(() => {
@@ -75,9 +89,29 @@ const PieChart = ({ subheader, chartColors, startDate, endDate, ...other }) => {
   // 토글 버튼 handle (전체, 소, 돼지)
   const handleBtnClick = (e) => {
     const value = e.target.value;
-    const chart_series = [data[value]['raw'], data[value]['processed']];
+    let newChartSeries = [-1, -1]; // 기본값으로 [-1, -1]을 설정
+
+    if (data && data !== null && data !== undefined && value in data) {
+      const categoryData = data[value];
+      if (
+        categoryData &&
+        'raw' in categoryData &&
+        'processed' in categoryData
+      ) {
+        const raw = categoryData.raw;
+        const processed = categoryData.processed;
+
+        newChartSeries = [
+          !Number.isNaN(raw) ? raw : -1,
+          !Number.isNaN(processed) ? processed : -1,
+        ];
+      }
+    } else {
+      console.log('Invalid data structure:', value);
+    }
+
     setLabel(value);
-    setChartSeries(chart_series);
+    setChartSeries(newChartSeries);
   };
 
   return (
@@ -114,7 +148,12 @@ const PieChart = ({ subheader, chartColors, startDate, endDate, ...other }) => {
       </Box>
 
       <StyledChartWrapper dir="ltr" style={{ marginTop: '20px' }}>
-        {chartSeries[0] === 0 && chartSeries[1] === 0 ? (
+        {chartSeries[0] === -1 && chartSeries[1] === -1 ? (
+          // 데이터 불러오기 실패한 경우
+          <div style={style.chartWrapperDiv}>
+            <span>데이터를 불러올 수 없습니다</span>
+          </div>
+        ) : chartSeries[0] === 0 && chartSeries[1] === 0 ? (
           // 데이터가 없는 경우
           <div style={style.chartWrapperDiv}>
             <span>데이터가 존재하지 않습니다</span>

--- a/test-web/src/components/Charts/StackedBarChart.js
+++ b/test-web/src/components/Charts/StackedBarChart.js
@@ -17,7 +17,7 @@ const StackedBarChart = ({ startDate, endDate }) => {
     theme.palette.success.light,
     theme.palette.primary.main,
 
-    '#01579B', // 짙은 남색
+    '#0322AB', // 짙은 남색
     '#6A1B9A', // 짙은 보라색
     '#C2185B', // 짙은 분홍색
     '#FF4081', // 진홍색
@@ -35,9 +35,16 @@ const StackedBarChart = ({ startDate, endDate }) => {
   const cattleCategories = ['채끝', '우둔', '설도', '양지', '사태'];
   const porkCategories = ['삼겹살', '뒷다리'];
 
+  // 누적 바 데이터 API fetch
+  const { data, isLoading, isError } = useStackedBarFetch(startDate, endDate);
+  console.log('stacked bar chart fetch 결과:', data);
+
   // fetch한 JSON 데이터에서 필요한 값 parsing 및 전처리하여 series에 저장
   const processStackedBarData = (data) => {
-    if (isLoading) {
+    if (
+      !data['beef_counts_by_primal_value'] ||
+      !data['pork_counts_by_primal_value']
+    ) {
       console.error('올바르지 않은 데이터 형식:', data);
       return;
     }
@@ -69,10 +76,6 @@ const StackedBarChart = ({ startDate, endDate }) => {
     // series에 저장
     setSeries(seriesArr);
   };
-
-  // 누적 바 데이터 API fetch
-  const { data, isLoading, isError } = useStackedBarFetch(startDate, endDate);
-  console.log('stacked bar chart fetch 결과:', data);
 
   // fetch한 데이터 parsing 함수 호출
   useEffect(() => {

--- a/test-web/src/components/Charts/StackedBarChart.js
+++ b/test-web/src/components/Charts/StackedBarChart.js
@@ -10,18 +10,23 @@ const StackedBarChart = ({ startDate, endDate }) => {
   const line = theme.palette.divider;
   // 누적 바 차트 부위 별 색
   const stackColors = [
-    theme.palette.success.light,
-    theme.palette.primary.main,
-    theme.palette.warning.main,
-    '#BB86FC',
-    theme.palette.error.main,
-    '#FF0266',
-    theme.palette.info.light,
-    theme.palette.warning.light,
-    theme.palette.secondary.main,
-    theme.palette.success.dark,
-    '#03DAC5',
-    theme.palette.error.light,
+    // 빨강, 주황, 노랑, 초록, 파랑
+    theme.palette.error.main, // 빨강 (theme.palette.error.main)
+    theme.palette.warning.main, // 주황 (theme.palette.warning.main)
+    theme.palette.warning.light, // 노랑 (theme.palette.warning.light)
+    theme.palette.success.light, // 초록 (theme.palette.success.light)
+    theme.palette.primary.main, // 파랑 (theme.palette.primary.main)
+
+    // 짙은 남색, 짙은 보라색, 짙은 분홍색, 진홍색
+    '#01579B', // 짙은 남색
+    '#6A1B9A', // 짙은 보라색
+    '#C2185B', // 짙은 분홍색
+    '#FF4081', // 진홍색
+
+    // 옅은 남색, 옅은 보라색, 옅은 분홍색
+    '#DBC0AF', // 옅은 남색
+    '#CE93D8', // 옅은 보라색
+    '#F48FB1', // 옅은 분홍색
   ];
 
   // API fetch 데이터 저장
@@ -29,8 +34,8 @@ const StackedBarChart = ({ startDate, endDate }) => {
 
   // 결합된 카테고리
   const combinedCategories = ['안심', '등심', '목심', '앞다리', '갈비'];
-  const cattleCategories = ['채끝', '우둔', '설도', '양지'];
-  const porkCategories = ['사태', '삼겹살', '뒷다리'];
+  const cattleCategories = ['채끝', '우둔', '설도', '양지', '사태'];
+  const porkCategories = ['삼겹살', '뒷다리'];
 
   // fetch한 JSON 데이터에서 필요한 값 parsing 및 전처리하여 series에 저장
   const processStackedBarData = (data) => {
@@ -185,10 +190,6 @@ const columnChartOptions = {
     title: {
       text: '개',
     },
-  },
-  legend: {
-    position: 'right',
-    offsetY: 40,
   },
   fill: {
     opacity: 1,

--- a/test-web/src/components/Charts/StackedBarChart.js
+++ b/test-web/src/components/Charts/StackedBarChart.js
@@ -11,19 +11,17 @@ const StackedBarChart = ({ startDate, endDate }) => {
   // 누적 바 차트 부위 별 색
   const stackColors = [
     // 빨강, 주황, 노랑, 초록, 파랑
-    theme.palette.error.main, // 빨강 (theme.palette.error.main)
-    theme.palette.warning.main, // 주황 (theme.palette.warning.main)
-    theme.palette.warning.light, // 노랑 (theme.palette.warning.light)
-    theme.palette.success.light, // 초록 (theme.palette.success.light)
-    theme.palette.primary.main, // 파랑 (theme.palette.primary.main)
+    theme.palette.error.main,
+    theme.palette.warning.main,
+    theme.palette.warning.light,
+    theme.palette.success.light,
+    theme.palette.primary.main,
 
-    // 짙은 남색, 짙은 보라색, 짙은 분홍색, 진홍색
     '#01579B', // 짙은 남색
     '#6A1B9A', // 짙은 보라색
     '#C2185B', // 짙은 분홍색
     '#FF4081', // 진홍색
 
-    // 옅은 남색, 옅은 보라색, 옅은 분홍색
     '#DBC0AF', // 옅은 남색
     '#CE93D8', // 옅은 보라색
     '#F48FB1', // 옅은 분홍색

--- a/test-web/src/components/Charts/choroplethMap/ChoroplethMap.js
+++ b/test-web/src/components/Charts/choroplethMap/ChoroplethMap.js
@@ -40,8 +40,20 @@ const ChoroplethMap = ({ mapData, startDate, endDate }) => {
     setGeoJSONData(updatedGeoJSON);
   };
 
+  // 지역 별 개수 데이터 API fetch
+  const { data, isLoading, isError } = useMapFetch(startDate, endDate);
+  console.log('map fetch 결과:', data);
+
   // fetch한 JSON 데이터 전처리
   const processMapData = (data) => {
+    if (
+      !data['cattle_counts_by_region'] ||
+      !data['pig_counts_by_region'] ||
+      !data['total_counts_by_region']
+    ) {
+      console.error('올바르지 않은 데이터 형식:', data);
+      return;
+    }
     // fetch한 JSON 데이터 parsing
     const cattleCnt = data['cattle_counts_by_region'];
     const porkCnt = data['pig_counts_by_region'];
@@ -50,10 +62,6 @@ const ChoroplethMap = ({ mapData, startDate, endDate }) => {
     addProperties(cattleCnt, porkCnt, totalCnt);
     setKeyIdx((prev) => prev + 1);
   };
-
-  // 지역 별 개수 데이터 API fetch
-  const { data, isLoading, isError } = useMapFetch(startDate, endDate);
-  console.log('map fetch 결과:', data);
 
   // fetch한 JSON 데이터 전처리 함수 call
   useEffect(() => {
@@ -147,7 +155,7 @@ const ChoroplethMap = ({ mapData, startDate, endDate }) => {
       center={[35.8754, 128.5823]} //center: 지도의 initial center를 설정 center={['위도', '경도']}.
       style={{ height: '350px' }} //style: map container의 높이를 설정
       zoom={6} //zoom: initial zoom level을 설정
-      scrollWheelZoom={false} //scrollWheelZoom: 스크롤 wheel로 zooming 하는 것을 막기
+      scrollWheelZoom={true} //scrollWheelZoom: 스크롤 wheel로 zooming 하는 것을 막지 않기
     >
       {/*Add a TileLayer component to display the map tiles. */}
       <TileLayer

--- a/test-web/src/components/User/UserList.js
+++ b/test-web/src/components/User/UserList.js
@@ -107,7 +107,7 @@ function UserList() {
     { field: 'userId', headerName: '아이디', width: 250 },
     {
       field: 'type',
-      headerName: '소속',
+      headerName: '권한',
       width: 200,
       renderCell: (params) => (
         <CustomEditCell


### PR DESCRIPTION
1 대시보드 내 통계 탭에서, 데이터 값이 올바르게 들어오지 않을 시 서버 터지는 오류 수정. 주로 파이차트 토글 시 및 렌더링 시 발생, 파이 그래프 UI 일부 수정. 윈도우 기준 가운데 글자 total 살짝 위로.
2 스택바 차트 색상 일부 변경.