### PR TITLE
fix: 반응형 웹 페이지 구현 및, 일부 사항 수정

### DIFF
--- a/test-web/src/App.jsx
+++ b/test-web/src/App.jsx
@@ -1,80 +1,77 @@
-import { Helmet } from "react-helmet";
-import { BrowserRouter as Router, Route, Routes } from "react-router-dom";
+import { Helmet } from 'react-helmet';
+import { BrowserRouter as Router, Route, Routes } from 'react-router-dom';
 
-import LogIn from "./routes/LogIn";
-import Home from "./routes/Home";
-import Dashboard from "./routes/Dashboard";
-import Stats from "./routes/Stats";
-import PA from "./routes/PA";
-import Profile from "./routes/Profile";
-import DataEdit from "./routes/DataEdit";
-import UserManagement from "./routes/UserManagement";
-import DataConfirm from "./routes/DataConfirm";
-import DataPredict from "./routes/DataPredict";
-import Box from "@mui/material/Box";
-import Sidebar from "./components/Base/Sidebar";
-import { createTheme, ThemeProvider } from "@mui/material/styles";
+import LogIn from './routes/LogIn';
+import Home from './routes/Home';
+import Dashboard from './routes/Dashboard';
+import Stats from './routes/Stats';
+import PA from './routes/PA';
+import Profile from './routes/Profile';
+import DataEdit from './routes/DataEdit';
+import UserManagement from './routes/UserManagement';
+import DataConfirm from './routes/DataConfirm';
+import DataPredict from './routes/DataPredict';
+import Box from '@mui/material/Box';
+import Sidebar from './components/Base/Sidebar';
+import { createTheme, ThemeProvider } from '@mui/material/styles';
 const defaultTheme = createTheme();
 
-
-
 function App() {
-const isLoggedin = localStorage.getItem("isLoggedIn") === "true";
-console.log(isLoggedin);
+  const isLoggedin = localStorage.getItem('isLoggedIn') === 'true';
+  console.log(isLoggedin);
 
   const routes = [
     {
-      path: "/",
-      title: "LogIn | DeePlant",
+      path: '/',
+      title: 'LogIn | DeePlant',
       component: isLoggedin ? <Home /> : <LogIn />,
     },
     {
-      path: "/Home",
-      title: "Home | DeePlant",
+      path: '/Home',
+      title: 'Home | DeePlant',
       component: <Home />,
     },
     {
-      path: "/DataManage",
-      title: "DataManage | DeePlant",
+      path: '/DataManage',
+      title: 'DataManage | DeePlant',
       component: <Dashboard />,
     },
     {
-      path: "/DataConfirm/:id",
-      title: "DataConfirm | Deeplant",
+      path: '/DataConfirm/:id',
+      title: 'DataConfirm | Deeplant',
       component: <DataConfirm />,
     },
     {
-      path: "/dataView/:id",
-      title: "DataView | DeePlant",
+      path: '/dataView/:id',
+      title: 'DataView | DeePlant',
       component: <DataEdit />,
     },
     {
-      path: "/dataPA/:id",
-      title: "PA-one | DeePlant",
+      path: '/dataPA/:id',
+      title: 'PA-one | DeePlant',
       component: <DataPredict />,
     },
     {
-      path: "/PA",
-      title: "PA | DeePlant",
+      path: '/PA',
+      title: 'PA | DeePlant',
       component: <PA />,
     },
     {
-      path: "/stats",
-      title: "Statistics | DeePlant",
+      path: '/stats',
+      title: 'Statistics | DeePlant',
       component: <Stats />,
     },
     {
-      path: "/profile",
-      title: "Profile | DeePlant",
+      path: '/profile',
+      title: 'Profile | DeePlant',
       component: <Profile />,
     },
     {
-      path: "/UserManagement",
-      title: "UserManage | Deeplant",
+      path: '/UserManagement',
+      title: 'UserManage | Deeplant',
       component: <UserManagement />,
     },
   ];
-
 
   return (
     <Router>
@@ -90,28 +87,28 @@ console.log(isLoggedin);
                 </Helmet>
                 <ThemeProvider theme={defaultTheme}>
                   {!isLoggedin ? (
-                    <LogIn/>
+                    <LogIn />
                   ) : (
-                    <Box sx={{ display: "flex" }}>
+                    <Box sx={{ display: 'flex' }}>
                       <Sidebar />
                       <Box
                         component="main"
                         sx={{
-                          backgroundColor: "#FAFBFC",
+                          backgroundColor: '#FAFBFC',
                           flexGrow: 1,
-                          height: "100vh",
-                          overflow: "auto",
-                          display: "flex",
-                          alignItems: "center",
-                          justifyContent: "center",
-                          flexDirection: "column",
+                          height: '100vh',
+                          overflow: 'auto',
+                          display: 'flex',
+                          alignItems: 'center',
+                          justifyContent: 'center',
+                          flexDirection: 'column',
                         }}
                       >
                         {route.component}
                       </Box>
                     </Box>
                   )}
-                 </ThemeProvider>
+                </ThemeProvider>
               </>
             }
           />

--- a/test-web/src/components/Base/Sidebar.js
+++ b/test-web/src/components/Base/Sidebar.js
@@ -27,7 +27,7 @@ import DataThresholdingIcon from '@mui/icons-material/DataThresholding';
 import StackedLineChartIcon from '@mui/icons-material/StackedLineChart';
 import GroupIcon from '@mui/icons-material/Group';
 import HomeIcon from '@mui/icons-material/Home';
-import { HiOutlineChip } from 'react-icons/hi';
+import TroubleshootIcon from '@mui/icons-material/Troubleshoot';
 
 import DeeplantLong from '../../src_assets/Deeplant_long.webp';
 import LOGO from '../../src_assets/LOGO.png';
@@ -49,7 +49,7 @@ const mainListItems = [
   },
   {
     label: '데이터 예측',
-    icon: <HiOutlineChip style={{ fontSize: 30 }} />,
+    icon: <TroubleshootIcon style={{ fontSize: 30 }} />,
     path: '/PA',
   },
   {
@@ -64,7 +64,8 @@ const mainListItems = [
   },
 ];
 
-const drawerWidth = `${(345 / 1920) * 100}vw`; // Width when drawer is open
+// const drawerWidth = `${(345 / 1920) * 100}vw`; // Width when drawer is open
+const drawerWidth = '345px'; // Width when drawer is open
 const defaultTheme = createTheme();
 
 const Drawer = styled(MuiDrawer, {
@@ -87,9 +88,9 @@ const Drawer = styled(MuiDrawer, {
         easing: theme.transitions.easing.sharp,
         duration: theme.transitions.duration.leavingScreen,
       }),
-      width: theme.spacing(7),
+      width: '64px', // 고정된 너비 설정
       [theme.breakpoints.up('sm')]: {
-        width: theme.spacing(8),
+        width: '64px', // sm 브레이크포인트 이상에서도 동일한 너비 유지
       },
     }),
   },
@@ -265,7 +266,7 @@ function Sidebar() {
           sx={{
             pt: '14px', // 홈 버튼에만 추가 상단 패딩
             pb: '12px', // 홈 버튼에만 추가 하단 패딩
-            ...(open && { mt: '20px' }), // 열렸을 때 추가 상단 여백
+            ...(open && { mt: '8px' }), // 열렸을 때 추가 상단 여백
           }}
         >
           {mainListItems.map((item) => (
@@ -306,7 +307,7 @@ function Sidebar() {
             display: 'flex',
             alignItems: 'center',
             justifyContent: 'flex-end',
-            px: [1],
+            px: [1.2],
           }}
         >
           <IconButton onClick={toggleDrawer}>

--- a/test-web/src/components/Charts/PieChart/pieChart.js
+++ b/test-web/src/components/Charts/PieChart/pieChart.js
@@ -84,6 +84,7 @@ const PieChart = ({ subheader, chartColors, startDate, endDate, ...other }) => {
     if (data !== null && data !== undefined) {
       processPieData(data);
     }
+    setLabel('total_counts');
   }, [data]);
 
   // 토글 버튼 handle (전체, 소, 돼지)

--- a/test-web/src/components/DataDetailPage/DataConfirmView.js
+++ b/test-web/src/components/DataDetailPage/DataConfirmView.js
@@ -70,7 +70,7 @@ function DataConfirmView({ dataProps }) {
   const [confirmVal, setConfirmVal] = useState(null);
 
   return (
-    <div style={{ width: '100%', marginTop: '40px' }}>
+    <div style={{ width: '100%', height: '100%', marginTop: '40px' }}>
       <div style={style.editBtnWrapper}>
         <IconButton
           style={style.acceptBtn}
@@ -136,7 +136,11 @@ function DataConfirmView({ dataProps }) {
             width: '27vw',
             margin: '0px 10px',
             boxShadow: 24,
+            minWidth: '360px',
             height: '65vh',
+            minHeight: '500px',
+            // display: 'flex',
+            // flexDirection: 'column',
           }}
         >
           <Tabs
@@ -267,8 +271,10 @@ const style = {
     display: 'flex',
     justifyContent: 'end',
     marginTop: 'auto',
+    paddingRight: '20px',
     borderBottomLeftRadius: '10px',
     borderBottomRightRadius: '10px',
+    minWidth: '1140px',
   },
   dataFieldColumn: {
     backgroundColor: '#9e9e9e',

--- a/test-web/src/components/DataDetailPage/DataPAView.js
+++ b/test-web/src/components/DataDetailPage/DataPAView.js
@@ -224,7 +224,14 @@ function DataPAView({ dataProps }) {
           divStyle={style.qrWrapper}
         />
         {/* 3. 세부 데이터 정보*/}
-        <Card style={{ width: '24vw', margin: '0px 10px', boxShadow: 24 }}>
+        <Card
+          style={{
+            width: '24vw',
+            margin: '0px 10px',
+            boxShadow: 24,
+            minWidth: '360px',
+          }}
+        >
           <Tabs
             defaultActiveKey="0"
             id="uncontrolled-tab-example"
@@ -303,6 +310,7 @@ const style = {
     justifyContent: 'end',
     borderBottomLeftRadius: '10px',
     borderBottomRightRadius: '10px',
+    minWidth: '1140px',
   },
   dataFieldColumn: {
     backgroundColor: '#9e9e9e',
@@ -339,6 +347,7 @@ const style = {
     margin: '0px 10px',
     marginBottom: '20px',
     boxShadow: 24,
+    minWidth: '360px',
   },
   imgTextWrapper: {
     color: '#002984',
@@ -366,6 +375,7 @@ const style = {
     width: '23vw',
     margin: '0px 10px',
     boxShadow: 24,
+    minWidth: '360px',
   },
   xaiImageWrapper: {
     width: '100%',
@@ -377,6 +387,7 @@ const style = {
     width: '23vw',
     margin: '0px 10px',
     boxShadow: 24,
+    minWidth: '360px',
   },
 };
 const divStyle = {

--- a/test-web/src/components/DataDetailPage/DataView.js
+++ b/test-web/src/components/DataDetailPage/DataView.js
@@ -257,14 +257,17 @@ function DataView({ dataProps }) {
           userId={userId}
           createdAt={createdAt}
         />
-
         {/* 3. 세부 데이터 정보*/}
         <Card
           style={{
             width: '27vw',
             margin: '0px 10px',
             boxShadow: 24,
+            minWidth: '360px',
             height: '65vh',
+            minHeight: '500px',
+            // display: 'flex',
+            // flexDirection: 'column',
           }}
         >
           <Tabs
@@ -466,13 +469,13 @@ const style = {
     justifyContent: 'space-between',
   },
   editBtnWrapper: {
-    paddingTop: '0px',
+    padding: '0px',
+    margin: '10px 0px 0px',
+    paddingRight: '10px',
     width: '100%',
     display: 'flex',
     justifyContent: 'end',
-    marginTop: 'auto',
-    borderBottomLeftRadius: '10px',
-    borderBottomRightRadius: '10px',
+    minWidth: '1140px',
   },
   dataFieldColumn: {
     backgroundColor: '#9e9e9e',
@@ -499,7 +502,7 @@ const style = {
   dataContainer: {
     height: '33px',
     borderBottom: '0.8px solid #e0e0e0',
-    width: '',
+    width: '60px',
     borderRight: '0.8px solid #e0e0e0',
     padding: '4px 5px',
   },

--- a/test-web/src/components/DataDetailPage/cardComps/MeatImgsCard.js
+++ b/test-web/src/components/DataDetailPage/cardComps/MeatImgsCard.js
@@ -152,9 +152,20 @@ const MeatImgsCard = ({
   };
 
   return (
-    <Card style={{ width: '27vw', margin: '0px 10px', boxShadow: 24 }}>
+    <Card
+      style={{
+        width: '27vw',
+        margin: '0px 10px',
+        boxShadow: 24,
+        minWidth: '360px',
+        height: '65vh',
+        minHeight: '500px',
+        display: 'flex',
+        flexDirection: 'column',
+      }}
+    >
       {/* 1.1. 이미지 */}
-      <Card.Body>
+      <Card.Body style={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
         {/**이미지 제목 */}
         <Card.Text style={style.imgTitleContainer}>
           {
@@ -303,10 +314,13 @@ const style = {
     height: '350px',
     width: '100%',
     borderRadius: '10px',
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
   },
   imgWrapper: {
-    height: '350px',
-    width: '400px',
+    maxHeight: '350px',
+    maxWidth: '100%',
     objectFit: 'contain',
   },
   imgNotExistWrapper: {
@@ -331,6 +345,8 @@ const style = {
     display: 'flex',
     justifyContent: 'center',
     alignItems: 'center',
+    flexWrap: 'wrap',
+    gap: '5px',
   },
   paginationLeftBtn: {
     height: '35px',
@@ -338,24 +354,30 @@ const style = {
     borderRadius: '10px',
     padding: '0',
     border: '1px solid black',
+    marginBottom: '5px',
   },
   paginationNavBtnWrapper: {
     display: 'flex',
     justifyContent: 'center',
-    margin: '0px 5px',
+    flexWrap: 'wrap',
+    gap: '5px',
   },
   paginationNavCurrDiv: {
-    height: 'fit-content',
-    width: 'fit-content',
-    padding: '10px',
+    height: '35px',
+    width: '35px',
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
     borderRadius: '5px',
     color: navy,
   },
   paginationNavNotCurrDiv: {
-    height: '100%',
-    width: 'fit-content',
+    height: '35px',
+    width: '35px',
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
     borderRadius: '5px',
-    padding: '10px',
     color: '#b0bec5',
   },
   paginationRightBtn: {
@@ -364,5 +386,6 @@ const style = {
     borderRadius: '10px',
     padding: '0',
     border: '1px solid black',
+    marginBottom: '5px',
   },
 };

--- a/test-web/src/components/DataDetailPage/cardComps/QRInfoCard.js
+++ b/test-web/src/components/DataDetailPage/cardComps/QRInfoCard.js
@@ -15,10 +15,19 @@ const QRInfoCard = ({
       style={
         page === 'predict'
           ? divStyle
-          : { width: '27vw', height: '65vh', margin: '0px 10px', boxShadow: 24 }
+          : {
+              width: '27vw',
+              margin: '0px 10px',
+              boxShadow: 24,
+              minWidth: '360px',
+              height: '65vh',
+              minHeight: '500px',
+              display: 'flex',
+              flexDirection: 'column',
+            }
       }
     >
-      <Card.Body>
+      <Card.Body style={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
         <Card.Text>
           <div
             style={{ color: '#002984', fontSize: '18px', fontWeight: '800' }}

--- a/test-web/src/components/DataListView/DataListComp.js
+++ b/test-web/src/components/DataListView/DataListComp.js
@@ -39,7 +39,7 @@ const DataListComp = ({
     });
 
     setMeatList(meatData);
-    console.log(meatData)
+    console.log(meatData);
   };
 
   // API fetch
@@ -94,7 +94,6 @@ const DataListComp = ({
 
   // 정상 데이터 로드 된 경우
   return (
-    
     <div>
       <div style={style.listContainer}>
         {meatList !== undefined && (
@@ -154,6 +153,7 @@ const style = {
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'space-between',
+    minWidth: '640px',
   },
   formControl: {
     minWidth: 120,

--- a/test-web/src/components/DataListView/DataListComp.js
+++ b/test-web/src/components/DataListView/DataListComp.js
@@ -143,6 +143,7 @@ const style = {
     paddingRight: '0px',
     paddingBottom: '0',
     height: 'auto',
+    minWidth: '640px',
   },
   paginationBar: {
     marginTop: '40px',

--- a/test-web/src/components/DataListView/PADataListComp.js
+++ b/test-web/src/components/DataListView/PADataListComp.js
@@ -144,6 +144,7 @@ const style = {
     paddingRight: '0px',
     paddingBottom: '0',
     height: 'auto',
+    minWidth: '640px',
   },
   paginationBar: {
     marginTop: '40px',

--- a/test-web/src/components/DataListView/PADataListComp.js
+++ b/test-web/src/components/DataListView/PADataListComp.js
@@ -154,6 +154,7 @@ const style = {
     display: 'flex',
     justifyContent: 'right',
     alignItems: 'center',
+    minWidth: '640px',
   },
   formControl: {
     minWidth: 120,

--- a/test-web/src/components/Search/SearchFilterBar.js
+++ b/test-web/src/components/Search/SearchFilterBar.js
@@ -30,14 +30,20 @@ function SearchFilterBar({ setStartDate, setEndDate }) {
 
   //조회 기간 (탭으로 클릭 시)
   const [isDur, setIsDur] = useState(true);
-  const [duration, setDuration] = useState(searchParams.get('duration') || 'week');
+  const [duration, setDuration] = useState(
+    searchParams.get('duration') || 'week'
+  );
   const [durStart, setDurStart] = useState(null);
   const [durEnd, setDurEnd] = useState(null);
   // 조회 기간 (직접 입력할 시)
-  const [calenderStart, setCalenderStart] = useState(dayjs(searchParams.get('start') || null));
-  const [calenderEnd, setCalenderEnd] = useState(dayjs(searchParams.get('end') || null));
+  const [calenderStart, setCalenderStart] = useState(
+    dayjs(searchParams.get('start') || null)
+  );
+  const [calenderEnd, setCalenderEnd] = useState(
+    dayjs(searchParams.get('end') || null)
+  );
 
-  console.log(duration)
+  console.log(duration);
 
   // 탭으로 클릭시 조회기간 변경
   const handleDr = (event) => {
@@ -65,7 +71,9 @@ function SearchFilterBar({ setStartDate, setEndDate }) {
       s.setHours(0, 0, 0, 0);
     }
     const start = new Date(s.getTime() + TIME_ZONE).toISOString().slice(0, -5);
-    const end = new Date(new Date().getTime() + TIME_ZONE).toISOString().slice(0, -5);
+    const end = new Date(new Date().getTime() + TIME_ZONE)
+      .toISOString()
+      .slice(0, -5);
     return { start, end };
   };
 
@@ -100,11 +108,11 @@ function SearchFilterBar({ setStartDate, setEndDate }) {
     setCalenderStart(null);
     setCalenderEnd(null);
     setIsDur(true);
-  
+
     const { start, end } = updateDates();
     setStartDate(start);
     setEndDate(end);
-  
+
     const queryParams = new URLSearchParams();
     queryParams.set('duration', 'week');
     navigate(`${location.pathname}?${queryParams.toString()}`);
@@ -340,6 +348,7 @@ const styles = {
     gap: '10px',
     gridTemplateColumns: 'minmax(400px, max-content) 1fr',
     width: 'fit-content',
+    minWidth: '500px',
     height: 'fit-content',
     borderRadius: '10px',
   },

--- a/test-web/src/components/User/UserList.js
+++ b/test-web/src/components/User/UserList.js
@@ -100,7 +100,6 @@ function UserList() {
       신규 회원 등록
     </Tooltip>
   );
-  ////////////
 
   const columns = [
     { field: 'name', headerName: '이름', width: 100 },
@@ -262,152 +261,159 @@ function UserList() {
   return (
     <div
       style={{
-        alignContent: 'center',
+        // alignContent: 'center',
         overflow: 'auto',
         width: '100%', //
         marginTop: '100px',
         paddingBottom: '100px',
-        marginLeft: '100px', //
+        marginLeft: `${(720 / 1920) * 100}vw`, //
+        // marginright: `${(380 / 1920) * 100}vw`, //
       }}
     >
-      <div>
-        <Toolbar />
-        <div style={{ display: 'flex', alignItems: 'center' }}>
-          <Typography
-            component="h2"
-            variant="h4"
-            gutterBottom
+      <Toolbar />
+      <div style={{ display: 'flex', alignItems: 'center' }}>
+        <Typography
+          component="h2"
+          variant="h4"
+          gutterBottom
+          style={{
+            color: '#151D48',
+            fontFamily: 'Poppins',
+            fontSize: `30px`,
+            fontStyle: 'normal',
+            fontWeight: 600,
+            // lineHeight: `${(36 / 1920) * 100 * 1.4}vw`,
+          }}
+        >
+          User Management
+        </Typography>
+      </div>
+      <Modal
+        show={registerShow}
+        onHide={handleRegisterClose}
+        backdrop="true"
+        keyboard={false}
+        centered
+      >
+        <Modal.Body>
+          <Modal.Title
             style={{
               color: '#151D48',
               fontFamily: 'Poppins',
-              fontSize: `30px`,
-              fontStyle: 'normal',
+              fontSize: `24px`,
               fontWeight: 600,
-              // lineHeight: `${(36 / 1920) * 100 * 1.4}vw`,
             }}
           >
-            User Management
-          </Typography>
-        </div>
-        <Modal
-          show={registerShow}
-          onHide={handleRegisterClose}
-          backdrop="true"
-          keyboard={false}
-          centered
+            신규 회원 등록
+          </Modal.Title>
+          <UserRegister handleClose={handleRegisterClose} />
+        </Modal.Body>
+      </Modal>
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          // maxWidth: `${(1470 / 1920) * 100}vw`,
+          maxWidth: '1040px',
+        }}
+      >
+        <Box
+          component="form"
+          sx={{
+            marginBottom: `${(16 / 1080) * 100}vh`,
+            paddingX: `8px`,
+            paddingY: `8px`,
+            width: '280px',
+            height: '50px',
+            // minHeight: '60px',
+            backgroundColor: '#FFF',
+          }}
         >
-          <Modal.Body>
-            <Modal.Title
-              style={{
-                color: '#151D48',
-                fontFamily: 'Poppins',
-                fontSize: `24px`,
-                fontWeight: 600,
-              }}
-            >
-              신규 회원 등록
-            </Modal.Title>
-            <UserRegister handleClose={handleRegisterClose} />
-          </Modal.Body>
-        </Modal>
-        <div style={{ display: 'flex', alignItems: 'center' }}>
-          <Box
-            component="form"
+          <SearchIcon />
+          <InputBase
+            placeholder=" 사용자 검색"
+            onChange={(event) => handleSearch(event)}
             sx={{
-              marginBottom: `${(16 / 1080) * 100}vh`,
-              paddingX: `${(16 / 1920) * 100}vw`,
-              paddingY: `${(12 / 1080) * 100}vh`,
-              // width: `${(513 / 1920) * 100}vw`,
-              height: `${(60 / 1080) * 100}vh`,
-              backgroundColor: '#FFF',
-            }}
-          >
-            <SearchIcon />
-            <InputBase
-              placeholder=" 사용자 검색"
-              onChange={(event) => handleSearch(event)}
-              sx={{
-                color: '#737791',
-                fontFamily: 'Poppins',
-                fontSize: `20px`,
-                fontStyle: 'normal',
-                fontWeight: 500,
-                // lineHeight: `${(20 / 1080) * 100}vh`,
-              }}
-            />
-          </Box>
-
-          <div style={{ marginLeft: 'auto' }}>
-            <OverlayTrigger
-              placement="top"
-              delay={{ show: 250, hide: 400 }}
-              overlay={renderTooltip}
-            >
-              <Button
-                className="mb-3"
-                onClick={handleRegisterShow}
-                style={{
-                  display: 'inline-flex',
-                  paddingX: `${(12 / 1920) * 100}vw`,
-                  paddingY: `${(16 / 1080) * 100}vh`,
-                  alignItems: 'center',
-                  gap: `${(8 / 1920) * 100}vw`,
-                  borderRadius: `${(10 / 1920) * 100}vw`,
-                  background: '#32CD32',
-                  borderColor: '#32CD32',
-                }}
-              >
-                <IoMdPersonAdd />
-              </Button>
-            </OverlayTrigger>
-          </div>
-        </div>
-
-        {isLoading ? (
-          <CircularProgress />
-        ) : (
-          <DataGrid
-            rows={searchedUsers.length > 0 ? searchedUsers : allUsers}
-            columns={columns.map((column) =>
-              column.field === 'type'
-                ? { ...column, editable: true } // Enable editing for the "type" field
-                : column
-            )}
-            pageSize={5}
-            pageSizeOptions={[5, 10, 20]}
-            pagination
-            autoHeight
-            onEditCellChange={handleCellEdit} // Attach the event handler for cell edits
-            initialState={{
-              pagination: {
-                paginationModel: {
-                  pageSize: 5,
-                },
-              },
-            }}
-            //pageSizeOptions={[5]}
-            disableRowSelectionOnClick
-            sx={{
-              width: `${(1470 / 1920) * 100}vw`,
-              height: `${(560 / 1080) * 100}vh`,
-              flexShrink: 0,
-              borderRadius: `${(20 / 1920) * 100}vw`,
-              border: '1px solid #F8F9FA',
-              backgroundColor: '#FFF',
-              boxShadow: `${(0 / 1920) * 100}vw ${(4 / 1080) * 100}vh ${
-                (20 / 1920) * 100
-              }vw ${(0 / 1080) * 100}vh rgba(238, 238, 238, 0.50)`,
-              minWidth: '700px',
+              color: '#737791',
+              fontFamily: 'Poppins',
+              fontSize: `18px`,
+              fontStyle: 'normal',
+              fontWeight: 500,
+              // lineHeight: `${(20 / 1080) * 100}vh`,
             }}
           />
-        )}
-        <CustomSnackbar
-          open={snackbarOpen}
-          message={snackbarMessage}
-          severity={snackbarSeverity}
-          onClose={closeSnackbar}
-        />
+        </Box>
+
+        <div style={{ marginLeft: 'auto' }}>
+          <OverlayTrigger
+            placement="top"
+            delay={{ show: 250, hide: 400 }}
+            overlay={renderTooltip}
+          >
+            <Button
+              className="mb-3"
+              onClick={handleRegisterShow}
+              style={{
+                display: 'inline-flex',
+                paddingX: `${(12 / 1920) * 100}vw`,
+                paddingY: `${(16 / 1080) * 100}vh`,
+                alignItems: 'center',
+                gap: `${(8 / 1920) * 100}vw`,
+                borderRadius: `${(10 / 1920) * 100}vw`,
+                background: '#32CD32',
+                borderColor: '#32CD32',
+              }}
+            >
+              <IoMdPersonAdd />
+            </Button>
+          </OverlayTrigger>
+        </div>
       </div>
+
+      {isLoading ? (
+        <CircularProgress />
+      ) : (
+        <DataGrid
+          rows={searchedUsers.length > 0 ? searchedUsers : allUsers}
+          columns={columns.map((column) =>
+            column.field === 'type'
+              ? { ...column, editable: true } // Enable editing for the "type" field
+              : column
+          )}
+          pageSize={5}
+          pageSizeOptions={[5, 10, 20]}
+          pagination
+          autoHeight
+          onEditCellChange={handleCellEdit} // Attach the event handler for cell edits
+          initialState={{
+            pagination: {
+              paginationModel: {
+                pageSize: 5,
+              },
+            },
+          }}
+          //pageSizeOptions={[5]}
+          disableRowSelectionOnClick
+          sx={{
+            width: `${(1470 / 1920) * 100}vw`,
+            height: `${(560 / 1080) * 100}vh`,
+            flexShrink: 0,
+            borderRadius: `${(20 / 1920) * 100}vw`,
+            border: '1px solid #F8F9FA',
+            backgroundColor: '#FFF',
+            boxShadow: `${(0 / 1920) * 100}vw ${(4 / 1080) * 100}vh ${
+              (20 / 1920) * 100
+            }vw ${(0 / 1080) * 100}vh rgba(238, 238, 238, 0.50)`,
+            maxWidth: '1040px',
+          }}
+        />
+      )}
+      <CustomSnackbar
+        open={snackbarOpen}
+        message={snackbarMessage}
+        severity={snackbarSeverity}
+        onClose={closeSnackbar}
+      />
     </div>
   );
 }

--- a/test-web/src/components/User/UserList.js
+++ b/test-web/src/components/User/UserList.js
@@ -260,143 +260,154 @@ function UserList() {
   };
 
   return (
-    <div>
-      <Toolbar />
-      <div style={{ display: 'flex', alignItems: 'center' }}>
-        <Typography
-          component="h2"
-          variant="h4"
-          gutterBottom
-          style={{
-            color: '#151D48',
-            fontFamily: 'Poppins',
-            fontSize: `${(36 / 1920) * 100}vw`,
-            fontStyle: 'normal',
-            fontWeight: 600,
-            lineHeight: `${(36 / 1920) * 100 * 1.4}vw`,
-          }}
-        >
-          User Management
-        </Typography>
-      </div>
-      <Modal
-        show={registerShow}
-        onHide={handleRegisterClose}
-        backdrop="true"
-        keyboard={false}
-        centered
-      >
-        <Modal.Body>
-          <Modal.Title
+    <div
+      style={{
+        alignContent: 'center',
+        overflow: 'auto',
+        width: '100%', //
+        marginTop: '100px',
+        paddingBottom: '100px',
+        marginLeft: '100px', //
+      }}
+    >
+      <div>
+        <Toolbar />
+        <div style={{ display: 'flex', alignItems: 'center' }}>
+          <Typography
+            component="h2"
+            variant="h4"
+            gutterBottom
             style={{
               color: '#151D48',
               fontFamily: 'Poppins',
-              fontSize: `${(36 / 1920) * 100}vw`,
-              fontWeight: 600,
-              lineHeight: `${(36 / 1920) * 100 * 1.4}vw`,
-            }}
-          >
-            신규 회원 등록
-          </Modal.Title>
-          <UserRegister handleClose={handleRegisterClose} />
-        </Modal.Body>
-      </Modal>
-      <div style={{ display: 'flex', alignItems: 'center' }}>
-        <Box
-          component="form"
-          sx={{
-            marginBottom: `${(16 / 1080) * 100}vh`,
-            paddingX: `${(16 / 1920) * 100}vw`,
-            paddingY: `${(12 / 1080) * 100}vh`,
-            width: `${(513 / 1920) * 100}vw`,
-            height: `${(60 / 1080) * 100}vh`,
-            backgroundColor: '#FFF',
-          }}
-        >
-          <SearchIcon />
-          <InputBase
-            placeholder=" 사용자 검색"
-            onChange={(event) => handleSearch(event)}
-            sx={{
-              color: '#737791',
-              fontFamily: 'Poppins',
-              fontSize: `${(20 / 1920) * 100}vw`,
+              fontSize: `30px`,
               fontStyle: 'normal',
-              fontWeight: 500,
-              lineHeight: `${(20 / 1080) * 100}vh`,
+              fontWeight: 600,
+              // lineHeight: `${(36 / 1920) * 100 * 1.4}vw`,
             }}
-          />
-        </Box>
-
-        <div style={{ marginLeft: 'auto' }}>
-          <OverlayTrigger
-            placement="top"
-            delay={{ show: 250, hide: 400 }}
-            overlay={renderTooltip}
           >
-            <Button
-              className="mb-3"
-              onClick={handleRegisterShow}
+            User Management
+          </Typography>
+        </div>
+        <Modal
+          show={registerShow}
+          onHide={handleRegisterClose}
+          backdrop="true"
+          keyboard={false}
+          centered
+        >
+          <Modal.Body>
+            <Modal.Title
               style={{
-                display: 'inline-flex',
-                paddingX: `${(12 / 1920) * 100}vw`,
-                paddingY: `${(16 / 1080) * 100}vh`,
-                alignItems: 'center',
-                gap: `${(8 / 1920) * 100}vw`,
-                borderRadius: `${(10 / 1920) * 100}vw`,
-                background: '#32CD32',
-                borderColor: '#32CD32',
+                color: '#151D48',
+                fontFamily: 'Poppins',
+                fontSize: `24px`,
+                fontWeight: 600,
               }}
             >
-              <IoMdPersonAdd />
-            </Button>
-          </OverlayTrigger>
-        </div>
-      </div>
+              신규 회원 등록
+            </Modal.Title>
+            <UserRegister handleClose={handleRegisterClose} />
+          </Modal.Body>
+        </Modal>
+        <div style={{ display: 'flex', alignItems: 'center' }}>
+          <Box
+            component="form"
+            sx={{
+              marginBottom: `${(16 / 1080) * 100}vh`,
+              paddingX: `${(16 / 1920) * 100}vw`,
+              paddingY: `${(12 / 1080) * 100}vh`,
+              // width: `${(513 / 1920) * 100}vw`,
+              height: `${(60 / 1080) * 100}vh`,
+              backgroundColor: '#FFF',
+            }}
+          >
+            <SearchIcon />
+            <InputBase
+              placeholder=" 사용자 검색"
+              onChange={(event) => handleSearch(event)}
+              sx={{
+                color: '#737791',
+                fontFamily: 'Poppins',
+                fontSize: `20px`,
+                fontStyle: 'normal',
+                fontWeight: 500,
+                // lineHeight: `${(20 / 1080) * 100}vh`,
+              }}
+            />
+          </Box>
 
-      {isLoading ? (
-        <CircularProgress />
-      ) : (
-        <DataGrid
-          rows={searchedUsers.length > 0 ? searchedUsers : allUsers}
-          columns={columns.map((column) =>
-            column.field === 'type'
-              ? { ...column, editable: true } // Enable editing for the "type" field
-              : column
-          )}
-          pageSize={5}
-          pageSizeOptions={[5, 10, 20]}
-          pagination
-          autoHeight
-          onEditCellChange={handleCellEdit} // Attach the event handler for cell edits
-          initialState={{
-            pagination: {
-              paginationModel: {
-                pageSize: 5,
+          <div style={{ marginLeft: 'auto' }}>
+            <OverlayTrigger
+              placement="top"
+              delay={{ show: 250, hide: 400 }}
+              overlay={renderTooltip}
+            >
+              <Button
+                className="mb-3"
+                onClick={handleRegisterShow}
+                style={{
+                  display: 'inline-flex',
+                  paddingX: `${(12 / 1920) * 100}vw`,
+                  paddingY: `${(16 / 1080) * 100}vh`,
+                  alignItems: 'center',
+                  gap: `${(8 / 1920) * 100}vw`,
+                  borderRadius: `${(10 / 1920) * 100}vw`,
+                  background: '#32CD32',
+                  borderColor: '#32CD32',
+                }}
+              >
+                <IoMdPersonAdd />
+              </Button>
+            </OverlayTrigger>
+          </div>
+        </div>
+
+        {isLoading ? (
+          <CircularProgress />
+        ) : (
+          <DataGrid
+            rows={searchedUsers.length > 0 ? searchedUsers : allUsers}
+            columns={columns.map((column) =>
+              column.field === 'type'
+                ? { ...column, editable: true } // Enable editing for the "type" field
+                : column
+            )}
+            pageSize={5}
+            pageSizeOptions={[5, 10, 20]}
+            pagination
+            autoHeight
+            onEditCellChange={handleCellEdit} // Attach the event handler for cell edits
+            initialState={{
+              pagination: {
+                paginationModel: {
+                  pageSize: 5,
+                },
               },
-            },
-          }}
-          //pageSizeOptions={[5]}
-          disableRowSelectionOnClick
-          sx={{
-            width: `${(1470 / 1920) * 100}vw`,
-            height: `${(560 / 1080) * 100}vh`,
-            flexShrink: 0,
-            borderRadius: `${(20 / 1920) * 100}vw`,
-            border: '1px solid #F8F9FA',
-            backgroundColor: '#FFF',
-            boxShadow: `${(0 / 1920) * 100}vw ${(4 / 1080) * 100}vh ${
-              (20 / 1920) * 100
-            }vw ${(0 / 1080) * 100}vh rgba(238, 238, 238, 0.50)`,
-          }}
+            }}
+            //pageSizeOptions={[5]}
+            disableRowSelectionOnClick
+            sx={{
+              width: `${(1470 / 1920) * 100}vw`,
+              height: `${(560 / 1080) * 100}vh`,
+              flexShrink: 0,
+              borderRadius: `${(20 / 1920) * 100}vw`,
+              border: '1px solid #F8F9FA',
+              backgroundColor: '#FFF',
+              boxShadow: `${(0 / 1920) * 100}vw ${(4 / 1080) * 100}vh ${
+                (20 / 1920) * 100
+              }vw ${(0 / 1080) * 100}vh rgba(238, 238, 238, 0.50)`,
+              minWidth: '700px',
+            }}
+          />
+        )}
+        <CustomSnackbar
+          open={snackbarOpen}
+          message={snackbarMessage}
+          severity={snackbarSeverity}
+          onClose={closeSnackbar}
         />
-      )}
-      <CustomSnackbar
-        open={snackbarOpen}
-        message={snackbarMessage}
-        severity={snackbarSeverity}
-        onClose={closeSnackbar}
-      />
+      </div>
     </div>
   );
 }

--- a/test-web/src/routes/Dashboard.js
+++ b/test-web/src/routes/Dashboard.js
@@ -179,7 +179,7 @@ function Dashboard() {
                 setValue(e.target.value);
               }}
             >
-              통계
+              현황
             </Button>
           )}
         </div>

--- a/test-web/src/routes/Dashboard.js
+++ b/test-web/src/routes/Dashboard.js
@@ -37,15 +37,15 @@ function Dashboard() {
   // 쿼리스트링 추출
   const location = useLocation();
   const searchParams = new URLSearchParams(location.search);
-  
+
   const pageOffset = new URLSearchParams(searchParams).get('pageOffset');
   const queryStartDate = new URLSearchParams(searchParams).get('startDate');
   const queryEndDate = new URLSearchParams(searchParams).get('endDate');
   const queryDuration = searchParams.get('duration');
 
   const now = new Date();
-    let start = new Date(now);
-    let end = new Date(now);
+  let start = new Date(now);
+  let end = new Date(now);
 
   useEffect(() => {
     if (queryDuration) {
@@ -77,13 +77,16 @@ function Dashboard() {
       // 기본값 설정 (7일 전부터 현재까지)
       start.setDate(now.getDate() - 7);
     }
-  
-    const formattedStartDate = new Date(start.getTime() + TIME_ZONE).toISOString().slice(0, -5);
-    const formattedEndDate = new Date(end.getTime() + TIME_ZONE).toISOString().slice(0, -5);
-  
+
+    const formattedStartDate = new Date(start.getTime() + TIME_ZONE)
+      .toISOString()
+      .slice(0, -5);
+    const formattedEndDate = new Date(end.getTime() + TIME_ZONE)
+      .toISOString()
+      .slice(0, -5);
+
     setStartDate(formattedStartDate);
     setEndDate(formattedEndDate);
-  
   }, [searchParams]);
 
   const handleDataFetch = (fetchedData) => {
@@ -97,7 +100,7 @@ function Dashboard() {
   return (
     <div
       style={{
-        overflow: 'overlay',
+        overflow: 'auto',
         width: '100%',
         marginTop: '100px',
         height: '100%',
@@ -111,6 +114,7 @@ function Dashboard() {
           display: 'flex',
           justifyContent: 'space-between',
           alignItems: 'center',
+          minWidth: '634px', // minimum width
         }}
       >
         {value === 'reject' ? (
@@ -246,6 +250,7 @@ const styles = {
     alignItems: 'center', // Add this line to vertically align items
     backgroundColor: 'white',
     margin: '10px 0px',
+    minWidth: '720px', // 특정 픽셀 이하로 줄어들지 않도록 설정
   },
   fixedTab: {
     right: '0',
@@ -256,6 +261,7 @@ const styles = {
     marginTop: '30px',
     borderBottom: 'solid rgba(0, 0, 0, 0.12)',
     borderBottomWidth: 'thin',
+    minWidth: '720px', // 특정 픽셀 이하로 줄어들지 않도록 설정
   },
   tabBtn: {
     border: 'none',

--- a/test-web/src/routes/DataConfirm.js
+++ b/test-web/src/routes/DataConfirm.js
@@ -13,7 +13,14 @@ function DataConfirm() {
   const startDate = new URLSearchParams(searchParams).get('startDate');
   const endDate = new URLSearchParams(searchParams).get('endDate');
   return (
-    <Box sx={{ display: 'flex' }}>
+    <Box
+      style={{
+        display: 'flex',
+        width: '100%',
+        height: '100%',
+        padding: '100px 80px',
+      }}
+    >
       <Box sx={style.fixed}>
         <div
           style={{ display: 'flex', alignItems: 'center', marginLeft: '10px' }}

--- a/test-web/src/routes/DataEdit.js
+++ b/test-web/src/routes/DataEdit.js
@@ -18,7 +18,13 @@ function DataEdit() {
   const idParam = useParams();
 
   return (
-    <Box style={{ width: '100%', padding: '0px 80px' }}>
+    <Box
+      style={{
+        width: '100%',
+        height: '100%',
+        padding: '45px 80px',
+      }}
+    >
       <Box>
         {/**데이터 목록으로 돌아가기 위한 컴포넌트 */}
         <div style={style.fixed}>

--- a/test-web/src/routes/DataPredict.js
+++ b/test-web/src/routes/DataPredict.js
@@ -17,7 +17,7 @@ function DataPredict() {
   console.log('예측', { pageOffset, startDate, endDate });
 
   return (
-    <Box sx={{ width: '100%', padding: '0px 80px' }}>
+    <Box sx={{ width: '100%', height: '100%', padding: '80px 80px' }}>
       <Box>
         {/**데이터 목록으로 돌아가기 위한 컴포넌트 */}
         <div style={style.fixed}>

--- a/test-web/src/routes/Home.js
+++ b/test-web/src/routes/Home.js
@@ -81,69 +81,82 @@ function Home() {
   };
 
   return (
-    <Container maxWidth="md">
-      <Typography
-        variant="h4" // Typography의 variant를 조정하여 원하는 스타일과 크기를 선택할 수 있습니다.
-        sx={{
-          color: '#151D48',
-          fontFamily: 'Poppins',
-          fontSize: `${(36 / 1920) * 100}vw`, // 상대적인 크기
-          fontStyle: 'normal',
-          fontWeight: 600,
-          lineHeight: `${(50.4 / 1080) * 100}vh`, // 상대적인 크기
-          marginBottom: `${(58 / 1080) * 100}vh`,
-        }}
-      >
-        원하시는 작업을 선택해주세요
-      </Typography>
-      <Grid container spacing={5}>
-        {cards.map((card) => (
-          <Grid item xs={12} sm={4} md={4} lg={4} key={card.title}>
-            <Box
-              sx={{
-                width: `${(261 / 1920) * 100}vw`, // Relative width
-                height: `${(260 / 1080) * 100}vh`, // Relative height
-                border: `${(1 / 1920) * 100}vw solid rgba(238, 238, 238, 0.50)`, // Relative border
-                borderRadius: `${(40 / 1920) * 100}vw`, // Relative border radius
-                overflow: 'hidden',
-                backgroundColor: 'white',
-                boxShadow: `${(0 / 1920) * 100}vw ${(4 / 1080) * 100}vh ${(20 / 1920) * 100}vw 0px rgba(238, 238, 238, 0.50)`, // Relative boxShadow
-                padding: `${(20 / 1920) * 100}vw ${(20 / 1080) * 100}vh`, // Relative padding
-              }}
-            >
-              <CardActionArea onClick={() => handleCardClick(card.link)}>
-                <CardMedia
-                  sx={{
-                    ...card.imageSize,
-                    margin: ' auto',
-                  }}
-                  image={card.image}
-                />
-                <CardContent>
-                  <Typography
-                    sx={{ textAlign: 'center' }}
-                    gutterBottom
-                    variant="h6"
-                    component="div"
-                  >
-                    {card.title}
-                  </Typography>
-                </CardContent>
-              </CardActionArea>
-            </Box>
-          </Grid>
-        ))}
-      </Grid>
-      <Snackbar
-        open={openSnackbar}
-        autoHideDuration={3000}
-        onClose={handleCloseSnackbar}
-      >
-        <Alert onClose={handleCloseSnackbar} severity="error">
-          권한이 없습니다
-        </Alert>
-      </Snackbar>
-    </Container>
+    <div
+      style={{
+        // alignContent: 'center',
+        overflow: 'auto',
+        // width: '100%',
+        marginTop: '100px',
+        paddingBottom: '100px',
+        // height: '100%',
+        // paddingLeft: '30px',
+        // paddingRight: '20px',
+      }}
+    >
+      <Container maxWidth="md">
+        <Typography
+          variant="h4" // Typography의 variant를 조정하여 원하는 스타일과 크기를 선택할 수 있습니다.
+          sx={{
+            color: '#151D48',
+            fontFamily: 'Poppins',
+            fontSize: `36px`, // 상대적인 크기
+            fontStyle: 'normal',
+            fontWeight: 600,
+            lineHeight: `${(50.4 / 1080) * 100}vh`, // 상대적인 크기
+            marginBottom: `${(58 / 1080) * 100}vh`,
+          }}
+        >
+          원하시는 작업을 선택해주세요
+        </Typography>
+        <Grid container spacing={5}>
+          {cards.map((card) => (
+            <Grid item xs={12} sm={4} md={4} lg={4} key={card.title}>
+              <Box
+                sx={{
+                  // width: `${(260 / 1920) * 100}vw`, // Relative width
+                  // height: `${(260 / 1080) * 100}vh`, // Relative height
+                  border: `${(1 / 1920) * 100}vw solid rgba(238, 238, 238, 0.50)`, // Relative border
+                  borderRadius: `${(40 / 1920) * 100}vw`, // Relative border radius
+                  overflow: 'hidden',
+                  backgroundColor: 'white',
+                  boxShadow: `${(0 / 1920) * 100}vw ${(4 / 1080) * 100}vh ${(20 / 1920) * 100}vw 0px rgba(238, 238, 238, 0.50)`, // Relative boxShadow
+                  padding: `${(20 / 1920) * 100}vw ${(20 / 1080) * 100}vh`, // Relative padding
+                }}
+              >
+                <CardActionArea onClick={() => handleCardClick(card.link)}>
+                  <CardMedia
+                    sx={{
+                      ...card.imageSize,
+                      margin: ' auto',
+                    }}
+                    image={card.image}
+                  />
+                  <CardContent>
+                    <Typography
+                      sx={{ textAlign: 'center' }}
+                      gutterBottom
+                      variant="h6"
+                      component="div"
+                    >
+                      {card.title}
+                    </Typography>
+                  </CardContent>
+                </CardActionArea>
+              </Box>
+            </Grid>
+          ))}
+        </Grid>
+        <Snackbar
+          open={openSnackbar}
+          autoHideDuration={3000}
+          onClose={handleCloseSnackbar}
+        >
+          <Alert onClose={handleCloseSnackbar} severity="error">
+            권한이 없습니다
+          </Alert>
+        </Snackbar>
+      </Container>
+    </div>
   );
 }
 

--- a/test-web/src/routes/Home.js
+++ b/test-web/src/routes/Home.js
@@ -102,7 +102,7 @@ function Home() {
             fontSize: `36px`, // 상대적인 크기
             fontStyle: 'normal',
             fontWeight: 600,
-            lineHeight: `${(50.4 / 1080) * 100}vh`, // 상대적인 크기
+            // lineHeight: `${(50.4 / 1080) * 100}vh`, // 상대적인 크기
             marginBottom: `${(58 / 1080) * 100}vh`,
           }}
         >

--- a/test-web/src/routes/PA.js
+++ b/test-web/src/routes/PA.js
@@ -21,8 +21,8 @@ function PA() {
   const handleValueChange = (newValue) => {
     setValue(newValue);
   };
-  const [value, setValue] = useState('list')
-  const [data, setData] = useState(null)
+  const [value, setValue] = useState('list');
+  const [data, setData] = useState(null);
   /**default 조회 날짜 : 현재 날짜 기준 일주일 전  */
   const s = new Date();
   s.setDate(s.getDate() - 7);
@@ -37,15 +37,15 @@ function PA() {
   // 쿼리스트링 추출
   const location = useLocation();
   const searchParams = new URLSearchParams(location.search);
-  
+
   const pageOffset = new URLSearchParams(searchParams).get('pageOffset');
   const queryStartDate = new URLSearchParams(searchParams).get('startDate');
   const queryEndDate = new URLSearchParams(searchParams).get('endDate');
   const queryDuration = searchParams.get('duration');
 
   const now = new Date();
-    let start = new Date(now);
-    let end = new Date(now);
+  let start = new Date(now);
+  let end = new Date(now);
 
   useEffect(() => {
     if (queryDuration) {
@@ -77,13 +77,16 @@ function PA() {
       // 기본값 설정 (7일 전부터 현재까지)
       start.setDate(now.getDate() - 7);
     }
-  
-    const formattedStartDate = new Date(start.getTime() + TIME_ZONE).toISOString().slice(0, -5);
-    const formattedEndDate = new Date(end.getTime() + TIME_ZONE).toISOString().slice(0, -5);
-  
+
+    const formattedStartDate = new Date(start.getTime() + TIME_ZONE)
+      .toISOString()
+      .slice(0, -5);
+    const formattedEndDate = new Date(end.getTime() + TIME_ZONE)
+      .toISOString()
+      .slice(0, -5);
+
     setStartDate(formattedStartDate);
     setEndDate(formattedEndDate);
-  
   }, [searchParams]);
 
   return (
@@ -105,12 +108,19 @@ function PA() {
           alignItems: 'center',
         }}
       >
-        <span style={{ color: `${navy}`, fontSize: '30px', fontWeight: '600' }}>
+        <span
+          style={{
+            color: `${navy}`,
+            fontSize: '30px',
+            fontWeight: '600',
+            minWidth: '720px', //720보다 좀 더 작아도 됨
+          }}
+        >
           Data prediction
         </span>
       </Box>
-          {/**이동 탭 (목록, 통계 , 반려) */}
-          <Box sx={styles.fixedTab}>
+      {/**이동 탭 (목록, 통계 , 반려) */}
+      <Box sx={styles.fixedTab}>
         <div style={{ display: 'flex' }}>
           <Button
             style={value === 'list' ? styles.tabBtnCilcked : styles.tabBtn}
@@ -163,6 +173,7 @@ const styles = {
     margin: '10px 0px',
     borderBottom: 'solid rgba(0, 0, 0, 0.12)',
     borderBottomWidth: 'thin',
+    minWidth: '720px', // 특정 픽셀 이하로 줄어들지 않도록 설정
   },
   fixedTab: {
     right: '0',
@@ -173,6 +184,7 @@ const styles = {
     marginTop: '30px',
     borderBottom: 'solid rgba(0, 0, 0, 0.12)',
     borderBottomWidth: 'thin',
+    minWidth: '720px', // 특정 픽셀 이하로 줄어들지 않도록 설정
   },
   tabBtn: {
     border: 'none',

--- a/test-web/src/routes/Profile.js
+++ b/test-web/src/routes/Profile.js
@@ -165,170 +165,177 @@ export default function Profile() {
   };
 
   return (
-    <Paper sx={{ p: 2 }}>
-      <div style={{ marginBottom: '1rem' }}>
-        <TextField
-          label="회원가입일"
-          name="createdAt"
-          value={updatedUserInfo.createdAt}
-          disabled
-        />
-      </div>
-      <div style={{ marginBottom: '1rem' }}>
-        <TextField
-          label="업데이트일"
-          name="updatedAt"
-          value={updatedUserInfo.updatedAt}
-          disabled
-        />
-      </div>
-      <div style={{ marginBottom: '1rem' }}>
-        <TextField
-          label="권한"
-          name="type"
-          value={updatedUserInfo.type}
-          disabled
-        />
-      </div>
-      <div style={{ marginBottom: '1rem' }}>
-        <TextField
-          label="이름"
-          name="name"
-          value={name}
-          onChange={handleInputChange}
-        />
-      </div>
-      <div style={{ marginBottom: '1rem' }}>
-        <TextField
-          label="직장"
-          name="company"
-          value={company}
-          onChange={handleInputChange}
-        />
-      </div>
-      <div style={{ marginBottom: '1rem' }}>
-        <TextField
-          label="직책"
-          name="jobTitle"
-          value={jobTitle}
-          onChange={handleInputChange}
-        />
-      </div>
-      <div style={{ marginBottom: '1rem' }}>
-        <TextField
-          label="주소"
-          name="homeAddr"
-          value={homeAddr}
-          onChange={handleInputChange}
-        />
-      </div>
-      <div style={{ display: 'flex', justifyContent: 'center' }}>
-        <Button
-          style={{ margin: '0.5rem' }}
-          variant="contained"
-          onClick={updateUserInfo}
-          disabled={isUpdating}
-        >
-          {isUpdating ? <CircularProgress size={24} /> : '정보 수정'}
-        </Button>
-        <Button
-          variant="contained"
-          onClick={handleOpenPasswordModal}
-          style={{ backgroundColor: 'red', color: 'white', margin: '0.5rem' }}
-        >
-          회원 탈퇴
-        </Button>
-      </div>
-
-      <Modal
-        open={isPasswordModalOpen}
-        onClose={handleClosePasswordModal}
-        aria-labelledby="password-modal"
-        aria-describedby="password-modal-description"
-      >
-        <Box
-          sx={{
-            position: 'absolute',
-            width: 300,
-            backgroundColor: 'white',
-            borderRadius: 8,
-            boxShadow: 5,
-            p: 2,
-            top: '50%',
-            left: '50%',
-            transform: 'translate(-50%, -50%)',
-            textAlign: 'center',
-          }}
-        >
-          <Typography variant="h6" id="password-modal-title" component="div">
-            비밀번호 확인
-          </Typography>
+    <div
+      style={{
+        paddingTop: '100px',
+        minHeight: '0px',
+      }}
+    >
+      <Paper sx={{ p: 2 }}>
+        <div style={{ marginBottom: '1rem' }}>
           <TextField
-            label="비밀번호"
-            type="password"
-            value={password}
-            onChange={handlePasswordChange}
-            sx={{ mt: 2, mb: 2 }}
-            fullWidth
+            label="회원가입일"
+            name="createdAt"
+            value={updatedUserInfo.createdAt}
+            disabled
           />
-          <Button variant="contained" onClick={reauthenticate}>
-            확인
+        </div>
+        <div style={{ marginBottom: '1rem' }}>
+          <TextField
+            label="업데이트일"
+            name="updatedAt"
+            value={updatedUserInfo.updatedAt}
+            disabled
+          />
+        </div>
+        <div style={{ marginBottom: '1rem' }}>
+          <TextField
+            label="권한"
+            name="type"
+            value={updatedUserInfo.type}
+            disabled
+          />
+        </div>
+        <div style={{ marginBottom: '1rem' }}>
+          <TextField
+            label="이름"
+            name="name"
+            value={name}
+            onChange={handleInputChange}
+          />
+        </div>
+        <div style={{ marginBottom: '1rem' }}>
+          <TextField
+            label="직장"
+            name="company"
+            value={company}
+            onChange={handleInputChange}
+          />
+        </div>
+        <div style={{ marginBottom: '1rem' }}>
+          <TextField
+            label="직책"
+            name="jobTitle"
+            value={jobTitle}
+            onChange={handleInputChange}
+          />
+        </div>
+        <div style={{ marginBottom: '1rem' }}>
+          <TextField
+            label="주소"
+            name="homeAddr"
+            value={homeAddr}
+            onChange={handleInputChange}
+          />
+        </div>
+        <div style={{ display: 'flex', justifyContent: 'center' }}>
+          <Button
+            style={{ margin: '0.5rem' }}
+            variant="contained"
+            onClick={updateUserInfo}
+            disabled={isUpdating}
+          >
+            {isUpdating ? <CircularProgress size={24} /> : '정보 수정'}
           </Button>
           <Button
             variant="contained"
-            onClick={handleClosePasswordModal}
-            style={{ marginLeft: '1rem' }}
+            onClick={handleOpenPasswordModal}
+            style={{ backgroundColor: 'red', color: 'white', margin: '0.5rem' }}
           >
-            취소
+            회원 탈퇴
           </Button>
-        </Box>
-      </Modal>
+        </div>
 
-      <Modal
-        open={isConfirmModalOpen}
-        onClose={handleCloseConfirmModal}
-        aria-labelledby="confirm-delete-modal"
-        aria-describedby="confirm-delete-description"
-      >
-        <Box
-          sx={{
-            position: 'absolute',
-            width: 300,
-            backgroundColor: 'white',
-            borderRadius: 8, // 더 둥글게
-            boxShadow: 5, // 그림자 추가
-            p: 2,
-            top: '50%',
-            left: '50%',
-            transform: 'translate(-50%, -50%)',
-            textAlign: 'center',
-          }}
+        <Modal
+          open={isPasswordModalOpen}
+          onClose={handleClosePasswordModal}
+          aria-labelledby="password-modal"
+          aria-describedby="password-modal-description"
         >
-          <Typography variant="h6" id="modal-modal-title" component="div">
-            회원 탈퇴 확인
-          </Typography>
-          <Typography id="modal-modal-description" sx={{ mt: 2 }}>
-            정말로 회원 탈퇴하시겠습니까? <br />이 작업은 취소할 수 없습니다.
-          </Typography>
-          <Button variant="contained" onClick={deleteself}>
-            확인
-          </Button>
-          <Button
-            variant="contained"
-            onClick={handleCloseConfirmModal}
-            style={{ marginLeft: '1rem' }}
+          <Box
+            sx={{
+              position: 'absolute',
+              width: 300,
+              backgroundColor: 'white',
+              borderRadius: 8,
+              boxShadow: 5,
+              p: 2,
+              top: '50%',
+              left: '50%',
+              transform: 'translate(-50%, -50%)',
+              textAlign: 'center',
+            }}
           >
-            취소
-          </Button>
-        </Box>
-      </Modal>
+            <Typography variant="h6" id="password-modal-title" component="div">
+              비밀번호 확인
+            </Typography>
+            <TextField
+              label="비밀번호"
+              type="password"
+              value={password}
+              onChange={handlePasswordChange}
+              sx={{ mt: 2, mb: 2 }}
+              fullWidth
+            />
+            <Button variant="contained" onClick={reauthenticate}>
+              확인
+            </Button>
+            <Button
+              variant="contained"
+              onClick={handleClosePasswordModal}
+              style={{ marginLeft: '1rem' }}
+            >
+              취소
+            </Button>
+          </Box>
+        </Modal>
 
-      <CustomSnackbar
-        open={snackbarOpen}
-        message={snackbarMessage}
-        severity={snackbarSeverity}
-        onClose={closeSnackbar}
-      />
-    </Paper>
+        <Modal
+          open={isConfirmModalOpen}
+          onClose={handleCloseConfirmModal}
+          aria-labelledby="confirm-delete-modal"
+          aria-describedby="confirm-delete-description"
+        >
+          <Box
+            sx={{
+              position: 'absolute',
+              width: 300,
+              backgroundColor: 'white',
+              borderRadius: 8, // 더 둥글게
+              boxShadow: 5, // 그림자 추가
+              p: 2,
+              top: '50%',
+              left: '50%',
+              transform: 'translate(-50%, -50%)',
+              textAlign: 'center',
+            }}
+          >
+            <Typography variant="h6" id="modal-modal-title" component="div">
+              회원 탈퇴 확인
+            </Typography>
+            <Typography id="modal-modal-description" sx={{ mt: 2 }}>
+              정말로 회원 탈퇴하시겠습니까? <br />이 작업은 취소할 수 없습니다.
+            </Typography>
+            <Button variant="contained" onClick={deleteself}>
+              확인
+            </Button>
+            <Button
+              variant="contained"
+              onClick={handleCloseConfirmModal}
+              style={{ marginLeft: '1rem' }}
+            >
+              취소
+            </Button>
+          </Box>
+        </Modal>
+
+        <CustomSnackbar
+          open={snackbarOpen}
+          message={snackbarMessage}
+          severity={snackbarSeverity}
+          onClose={closeSnackbar}
+        />
+      </Paper>
+    </div>
   );
 }

--- a/test-web/src/routes/Stats.js
+++ b/test-web/src/routes/Stats.js
@@ -18,11 +18,11 @@ function Stats() {
     const queryStartDate = searchParams.get('startDate');
     const queryEndDate = searchParams.get('endDate');
     const queryDuration = searchParams.get('duration');
-  
+
     const now = new Date();
     let start = new Date(now);
     let end = new Date(now);
-  
+
     if (queryDuration) {
       // duration 파라미터에 따라 시작 날짜 설정
       switch (queryDuration) {
@@ -52,13 +52,16 @@ function Stats() {
       // 기본값 설정 (7일 전부터 현재까지)
       start.setDate(now.getDate() - 7);
     }
-  
-    const formattedStartDate = new Date(start.getTime() + TIME_ZONE).toISOString().slice(0, -5);
-    const formattedEndDate = new Date(end.getTime() + TIME_ZONE).toISOString().slice(0, -5);
-  
+
+    const formattedStartDate = new Date(start.getTime() + TIME_ZONE)
+      .toISOString()
+      .slice(0, -5);
+    const formattedEndDate = new Date(end.getTime() + TIME_ZONE)
+      .toISOString()
+      .slice(0, -5);
+
     setStartDate(formattedStartDate);
     setEndDate(formattedEndDate);
-  
   }, [searchParams]);
 
   return (
@@ -77,10 +80,10 @@ function Stats() {
           style={{
             color: '#151D48',
             fontFamily: 'Poppins',
-            fontSize: `${(36 / 1920) * 100}vw`,
+            fontSize: `30px`,
             fontStyle: 'normal',
             fontWeight: 600,
-            lineHeight: `${(36 / 1920) * 100 * 1.4}vw`,
+            // lineHeight: `${(36 / 1920) * 100 * 1.4}vw`,
           }}
         >
           Statistics Analysis


### PR DESCRIPTION
![Screenshot 2024-07-17 at 10 32 26](https://github.com/user-attachments/assets/ffa7ec0f-1a27-4a49-b3b1-cbbfad5a5fdc)
![Screenshot 2024-07-17 at 10 36 18](https://github.com/user-attachments/assets/30b98fcf-68c4-441d-a1ac-5209f5e1c483)
![Screenshot 2024-07-17 at 10 37 59](https://github.com/user-attachments/assets/5c518dd4-e9f6-45ba-9686-df1cc0d042ac)
![Screenshot 2024-07-17 at 10 37 59](https://github.com/user-attachments/assets/27ad2f59-a787-44da-8bfd-2fc586ed1aa4)

- 반응형 웹페이지를 구현하였습니다.
각 페이지(홈, 대시보드, 데이터 상세 뷰, 데이터 예측, 데이터 예측 상세 뷰, 유저 관리)(**통계 부분 작업안함, 프로필 페이지 추가작업 예정**)에 대해, 화면 크기를 줄이면 내부 요소가 반응형으로 줄어 찌그러져 의도대로 표시되지 않던 것을 minWidth를 주로 사용하여 수정하였습니다.
또한 각 페이지에서 브라우저 크기를 줄이면 사이드바 및 툴바에 요소들이 가려지던 문제를 수정하였습니다.
이후 figma에 맞추어 추가 수정해야할 수 있습니다. 
- 사소한 변경사항으로 대시보드 내 육류 통계 탭 이름을 '현황'으로 변경하였고, 해당 페이지에서 서치필터를 통해 데이터가 업데이트 되면, 파이차트에서 토글이 전체로 초기화되도록(의도되로 작동하도록) 수정하였습니다.