### PR TITLE
hotfix: /meat/get에서 offset, count parameter가 주어지지 않았을 때에 예외 처리 추가

### DIFF
--- a/test-backend/test-flask/db/db_controller.py
+++ b/test-backend/test-flask/db/db_controller.py
@@ -576,9 +576,10 @@ def get_range_meat_data(
     statusType=None,
     company=None,
 ):
-    count = safe_int(count)
-    offset = safe_int(offset)
-    offset = offset*count
+    if count and offset:
+        count = safe_int(count)
+        offset = safe_int(offset)
+        offset = offset*count
     start = convert2datetime(start, 0)
     end = convert2datetime(end, 0)
 
@@ -627,7 +628,9 @@ def get_range_meat_data(
         db_total_len = query.filter(
             Meat.createdAt.between(start, end)
         ).count()
-    query = query.order_by(Meat.createdAt.desc()).offset(offset).limit(count)
+    query = query.order_by(Meat.createdAt.desc())
+    if offset and count:
+        query = query.offset(offset).limit(count)
 
     # 탐색
     meat_data = query.all()


### PR DESCRIPTION
## 수정한 점
- `offset`, `count` 파라미터가 주어지지 않을 경우에 대한 예외 처리 추가