### PR TITLE
fix: /meat/get API 수정

### DIFF
--- a/test-backend/test-flask/api/get_api.py
+++ b/test-backend/test-flask/api/get_api.py
@@ -23,26 +23,27 @@ get_api = Blueprint("get_api", __name__)
 
 
 # 전체 육류 데이터 출력
-@get_api.route("/", methods=["GET", "POST"])
+@get_api.route("/", methods=["GET"])
 def getMeatData():
     try:
-        if request.method == "GET":
-            db_session = current_app.db_session
-            offset = request.args.get("offset")
-            count = request.args.get("count")
-            start = request.args.get("start")
-            end = request.args.get("end")
-            return get_range_meat_data(db_session, offset, count, start, end).get_json()
-
+        db_session = current_app.db_session
+        offset = request.args.get("offset")
+        count = request.args.get("count")
+        start = request.args.get("start")
+        end = request.args.get("end")
+        specie = request.args.get("specieValue")
+        if specie == '전체':
+            specie_value = 2
         else:
-            return jsonify({"msg": "Invalid Route, Please Try Again."}), 404
+            specie_value = species.index(specie)
+        return get_range_meat_data(db_session, offset, count, start, end, specie_value).get_json()
     except Exception as e:
         logger.exception(str(e))
         return (
             jsonify(
                 {"msg": "Server Error", "time": datetime.now().strftime("%H:%M:%S")}
             ),
-            505,
+            500,
         )
 
 

--- a/test-backend/test-flask/db/db_controller.py
+++ b/test-backend/test-flask/db/db_controller.py
@@ -614,7 +614,7 @@ def get_range_meat_data(
         db_total_len = query.filter(
             Meat.createdAt.between(start, end)
         ).count()
-    query = query.offset(offset).limit(count)
+    query = query.order_by(Meat.createdAt.desc()).offset(offset).limit(count)
 
     # 탐색
     meat_data = query.all()

--- a/test-backend/test-flask/db/db_controller.py
+++ b/test-backend/test-flask/db/db_controller.py
@@ -403,7 +403,7 @@ def create_specific_probexpt_data(db_session, data):
 
 # GET
 def get_meat(db_session, id):
-    # 1. 원육 데이터 가져오기
+    # 1. 원육 데이터 조회
     meat = db_session.query(Meat).filter_by(id = id).first()
 
     if meat is None:
@@ -417,7 +417,8 @@ def get_meat(db_session, id):
         .filter_by(id = result["statusType"])
         .first()
     )
-    # 참조관계 또는 날짜 데이터 형식 변환
+    
+    # 2. 참조관계 또는 날짜 데이터 형식 변환
     result["sexType"] = sexType.value
     (
         result["specieValue"],
@@ -432,13 +433,13 @@ def get_meat(db_session, id):
     result["butcheryYmd"] = convert2string(result["butcheryYmd"], 2)
     result["birthYmd"] = convert2string(result["birthYmd"], 2)
 
-    # user info
+    # 3. 유저 정보 추가
     user = get_user(db_session, meat.userId)
     result["userName"] = user.name
     result["userType"] = usrType[user.type]
     result["company"] = user.company
 
-    # 6. freshmeat , heatedmeat, probexpt
+    # 4. 딥에이징 정보 - 관능데이터, 실험실데이터
     number_of_deep_aging_data = (db_session.query(func.max(DeepAgingInfo.seqno))
                                  .filter_by(id = id)
                                  .scalar())

--- a/test-backend/test-flask/utils.py
+++ b/test-backend/test-flask/utils.py
@@ -190,7 +190,7 @@ def convert2datetime(date_string, format):
         return date_string
     if format == 0:
         return datetime.strptime(date_string, "%Y-%m-%dT%H:%M:%S")
-    if format == 1:
+    elif format == 1:
         tz = pytz.timezone("Asia/Seoul")
         return datetime.now(tz).strftime("%Y-%m-%dT%H:%M:%S")
     elif format == 2:
@@ -244,7 +244,7 @@ def item_encoder(data_dict, item, input_data=None):
         "juiciness",
         "tenderness",
         "umami",
-        "palability",
+        "palatability",
         "L",
         "a",
         "b",


### PR DESCRIPTION
## 수정한 점
- `/meat/get` API 수정
  - 육류의 종에 따른 분류 추가
  - DTO가 수정됨에 따라 육류 데이터를 등록한 유저의 일부 정보를 추가하도록 하는 코드 추가
  - 데이터 조회 시 정렬하는 기능이 없으므로, 해당 코드 주석 처리
  <img width="1079" alt="스크린샷 2024-07-17 오후 4 08 18" src="https://github.com/user-attachments/assets/49957cf3-cb0c-4817-9347-f401c9e5c1f9">


- `/meat/get/by-meat-id` API 수정 (기존 `/meat/get/by-id`)
  - 수정된 DTO에 따라, 원육과 처리육에 대한 명시적 구분 대신 `deepAgingData` value 배열의 `seqno`를 통해 육류를 구분할 수 있도록 데이터 구성
    - 데이터 구조가 변경됨에 따라 `get_meat()` 함수를 사용하여 육류 데이터를 조회하던 API 등에서 `rawmeat`, `processedmeat` 정보를 지우던 코드가 `deepAgingData`를 지우도록 수정
  - 각 `seqno`에 따른 육류의 세부 데이터를 등록한 유저의 이름이 데이터에 포함되도록 로직 추가
  <img width="1624" alt="스크린샷 2024-07-17 오후 4 12 03" src="https://github.com/user-attachments/assets/73744db9-a93a-432e-94aa-89e1947635a0">

- Status code 설정
- 변수 convention에 따라 수정 