### PR TITLE
fix: 승인 상태별 육류 데이터 조회 및 육류 부위 정보 조회 API 수정

### DIFF
--- a/test-backend/test-flask/api/get_api.py
+++ b/test-backend/test-flask/api/get_api.py
@@ -286,11 +286,11 @@ def getMeatDataByRangeStatusType():
         end_str = request.args.get("end")
         specie_value = request.args.get("specieValue")
 
-        # start = convert2datetime(start_str, 0)
-        # end = convert2datetime(end_str, 0)
+        start = convert2datetime(start_str, 0)
+        end = convert2datetime(end_str, 0)
         if status_type and specie_value:
             return _getMeatDataByRangeStatusType(
-                db_session, status_type, offset, count, specie_value, start_str, end_str
+                db_session, status_type, offset, count, specie_value, start, end
             )
         else:
             return jsonify("No statusType or specieValue in parameter"), 400
@@ -331,7 +331,7 @@ def getTexanomyData():
         db_session = current_app.db_session
         return _getTexanomyData(db_session)
     except Exception as e:
-        logger.exception(str(e))
+        # logger.exception(str(e))
         return (
             jsonify(
                 {"msg": "Server Error", "time": datetime.now().strftime("%H:%M:%S")}

--- a/test-backend/test-flask/api/get_api.py
+++ b/test-backend/test-flask/api/get_api.py
@@ -284,15 +284,16 @@ def getMeatDataByRangeStatusType():
         count = request.args.get("count")
         start_str = request.args.get("start")
         end_str = request.args.get("end")
+        specie_value = request.args.get("specieValue")
 
-        start = convert2datetime(start_str, 0)
-        end = convert2datetime(end_str, 0)
-        if status_type:
+        # start = convert2datetime(start_str, 0)
+        # end = convert2datetime(end_str, 0)
+        if status_type and specie_value:
             return _getMeatDataByRangeStatusType(
-                db_session, status_type, offset, count, start, end
+                db_session, status_type, offset, count, specie_value, start_str, end_str
             )
         else:
-            return jsonify("No statusType in parameter"), 400
+            return jsonify("No statusType or specieValue in parameter"), 400
     except Exception as e:
         # logger.exception(str(e))
         return (
@@ -324,22 +325,18 @@ def getMeatDataByTotalStatusType():
 
 
 # Texanomy 하드코딩 기본 데이터 출력
-@get_api.route("/default-data", methods=["GET", "POST"])
+@get_api.route("/default-data", methods=["GET"])
 def getTexanomyData():
     try:
-        if request.method == "GET":
-            db_session = current_app.db_session
-            return _getTexanomyData(db_session)
-
-        else:
-            return jsonify({"msg": "Invalid Route, Please Try Again."}), 404
+        db_session = current_app.db_session
+        return _getTexanomyData(db_session)
     except Exception as e:
         logger.exception(str(e))
         return (
             jsonify(
                 {"msg": "Server Error", "time": datetime.now().strftime("%H:%M:%S")}
             ),
-            505,
+            500,
         )
 
 

--- a/test-backend/test-flask/api/get_api.py
+++ b/test-backend/test-flask/api/get_api.py
@@ -251,58 +251,55 @@ def getMeatDataByUser():
         )
 
 
-# 육류 승인 여부별 육류 데이터 출력
-@get_api.route("/by-status", methods=["GET", "POST"])
-def getMeatDataByStatusType():
-    try:
-        if request.method == "GET":
-            db_session = current_app.db_session
-            statusType_value = safe_int(request.args.get("statusType"))
-            if statusType_value:
-                return _getMeatDataByStatusType(db_session, statusType_value)
-            else:
-                return jsonify("No statusType in parameter"), 401
-        else:
-            return jsonify({"msg": "Invalid Route, Please Try Again."}), 404
-    except Exception as e:
-        logger.exception(str(e))
-        return (
-            jsonify(
-                {"msg": "Server Error", "time": datetime.now().strftime("%H:%M:%S")}
-            ),
-            505,
-        )
+# # 육류 승인 여부별 육류 데이터 출력
+# @get_api.route("/by-status", methods=["GET", "POST"])
+# def getMeatDataByStatusType():
+#     try:
+#         if request.method == "GET":
+#             db_session = current_app.db_session
+#             statusType_value = safe_int(request.args.get("statusType"))
+#             if statusType_value:
+#                 return _getMeatDataByStatusType(db_session, statusType_value)
+#             else:
+#                 return jsonify("No statusType in parameter"), 401
+#         else:
+#             return jsonify({"msg": "Invalid Route, Please Try Again."}), 404
+#     except Exception as e:
+#         logger.exception(str(e))
+#         return (
+#             jsonify(
+#                 {"msg": "Server Error", "time": datetime.now().strftime("%H:%M:%S")}
+#             ),
+#             505,
+#         )
 
 
 # 육류 승인 여부별 범위 육류 데이터 출력
-@get_api.route("/by-status-range", methods=["GET", "POST"])
+@get_api.route("/by-status", methods=["GET"])
 def getMeatDataByRangeStatusType():
     try:
-        if request.method == "GET":
-            db_session = current_app.db_session
-            statusType_value = safe_int(request.args.get("statusType"))
-            offset = request.args.get("offset")
-            count = request.args.get("count")
-            start_str = request.args.get("start")
-            end_str = request.args.get("end")
+        db_session = current_app.db_session
+        status_type = safe_int(request.args.get("statusType"))
+        offset = request.args.get("offset")
+        count = request.args.get("count")
+        start_str = request.args.get("start")
+        end_str = request.args.get("end")
 
-            start = convert2datetime(start_str, 0)
-            end = convert2datetime(end_str, 0)
-            if statusType_value:
-                return _getMeatDataByRangeStatusType(
-                    db_session, statusType_value, offset, count, start, end
-                )
-            else:
-                return jsonify("No statusType in parameter"), 401
+        start = convert2datetime(start_str, 0)
+        end = convert2datetime(end_str, 0)
+        if status_type:
+            return _getMeatDataByRangeStatusType(
+                db_session, status_type, offset, count, start, end
+            )
         else:
-            return jsonify({"msg": "Invalid Route, Please Try Again."}), 404
+            return jsonify("No statusType in parameter"), 400
     except Exception as e:
-        logger.exception(str(e))
+        # logger.exception(str(e))
         return (
             jsonify(
                 {"msg": "Server Error", "time": datetime.now().strftime("%H:%M:%S")}
             ),
-            505,
+            500,
         )
 
 

--- a/test-backend/test-flask/api/get_api.py
+++ b/test-backend/test-flask/api/get_api.py
@@ -279,7 +279,7 @@ def getMeatDataByUser():
 def getMeatDataByRangeStatusType():
     try:
         db_session = current_app.db_session
-        status_type = safe_int(request.args.get("statusType"))
+        status_type = request.args.get("statusType")
         offset = request.args.get("offset")
         count = request.args.get("count")
         start_str = request.args.get("start")
@@ -293,9 +293,9 @@ def getMeatDataByRangeStatusType():
                 db_session, status_type, offset, count, specie_value, start, end
             )
         else:
-            return jsonify("No statusType or specieValue in parameter"), 400
+            return jsonify("Invalid statusType or specieValue in parameter"), 400
     except Exception as e:
-        # logger.exception(str(e))
+        logger.exception(str(e))
         return (
             jsonify(
                 {"msg": "Server Error", "time": datetime.now().strftime("%H:%M:%S")}

--- a/test-backend/test-flask/api/user_api.py
+++ b/test-backend/test-flask/api/user_api.py
@@ -102,7 +102,7 @@ def login_user():
             500,
         )
 
-      
+
 # 유저 등록 API
 @user_api.route("/register", methods=["POST"])
 def register_user_data():

--- a/test-backend/test-flask/api/user_api.py
+++ b/test-backend/test-flask/api/user_api.py
@@ -197,12 +197,14 @@ def update_user_data():
             jsonify(
                 {
                     "userId": updated_user.userId,
+                    "name": updated_user.name,
                     "homeAddr": updated_user.homeAddr,
                     "company": updated_user.company,
                     "jobTitle": updated_user.jobTitle,
                     "alarm": updated_user.alarm,
                     "type": usrType[updated_user.type],
-                    "updatedAt": updated_user.updatedAt
+                    "updatedAt": updated_user.updatedAt,
+                    "createdAt": updated_user.createdAt
                 }
             ), 
             200,

--- a/test-backend/test-flask/db/db_controller.py
+++ b/test-backend/test-flask/db/db_controller.py
@@ -829,16 +829,30 @@ def _getMeatDataByStatusType(db_session, varified):
 
 
 def _getMeatDataByRangeStatusType(
-    db_session, status_type, offset, count, start=None, end=None
+    db_session, status_type, offset, count, specie_value, start=None, end=None
 ):
     offset = safe_int(offset)
     count = safe_int(count)
-    # Base query
-    query = (
-        db_session.query(Meat)
-        .filter_by(statusType=status_type)
-        .order_by(Meat.createdAt.desc())
-    )
+    if specie_value == '소':
+        # Base query
+        query = (
+            db_session.query(Meat)
+            .filter(
+                Meat.statusType == status_type,
+                Meat.categoryId < 100
+            )
+            .order_by(Meat.createdAt.desc())
+        )
+    else:
+        # Base query
+        query = (
+            db_session.query(Meat)
+            .filter(
+                Meat.statusType == status_type,
+                Meat.categoryId >= 100
+            )
+            .order_by(Meat.createdAt.desc())
+        )
 
     # Date Filter
     if start and end:
@@ -901,10 +915,8 @@ def _getTexanomyData(db_session):
     species_all = db_session.query(SpeciesInfo).all()
     result = {}
     for species in species_all:
-        # Use joinedload to avoid N+1 problem
         categories = (
             db_session.query(CategoryInfo)
-            .options(joinedload(CategoryInfo.meats))
             .filter_by(speciesId=species.id)
             .all()
         )

--- a/test-backend/test-flask/db/db_controller.py
+++ b/test-backend/test-flask/db/db_controller.py
@@ -831,9 +831,10 @@ def _getMeatDataByStatusType(db_session, varified):
 def _getMeatDataByRangeStatusType(
     db_session, status_type, offset, count, specie_value, start=None, end=None
 ):
+    status_type = safe_int(status_type)
     offset = safe_int(offset)
     count = safe_int(count)
-    # Base query
+    # Specie_value별로 Base query를 다르게 설정 - 소, 돼지, 전체
     if specie_value == '소':
         query = (
             db_session.query(Meat)
@@ -841,28 +842,30 @@ def _getMeatDataByRangeStatusType(
                 Meat.statusType == status_type,
                 Meat.categoryId < 100
             )
-            .order_by(Meat.createdAt.desc())
         )
-    else:
+    elif specie_value == '돼지':
         query = (
             db_session.query(Meat)
             .filter(
                 Meat.statusType == status_type,
                 Meat.categoryId >= 100
             )
-            .order_by(Meat.createdAt.desc())
+        )
+    else:
+        query = (
+            db_session.query(Meat)
+            .filter(
+                Meat.statusType == status_type
+            )
         )
 
     # Date Filter
     if start and end:
         query = query.filter(
-            Meat.statusType == 1,
             Meat.createdAt.between(start, end)
-        )
-        db_total_len = db_session.query(Meat).filter(
-            Meat.statusType == status_type,
-            Meat.createdAt.between(start, end)
-        ).count()
+        ).order_by(Meat.createdAt.desc())
+        
+        db_total_len = query.count()
     query = query.offset(offset * count).limit(count)
 
     result = []

--- a/test-backend/test-flask/db/db_controller.py
+++ b/test-backend/test-flask/db/db_controller.py
@@ -712,7 +712,7 @@ def get_all_user(db_session):
     try:
         users = db_session.query(User).all()
         for user in users:
-            user.createdAt = convert2string(user.createdAt, 1)
+            user.createdAt = convert2string(user.createdAt, 0)
         return users
     except Exception as e:
         raise Exception(str(e))
@@ -833,8 +833,8 @@ def _getMeatDataByRangeStatusType(
 ):
     offset = safe_int(offset)
     count = safe_int(count)
+    # Base query
     if specie_value == '소':
-        # Base query
         query = (
             db_session.query(Meat)
             .filter(
@@ -844,7 +844,6 @@ def _getMeatDataByRangeStatusType(
             .order_by(Meat.createdAt.desc())
         )
     else:
-        # Base query
         query = (
             db_session.query(Meat)
             .filter(

--- a/test-backend/test-flask/db/db_controller.py
+++ b/test-backend/test-flask/db/db_controller.py
@@ -409,6 +409,7 @@ def get_meat(db_session, id):
     if meat is None:
         return None
     result = to_dict(meat)
+    result['meatId'] = result.pop('id')
     sexType = db_session.query(SexInfo).filter(SexInfo.id == result["sexType"]).first()
     gradeNum = (
         db_session.query(GradeInfo).filter(GradeInfo.id == result["gradeNum"]).first()
@@ -720,7 +721,7 @@ def get_user(db_session, user_id):
     try:
         user_data = db_session.query(User).filter(User.userId == user_id).first()
         if user_data is not None:
-            user_data.createdAt = convert2string(user_data.createdAt, 1)
+            user_data.createdAt = convert2string(user_data.createdAt, 0)
         return user_data
     except Exception as e:
         raise Exception(str(e))
@@ -828,28 +829,26 @@ def _getMeatDataByStatusType(db_session, varified):
 
 
 def _getMeatDataByRangeStatusType(
-    db_session, varified, offset, count, start=None, end=None
+    db_session, status_type, offset, count, start=None, end=None
 ):
     offset = safe_int(offset)
     count = safe_int(count)
     # Base query
     query = (
         db_session.query(Meat)
-        .options()
-        .filter_by(statusType=varified)
+        .filter_by(statusType=status_type)
         .order_by(Meat.createdAt.desc())
     )
 
     # Date Filter
-    #db_total_len = db_session.query(Meat).count()
-    if start is not None and end is not None:
+    if start and end:
         query = query.filter(
-            Meat.createdAt.between(start, end),
-            Meat.statusType == 1
+            Meat.statusType == 1,
+            Meat.createdAt.between(start, end)
         )
         db_total_len = db_session.query(Meat).filter(
-            Meat.createdAt.between(start, end),
-            Meat.statusType == varified
+            Meat.statusType == status_type,
+            Meat.createdAt.between(start, end)
         ).count()
     query = query.offset(offset * count).limit(count)
 
@@ -858,30 +857,32 @@ def _getMeatDataByRangeStatusType(
 
     for meat in meat_data:
         temp = get_meat(db_session, meat.id)
-        userTemp = get_user(db_session, temp.get("userId"))
-        if userTemp:
-            temp["name"] = userTemp.get("name")
-            temp["company"] = userTemp.get("company")
-            temp["type"] = userTemp.get("type")
+        user_temp = get_user(db_session, temp["userId"])
+
+        if user_temp:
+            temp["userName"] = user_temp.name
+            temp["company"] = user_temp.company
+            temp["userType"] = usrType[user_temp.type]
         else:
-            temp["name"] = userTemp
-            temp["company"] = userTemp
-            temp["type"] = userTemp
+            temp["userName"] = user_temp
+            temp["company"] = user_temp
+            temp["userType"] = user_temp
+
         del temp["processedmeat"]
         del temp["rawmeat"]
         result.append(temp)
-    varified_id = varified
-    if varified == 2:
-        varified = "승인"
-    elif varified == 1:
-        varified = "반려"
+
+    if status_type == 2:
+        status_type = "승인"
+    elif status_type == 1:
+        status_type = "반려"
     else:
-        varified = "대기중"
+        status_type = "대기중"
     return (
         jsonify(
             {
                 "DB Total len": db_total_len,
-                f"{varified}": result,
+                f"{status_type}": result,
             }
         ),
         200,

--- a/test-backend/test-flask/utils.py
+++ b/test-backend/test-flask/utils.py
@@ -190,7 +190,7 @@ def convert2datetime(date_string, format):
         return date_string
     if format == 0:
         return datetime.strptime(date_string, "%Y-%m-%dT%H:%M:%S")
-    if format == 1:
+    elif format == 1:
         tz = pytz.timezone("Asia/Seoul")
         return datetime.now(tz).strftime("%Y-%m-%dT%H:%M:%S")
     elif format == 2:
@@ -244,7 +244,7 @@ def item_encoder(data_dict, item, input_data=None):
         "juiciness",
         "tenderness",
         "umami",
-        "palability",
+        "palatability",
         "L",
         "a",
         "b",
@@ -317,7 +317,7 @@ def item_encoder(data_dict, item, input_data=None):
         "juiciness",
         "tenderness",
         "umami",
-        "palability",
+        "palatability",
         "L",
         "a",
         "b",


### PR DESCRIPTION
## 주요 수정 사항
### 1. /meat/get/by-status
    - 기존의 by-status 함수는 주석 처리하고, by-status-range 함수를 수정함.
    - 메소드는 GET으로만 수정
    - 종 분류에 대한 파라미터(specieValue)도 받아서 소, 돼지 데이터를 별도로 관리할 수 있도록 함. 
      이때 종 분류 없이 '전체'에 대한 데이터도 조회할 수 있도록 base query 수정함.
    - DTO에 맞게 리턴해야 하는 변수명 수정함.
    - varified라는 변수명이 직관적이지 않아서 status_type이라는 변수명으로 수정함.
    - get_meat() 컨트롤러에서 meat.id를 공통 DTO에 맞게 meatId로 수정함.
    - 필터링할 때 정렬을 최소화하기 위해 statusType으로 우선 필터링하고, createdAt의 최신순으로 정렬하도록 필터링 순서 변경.
<img width="700" alt="스크린샷 2024-07-16 오후 4 43 42" src="https://github.com/user-attachments/assets/ff9b8a6a-815a-4de3-a90f-14fa3707aca3">


### 2. /meat/get/default-data
    - 메소드 GET으로만 수정
    - utils.py에 작성해놓은 기본 정보들을 불러오는 API이기 때문에 추가 작업 진행한 것 없음.


### 3. utils.py
    - item_encoder() 함수에서 palability -> palatability로 오타 수정
    - convert2datetime() 함수에서 조건문 수정