### PR TITLE
feat : meat_registraion UI edit

### DIFF
--- a/app/structure/lib/components/custom_dialog.dart
+++ b/app/structure/lib/components/custom_dialog.dart
@@ -252,7 +252,7 @@ void showSaveImageDialog(BuildContext context, String imgPath,
         shape: RoundedRectangleBorder(
             borderRadius: BorderRadius.all(Radius.circular(20.r))),
         child: SizedBox(
-          height: 790.h,
+          height: 850.h,
           width: 650.w,
           child: Center(
             child: Column(
@@ -270,7 +270,7 @@ void showSaveImageDialog(BuildContext context, String imgPath,
                 ClipRRect(
                   borderRadius: BorderRadius.circular(20.r),
                   child: Image.file(File(imgPath),
-                      width: 570.w, height: 410.h, fit: BoxFit.fitWidth),
+                      width: 570.w, height: 570.w, fit: BoxFit.fitWidth),
                 ),
                 SizedBox(height: 55.h),
 

--- a/app/structure/lib/components/step_card.dart
+++ b/app/structure/lib/components/step_card.dart
@@ -20,10 +20,12 @@ class StepCard extends StatelessWidget {
   final String mainText;
   // 0 - 미진행, 1 - 완료, 2 - 미완료, 3 - 수정 가능, 4 - 수정 불가
   final int? status;
+  final Function onTap;
   final String imageUrl;
   const StepCard({
     super.key,
     required this.mainText,
+    required this.onTap,
     this.status,
     required this.imageUrl,
   });
@@ -53,45 +55,53 @@ class StepCard extends StatelessWidget {
     ];
 
     return Container(
-      padding: EdgeInsets.symmetric(horizontal: 5.w, vertical: 10.h),
-      width: 588.w,
-      height: 109.h,
-      decoration: const BoxDecoration(
-        border: null,
-      ),
-      child: Row(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: [
-          // 이미지 지정
-          Image.asset(imageUrl, width: 62.w, height: 62.h),
-          SizedBox(width: 35.w),
+        // padding: EdgeInsets.all(20.w),
+        padding: EdgeInsets.symmetric(
+          horizontal: 20.w,
+        ),
+        margin: EdgeInsets.symmetric(horizontal: 20.w),
+        // width: 588.w,
+        height: 109.h,
+        decoration: const BoxDecoration(
+          border: null,
+        ),
+        child: InkWell(
+          borderRadius: BorderRadius.circular(20.r),
+          onTap: () => onTap(),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              // 이미지 지정
+              Image.asset(imageUrl, width: 62.w, height: 62.h),
+              SizedBox(width: 35.w),
 
-          // 메인 텍스트
-          Text(mainText, style: Palette.h4),
-          const Spacer(),
+              // 메인 텍스트
+              Text(mainText, style: Palette.h4),
+              const Spacer(),
 
-          // status 상자 - null이면 표시하지 않음
-          if (status != null)
-            Container(
-              decoration: BoxDecoration(
-                borderRadius: BorderRadius.circular(10.sp),
-                color: statusColor[status!],
-              ),
-              width: 108.w,
-              height: 48.h,
-              child: Center(
-                child: Text(
-                  statusString[status!],
-                  style: statusTextStyle[status!],
+              // status 상자 - null이면 표시하지 않음
+              if (status != null)
+                Container(
+                  decoration: BoxDecoration(
+                    borderRadius: BorderRadius.circular(10.sp),
+                    color: statusColor[status!],
+                  ),
+                  width: 108.w,
+                  height: 48.h,
+                  child: Center(
+                    child: Text(
+                      statusString[status!],
+                      style: statusTextStyle[status!],
+                    ),
+                  ),
                 ),
-              ),
-            ),
-          SizedBox(width: 20.w),
+              SizedBox(width: 20.w),
 
-          // 오른쪽 화살표
-          Image.asset('assets/images/arrow-r.png', width: 33.w, height: 33.h),
-        ],
-      ),
-    );
+              // 오른쪽 화살표
+              Image.asset('assets/images/arrow-r.png',
+                  width: 33.w, height: 33.h),
+            ],
+          ),
+        ));
   }
 }

--- a/app/structure/lib/screen/data_management/normal/edit_meat_data_screen.dart
+++ b/app/structure/lib/screen/data_management/normal/edit_meat_data_screen.dart
@@ -29,51 +29,47 @@ class EditMeatDataScreen extends StatelessWidget {
             SizedBox(height: 48.h),
 
             // 육류 기본 정보
-            InkWell(
+            StepCard(
+              mainText: '육류 기본정보',
+              status: context.read<EditMeatDataViewModel>().isNormal
+                  ? context.read<EditMeatDataViewModel>().isEditable
+                      ? 3 // 수정 가능
+                      : 4 // 수정 불가
+                  : null, // 없음
+
               onTap: () =>
                   context.read<EditMeatDataViewModel>().clicekdBasic(context),
-              child: StepCard(
-                mainText: '육류 기본정보',
-                status: context.read<EditMeatDataViewModel>().isNormal
-                    ? context.read<EditMeatDataViewModel>().isEditable
-                        ? 3 // 수정 가능
-                        : 4 // 수정 불가
-                    : null, // 없음
-                imageUrl: 'assets/images/meat_info.png',
-              ),
+              imageUrl: 'assets/images/meat_info.png',
             ),
             SizedBox(height: 18.h),
 
             // 육류 단면 촬영
-            InkWell(
+            StepCard(
+              mainText: '육류 단면 촬영',
+              status: context.read<EditMeatDataViewModel>().isNormal
+                  ? context.read<EditMeatDataViewModel>().isEditable
+                      ? 3 // 수정 가능
+                      : 4 // 수정 불가
+                  : null, // 없음
               onTap: () =>
                   context.read<EditMeatDataViewModel>().clickedImage(context),
-              child: StepCard(
-                mainText: '육류 단면 촬영',
-                status: context.read<EditMeatDataViewModel>().isNormal
-                    ? context.read<EditMeatDataViewModel>().isEditable
-                        ? 3 // 수정 가능
-                        : 4 // 수정 불가
-                    : null, // 없음
-                // isEditable: context.read<EditMeatDataViewModel>().isEditable,
-                imageUrl: 'assets/images/meat_image.png',
-              ),
+              // isEditable: context.read<EditMeatDataViewModel>().isEditable,
+              imageUrl: 'assets/images/meat_image.png',
             ),
+
             SizedBox(height: 18.h),
 
             // 신선육 관능 평가
-            InkWell(
+            StepCard(
+              mainText: '원육 관능평가',
+              status: context.read<EditMeatDataViewModel>().isNormal
+                  ? context.read<EditMeatDataViewModel>().isEditable
+                      ? 3 // 수정 가능
+                      : 4 // 수정 불가
+                  : null, // 없음
               onTap: () =>
                   context.read<EditMeatDataViewModel>().clicekdFresh(context),
-              child: StepCard(
-                mainText: '신선육 관능평가',
-                status: context.read<EditMeatDataViewModel>().isNormal
-                    ? context.read<EditMeatDataViewModel>().isEditable
-                        ? 3 // 수정 가능
-                        : 4 // 수정 불가
-                    : null, // 없음
-                imageUrl: 'assets/images/meat_eval.png',
-              ),
+              imageUrl: 'assets/images/meat_eval.png',
             ),
 
             const Spacer(),

--- a/app/structure/lib/screen/data_management/researcher/add_processed_meat_main_screen.dart
+++ b/app/structure/lib/screen/data_management/researcher/add_processed_meat_main_screen.dart
@@ -43,54 +43,49 @@ class _AddProcessedMeatMainScreenState
             SizedBox(height: 40.h),
 
             // 처리육 단면 촬영
-            InkWell(
+            StepCard(
+              mainText: '처리육 단면 촬영',
+              status: widget.meatModel.deepAgedImageCompleted ? 1 : 2,
               onTap: () => context
                   .read<AddProcessedMeatViewModel>()
                   .clickedImage(context),
-              child: StepCard(
-                mainText: '처리육 단면 촬영',
-                status: widget.meatModel.deepAgedImageCompleted ? 1 : 2,
-                imageUrl: 'assets/images/meat_image.png',
-              ),
+              imageUrl: 'assets/images/meat_image.png',
             ),
+
             SizedBox(height: 18.h),
 
             // 처리육 관능평가
-            InkWell(
+            StepCard(
+              mainText: '처리육 관능평가',
+              status: widget.meatModel.deepAgedFreshCompleted ? 1 : 2,
               onTap: () => context
                   .read<AddProcessedMeatViewModel>()
                   .clickedEval(context),
-              child: StepCard(
-                mainText: '처리육 관능평가',
-                status: widget.meatModel.deepAgedFreshCompleted ? 1 : 2,
-                imageUrl: 'assets/images/meat_eval.png',
-              ),
+              imageUrl: 'assets/images/meat_eval.png',
             ),
             SizedBox(height: 18.h),
 
             // 처리육 전자혀
-            InkWell(
+            StepCard(
+              mainText: '처리육 전자혀 데이터',
+              status: widget.meatModel.tongueCompleted ? 1 : 2,
               onTap: () => context
                   .read<AddProcessedMeatViewModel>()
                   .clickedTongue(context),
-              child: StepCard(
-                mainText: '처리육 전자혀 데이터',
-                status: widget.meatModel.tongueCompleted ? 1 : 2,
-                imageUrl: 'assets/images/meat_tongue.png',
-              ),
+              imageUrl: 'assets/images/meat_tongue.png',
             ),
+
             SizedBox(height: 18.h),
 
             // 처리육 실험
-            InkWell(
+            StepCard(
+              mainText: '처리육 실험 데이터',
+              status: widget.meatModel.labCompleted ? 1 : 2,
               onTap: () =>
                   context.read<AddProcessedMeatViewModel>().clickedLab(context),
-              child: StepCard(
-                mainText: '처리육 실험 데이터',
-                status: widget.meatModel.labCompleted ? 1 : 2,
-                imageUrl: 'assets/images/meat_lab.png',
-              ),
+              imageUrl: 'assets/images/meat_lab.png',
             ),
+
             SizedBox(height: 18.h),
 
             // Divdier
@@ -103,54 +98,50 @@ class _AddProcessedMeatMainScreenState
             ),
 
             // 가열육 단면 촬영
-            InkWell(
+            StepCard(
+              mainText: '가열육 단면 촬영',
+              status: widget.meatModel.deepAgedImageCompleted ? 1 : 2,
               onTap: () => context
                   .read<AddProcessedMeatViewModel>()
                   .clickedImage(context),
-              child: StepCard(
-                mainText: '가열육 단면 촬영',
-                status: widget.meatModel.deepAgedImageCompleted ? 1 : 2,
-                imageUrl: 'assets/images/meat_image.png',
-              ),
+              imageUrl: 'assets/images/meat_image.png',
             ),
+
             SizedBox(height: 18.h),
 
             // 가열육 관능 평가
-            InkWell(
+            StepCard(
+              mainText: '가열육 관능평가',
+              status: widget.meatModel.heatedCompleted ? 1 : 2,
               onTap: () => context
                   .read<AddProcessedMeatViewModel>()
                   .clickedHeatedEval(context),
-              child: StepCard(
-                mainText: '가열육 관능평가',
-                status: widget.meatModel.heatedCompleted ? 1 : 2,
-                imageUrl: 'assets/images/meat_eval.png',
-              ),
+              imageUrl: 'assets/images/meat_eval.png',
             ),
+
             SizedBox(height: 18.h),
 
             // 가열육 전자혀
-            InkWell(
+            StepCard(
+              mainText: '가열육 전자혀 데이터',
+              status: widget.meatModel.tongueCompleted ? 1 : 2,
               onTap: () => context
                   .read<AddProcessedMeatViewModel>()
                   .clickedTongue(context),
-              child: StepCard(
-                mainText: '가열육 전자혀 데이터',
-                status: widget.meatModel.tongueCompleted ? 1 : 2,
-                imageUrl: 'assets/images/meat_tongue.png',
-              ),
+              imageUrl: 'assets/images/meat_tongue.png',
             ),
+
             SizedBox(height: 18.h),
 
             // 가열육 실험 데이터
-            InkWell(
+            StepCard(
+              mainText: '가열육 실험 데이터',
+              status: widget.meatModel.labCompleted ? 1 : 2,
               onTap: () =>
                   context.read<AddProcessedMeatViewModel>().clickedLab(context),
-              child: StepCard(
-                mainText: '가열육 실험 데이터',
-                status: widget.meatModel.labCompleted ? 1 : 2,
-                imageUrl: 'assets/images/meat_lab.png',
-              ),
+              imageUrl: 'assets/images/meat_lab.png',
             ),
+
             SizedBox(height: 40.h),
 
             Container(

--- a/app/structure/lib/screen/data_management/researcher/add_raw_meat_main_screen.dart
+++ b/app/structure/lib/screen/data_management/researcher/add_raw_meat_main_screen.dart
@@ -32,70 +32,64 @@ class StepFreshMeat extends StatelessWidget {
             Column(
               children: [
                 // 육류 기본 정보
-                InkWell(
+                StepCard(
                   onTap: () =>
                       context.read<AddRawMeatViewModel>().clicekdBasic(context),
-                  child: const StepCard(
-                    mainText: '육류 기본정보',
-                    status: 4, // 없음
-                    imageUrl: 'assets/images/meat_info.png',
-                  ),
+                  mainText: '육류 기본정보',
+                  status: 4, // 없음
+                  imageUrl: 'assets/images/meat_info.png',
                 ),
+
                 SizedBox(height: 10.h),
 
                 // 육류 단면 촬영
-                InkWell(
+
+                StepCard(
+                  mainText: '육류 단면 촬영',
+                  status: 4, // 없음
                   onTap: () => context
                       .read<AddRawMeatViewModel>()
                       .clickedBasicImage(context),
-                  child: const StepCard(
-                    mainText: '육류 단면 촬영',
-                    status: 4, // 없음
-                    // isEditable: context.read<EditMeatDataViewModel>().isEditable,
-                    imageUrl: 'assets/images/meat_image.png',
-                  ),
+                  // isEditable: context.read<EditMeatDataViewModel>().isEditable,
+                  imageUrl: 'assets/images/meat_image.png',
                 ),
                 SizedBox(height: 10.h),
 
                 // 신선육 관능 평가
-                InkWell(
+                StepCard(
+                  mainText: '신선육 관능평가',
+                  status: 4, // 없음
                   onTap: () =>
                       context.read<AddRawMeatViewModel>().clicekdFresh(context),
-                  child: const StepCard(
-                    mainText: '신선육 관능평가',
-                    status: 4, // 없음
-                    imageUrl: 'assets/images/meat_eval.png',
-                  ),
+                  imageUrl: 'assets/images/meat_eval.png',
                 ),
+
                 SizedBox(
                   height: 10.h,
                 ),
-                InkWell(
+                StepCard(
+                  mainText: '원육 전자혀 데이터',
+                  status: meatModel.tongueCompleted ? 1 : 2,
                   onTap: () => context
                       .read<AddRawMeatViewModel>()
                       .clickedTongue(context),
-                  child: StepCard(
-                    mainText: '원육 전자혀 데이터',
-                    status: meatModel.tongueCompleted ? 1 : 2,
-                    // isCompleted: meatModel.tongueCompleted,
-                    // isBefore: false,
-                    imageUrl: 'assets/images/meat_tongue.png',
-                  ),
+                  // isCompleted: meatModel.tongueCompleted,
+                  // isBefore: false,
+                  imageUrl: 'assets/images/meat_tongue.png',
                 ),
                 SizedBox(
                   height: 10.h,
                 ),
-                InkWell(
+                StepCard(
+                  mainText: '원육 실험 데이터',
+                  status: meatModel.labCompleted ? 1 : 2,
                   onTap: () =>
                       context.read<AddRawMeatViewModel>().clickedLab(context),
-                  child: StepCard(
-                    mainText: '원육 실험 데이터',
-                    status: meatModel.labCompleted ? 1 : 2,
-                    // isCompleted: meatModel.labCompleted,
-                    // isBefore: false,
-                    imageUrl: 'assets/images/meat_lab.png',
-                  ),
+                  // isCompleted: meatModel.labCompleted,
+                  // isBefore: false,
+                  imageUrl: 'assets/images/meat_lab.png',
                 ),
+
                 SizedBox(
                   height: 10.h,
                 ),
@@ -106,57 +100,50 @@ class StepFreshMeat extends StatelessWidget {
                     thickness: 1,
                   ),
                 ),
-                InkWell(
+                StepCard(
+                  mainText: '가열육 단면 촬영',
+                  //가열육 단면촬영 체크하는 변수 meatModel의 변수 추가하고 변경
+                  status: meatModel.deepAgedImageCompleted ? 1 : 2,
                   onTap: () =>
                       context.read<AddRawMeatViewModel>().clickedImage(context),
-                  child: StepCard(
-                    mainText: '가열육 단면 촬영',
-                    //가열육 단면촬영 체크하는 변수 meatModel의 변수 추가하고 변경
-                    status: meatModel.deepAgedImageCompleted ? 1 : 2,
-                    // isCompleted: meatModel.deepAgedImageCompleted,
-                    // isBefore: false,
-                    imageUrl: 'assets/images/meat_image.png',
-                  ),
+                  // isCompleted: meatModel.deepAgedImageCompleted,
+                  // isBefore: false,
+                  imageUrl: 'assets/images/meat_image.png',
                 ),
-                InkWell(
+                StepCard(
+                  mainText: '가열육 관능평가',
+                  status: meatModel.heatedCompleted ? 1 : 2,
                   onTap: () => context
                       .read<AddRawMeatViewModel>()
                       .clickedHeated(context),
-                  child: StepCard(
-                    mainText: '가열육 관능평가',
-                    status: meatModel.heatedCompleted ? 1 : 2,
-                    // isCompleted: meatModel.heatedCompleted,
-                    // isBefore: false,
-                    imageUrl: 'assets/images/meat_eval.png',
-                  ),
+                  // isCompleted: meatModel.heatedCompleted,
+                  // isBefore: false,
+                  imageUrl: 'assets/images/meat_eval.png',
                 ),
                 SizedBox(
                   height: 10.h,
                 ),
-                InkWell(
+                StepCard(
+                  mainText: '가열육 전자혀 데이터',
+                  status: meatModel.tongueCompleted ? 1 : 2,
                   onTap: () => context
                       .read<AddRawMeatViewModel>()
                       .clickedTongue(context),
-                  child: StepCard(
-                    mainText: '가열육 전자혀 데이터',
-                    status: meatModel.tongueCompleted ? 1 : 2,
-                    // isCompleted: meatModel.tongueCompleted,
-                    // isBefore: false,
-                    imageUrl: 'assets/images/meat_tongue.png',
-                  ),
+                  // isCompleted: meatModel.tongueCompleted,
+                  // isBefore: false,
+                  imageUrl: 'assets/images/meat_tongue.png',
                 ),
                 SizedBox(
                   height: 10.h,
                 ),
-                InkWell(
+                StepCard(
+                  mainText: '가열육 실험 데이터',
+                  status: meatModel.labCompleted ? 1 : 2,
                   onTap: () =>
                       context.read<AddRawMeatViewModel>().clickedLab(context),
-                  child: StepCard(
-                    mainText: '가열육 실험 데이터',
-                    status: meatModel.labCompleted ? 1 : 2,
-                    imageUrl: 'assets/images/meat_lab.png',
-                  ),
+                  imageUrl: 'assets/images/meat_lab.png',
                 ),
+
                 Container(
                   margin: EdgeInsets.only(bottom: 20.h),
                   child: MainButton(

--- a/app/structure/lib/screen/meat_registration/freshmeat_eval_screen.dart
+++ b/app/structure/lib/screen/meat_registration/freshmeat_eval_screen.dart
@@ -61,46 +61,54 @@ class _FreshMeatEvalScreenState extends State<FreshMeatEvalScreen>
                 crossAxisAlignment: CrossAxisAlignment.center,
                 children: [
                   SizedBox(height: 40.h),
-                  SizedBox(
-                    width: 640.w,
-                    height: 475.h,
-                    // 관능평가를 위한 이미지 할당.
-                    child: context
-                            .read<FreshMeatEvalViewModel>()
-                            .meatImage
-                            .contains('http')
-                        ? Image.network(
-                            context.read<FreshMeatEvalViewModel>().meatImage,
-                            loadingBuilder: (BuildContext context, Widget child,
-                                ImageChunkEvent? loadingProgress) {
-                              if (loadingProgress == null) {
-                                return child;
-                              } else {
-                                return LoadingScreen(
-                                  value: loadingProgress.expectedTotalBytes !=
-                                          null
-                                      ? loadingProgress.cumulativeBytesLoaded /
-                                          (loadingProgress.expectedTotalBytes ??
-                                              1)
-                                      : null,
-                                );
-                              }
-                            },
-                            // 에러 정의
-                            errorBuilder: (BuildContext context, Object error,
-                                StackTrace? stackTrace) {
-                              return const Icon(Icons.error);
-                            },
-                            fit: BoxFit.cover,
-                          )
-                        : Image.file(
-                            File(context
+                  ClipRRect(
+                      borderRadius: BorderRadius.circular(20.0),
+                      child: SizedBox(
+                        width: 640.w,
+                        height: 640.w,
+                        // 관능평가를 위한 이미지 할당.
+                        child: context
                                 .read<FreshMeatEvalViewModel>()
-                                .meatImage),
-                            fit: BoxFit.cover,
-                          ),
-                  ),
-                  SizedBox(height: 60.h),
+                                .meatImage
+                                .contains('http')
+                            ? Image.network(
+                                context
+                                    .read<FreshMeatEvalViewModel>()
+                                    .meatImage,
+                                loadingBuilder: (BuildContext context,
+                                    Widget child,
+                                    ImageChunkEvent? loadingProgress) {
+                                  if (loadingProgress == null) {
+                                    return child;
+                                  } else {
+                                    return LoadingScreen(
+                                      value:
+                                          loadingProgress.expectedTotalBytes !=
+                                                  null
+                                              ? loadingProgress
+                                                      .cumulativeBytesLoaded /
+                                                  (loadingProgress
+                                                          .expectedTotalBytes ??
+                                                      1)
+                                              : null,
+                                    );
+                                  }
+                                },
+                                // 에러 정의
+                                errorBuilder: (BuildContext context,
+                                    Object error, StackTrace? stackTrace) {
+                                  return const Icon(Icons.error);
+                                },
+                                fit: BoxFit.cover,
+                              )
+                            : Image.file(
+                                File(context
+                                    .read<FreshMeatEvalViewModel>()
+                                    .meatImage),
+                                fit: BoxFit.cover,
+                              ),
+                      )),
+                  // SizedBox(height: 60.h),
 
                   // 관능평가 데이터가 입력 되었는지 체크.
                   Row(

--- a/app/structure/lib/screen/meat_registration/meat_registration_screen.dart
+++ b/app/structure/lib/screen/meat_registration/meat_registration_screen.dart
@@ -52,41 +52,38 @@ class _MeatRegistrationScreenState extends State<MeatRegistrationScreen> {
                   SizedBox(height: 55.h),
 
                   // STEP 1 : 육류 기본정보 등록
-                  InkWell(
+                  //       onTap: () => context
+                  // .read<MeatRegistrationViewModel>()
+                  // .clickedBasic(context),
+                  StepCard(
+                    mainText: '육류 기본정보',
+                    status: widget.meatModel.basicCompleted ? 1 : 2,
                     onTap: () => context
                         .read<MeatRegistrationViewModel>()
                         .clickedBasic(context),
-                    child: StepCard(
-                      mainText: '육류 기본정보',
-                      status: widget.meatModel.basicCompleted ? 1 : 2,
-                      // isCompleted: widget.meatModel.basicCompleted,
-                      // isBefore: false,
-                      imageUrl: 'assets/images/meat_info.png',
-                    ),
+                    imageUrl: 'assets/images/meat_info.png',
                   ),
-                  SizedBox(height: 4.h),
-                  Padding(
-                    padding: EdgeInsets.symmetric(horizontal: 40.w),
+
+                  Container(
+                    margin: EdgeInsets.symmetric(horizontal: 40.w),
                     child: const Divider(
                       thickness: 1,
                     ),
                   ),
-                  SizedBox(height: 4.h),
 
                   // STEP 2 : 육류 단면 촬영
-                  InkWell(
-                      onTap: () => widget.meatModel.basicCompleted
-                          ? context
-                              .read<MeatRegistrationViewModel>()
-                              .clickedImage(context)
-                          : null,
-                      child: StepCard(
-                        mainText: '육류 단면 촬영',
-                        status: widget.meatModel.freshImageCompleted ? 1 : 2,
-                        // isCompleted: widget.meatModel.freshImageCompleted,
-                        // isBefore: false,
-                        imageUrl: 'assets/images/meat_image.png',
-                      )),
+                  StepCard(
+                    mainText: '육류 단면 촬영',
+                    status: widget.meatModel.freshImageCompleted ? 1 : 2,
+                    onTap: () => widget.meatModel.basicCompleted
+                        ? context
+                            .read<MeatRegistrationViewModel>()
+                            .clickedImage(context)
+                        : null,
+                    // isCompleted: widget.meatModel.freshImageCompleted,
+                    // isBefore: false,
+                    imageUrl: 'assets/images/meat_image.png',
+                  ),
                   SizedBox(height: 4.h),
                   Padding(
                     padding: EdgeInsets.symmetric(horizontal: 40.w),
@@ -97,19 +94,18 @@ class _MeatRegistrationScreenState extends State<MeatRegistrationScreen> {
                   SizedBox(height: 4.h),
 
                   // STEP 3 : 신선육 관능평가
-                  InkWell(
-                      onTap: () => widget.meatModel.freshImageCompleted
-                          ? context
-                              .read<MeatRegistrationViewModel>()
-                              .clickedFreshmeat(context)
-                          : null,
-                      child: StepCard(
-                        mainText: '신선육 관능평가',
-                        status: widget.meatModel.rawFreshCompleted ? 1 : 2,
-                        // isCompleted: widget.meatModel.rawFreshCompleted,
-                        // isBefore: false,
-                        imageUrl: 'assets/images/meat_eval.png',
-                      )),
+                  StepCard(
+                    mainText: '신선육 관능평가',
+                    status: widget.meatModel.rawFreshCompleted ? 1 : 2,
+                    onTap: () => widget.meatModel.freshImageCompleted
+                        ? context
+                            .read<MeatRegistrationViewModel>()
+                            .clickedFreshmeat(context)
+                        : null,
+                    // isCompleted: widget.meatModel.rawFreshCompleted,
+                    // isBefore: false,
+                    imageUrl: 'assets/images/meat_eval.png',
+                  ),
                   SizedBox(height: 116.h),
 
                   // 하단 완료 버튼

--- a/app/structure/lib/screen/meat_registration/registration_meat_image_screen.dart
+++ b/app/structure/lib/screen/meat_registration/registration_meat_image_screen.dart
@@ -111,62 +111,65 @@ class RegistrationMeatImageScreen extends StatelessWidget {
                       ? Stack(
                           // 삭제 버튼을 이미지 위에 띄우기 위한 'stack' 위젯 사용
                           children: [
-                            SizedBox(
-                              width: 640.w,
-                              height: 653.h,
+                            ClipRRect(
+                                borderRadius: BorderRadius.circular(20.0),
+                                child: SizedBox(
+                                  width: 640.w,
+                                  height: 640.w,
 
-                              // 이미지 할당
-                              child: context
+                                  // 이미지 할당
+                                  child: context
+                                                  .watch<
+                                                      RegistrationMeatImageViewModel>()
+                                                  .imagePath !=
+                                              null &&
+                                          context
                                               .watch<
                                                   RegistrationMeatImageViewModel>()
-                                              .imagePath !=
-                                          null &&
-                                      context
-                                          .watch<
-                                              RegistrationMeatImageViewModel>()
-                                          .imagePath!
-                                          .contains('http')
-                                  // s3에 업로드 된 이미지 (수정)
-                                  ? Image.network(
-                                      context
-                                          .read<
-                                              RegistrationMeatImageViewModel>()
-                                          .imagePath!,
-                                      loadingBuilder: (BuildContext context,
-                                          Widget child,
-                                          ImageChunkEvent? loadingProgress) {
-                                        if (loadingProgress == null) {
-                                          return child;
-                                        } else {
-                                          return LoadingScreen(
-                                            value: loadingProgress
-                                                        .expectedTotalBytes !=
-                                                    null
-                                                ? loadingProgress
-                                                        .cumulativeBytesLoaded /
-                                                    (loadingProgress
-                                                            .expectedTotalBytes ??
-                                                        1)
-                                                : null,
-                                          );
-                                        }
-                                      },
-                                      errorBuilder: (BuildContext context,
-                                          Object error,
-                                          StackTrace? stackTrace) {
-                                        return const Icon(Icons.error);
-                                      },
-                                      fit: BoxFit.cover,
-                                    )
-                                  // 이미지 촬영 중 임시저장 된 사진
-                                  : Image.file(
-                                      File(context
-                                          .read<
-                                              RegistrationMeatImageViewModel>()
-                                          .imagePath!),
-                                      fit: BoxFit.cover,
-                                    ),
-                            ),
+                                              .imagePath!
+                                              .contains('http')
+                                      // s3에 업로드 된 이미지 (수정)
+                                      ? Image.network(
+                                          context
+                                              .read<
+                                                  RegistrationMeatImageViewModel>()
+                                              .imagePath!,
+                                          loadingBuilder: (BuildContext context,
+                                              Widget child,
+                                              ImageChunkEvent?
+                                                  loadingProgress) {
+                                            if (loadingProgress == null) {
+                                              return child;
+                                            } else {
+                                              return LoadingScreen(
+                                                value: loadingProgress
+                                                            .expectedTotalBytes !=
+                                                        null
+                                                    ? loadingProgress
+                                                            .cumulativeBytesLoaded /
+                                                        (loadingProgress
+                                                                .expectedTotalBytes ??
+                                                            1)
+                                                    : null,
+                                              );
+                                            }
+                                          },
+                                          errorBuilder: (BuildContext context,
+                                              Object error,
+                                              StackTrace? stackTrace) {
+                                            return const Icon(Icons.error);
+                                          },
+                                          fit: BoxFit.cover,
+                                        )
+                                      // 이미지 촬영 중 임시저장 된 사진
+                                      : Image.file(
+                                          File(context
+                                              .read<
+                                                  RegistrationMeatImageViewModel>()
+                                              .imagePath!),
+                                          fit: BoxFit.cover,
+                                        ),
+                                )),
 
                             // 삭제 버튼
                             Positioned(


### PR DESCRIPTION
- 단면촬영 사진 1:1 비율
- 단면 촬영 사진 저장 1:1 비율
- 신선육(원육) 관능평가 사진 1:1 비율
- 단면 촬영 사진 edge round 처리
- 원육 사진 edge round 처리
<img width="281" alt="스크린샷 2024-07-15 오후 2 40 37" src="https://github.com/user-attachments/assets/0081bf08-7ada-47a3-823a-46595aed7c9e">

- 육류 등록 버튼 inkwell round 처리
- step card 수정 후 stepcard가 사용된 모든 파일 수정.
<img width="294" alt="스크린샷 2024-07-15 오후 2 37 28" src="https://github.com/user-attachments/assets/1e58956f-6388-4535-bb37-d1819a0bece3">


- 데이터 관리 화면(Home) 신선육 관능평가 → 원육 관능평가로 텍스트 대체
- 신선육 관능평가 화면 title : ‘원육 관능평가’로 바꾸기