### PR TITLE
fix: /meat/update API 수정

### DIFF
--- a/test-backend/test-flask/api/add_api.py
+++ b/test-backend/test-flask/api/add_api.py
@@ -51,6 +51,8 @@ def add_specific_meat_data():
             )
             if updated_meat_id:
                 return jsonify({"msg": f"Success to update Raw Meat {updated_meat_id} Information"}), 200
+            else:
+                return jsonify({"msg": f"Already Confirmed Meat Data"}), 400
 
     except Exception as e:
         # logger.exception(str(e))

--- a/test-backend/test-flask/api/update_api.py
+++ b/test-backend/test-flask/api/update_api.py
@@ -10,47 +10,39 @@ from utils import *
 update_api = Blueprint("update_api", __name__)
 
 # 육류 데이터 승인 API
-@update_api.route("/confirm", methods=["GET", "POST"])
+@update_api.route("/confirm", methods=["PATCH"])
 def updateConfirmData():
     try:
-        if request.method == "GET":
-            db_session = current_app.db_session
-            id = safe_str(request.args.get("id"))
-            if id:
-                return _updateConfirmData(db_session, id)
-            else:
-                return jsonify("No id parameter"), 401
-
+        db_session = current_app.db_session
+        meat_id = safe_str(request.args.get("meatId"))
+        if meat_id:
+            return _updateConfirmData(db_session, meat_id)
         else:
-            return jsonify({"msg": "Invalid Route, Please Try Again."}), 404
+            return jsonify("No meatId parameter"), 400
     except Exception as e:
-        logger.exception(str(e))
+        # logger.exception(str(e))
         return (
             jsonify(
                 {"msg": "Server Error", "time": datetime.now().strftime("%H:%M:%S")}
             ),
-            505,
+            500,
         )
 
 # 육류 데이터 반려 API
-@update_api.route("/reject", methods=["GET", "POST"])
+@update_api.route("/reject", methods=["PATCH"])
 def updateRejectData():
     try:
-        if request.method == "GET":
-            db_session = current_app.db_session
-            id = safe_str(request.args.get("id"))
-            if id:
-                return _updateRejectData(db_session, id)
-            else:
-                return jsonify("No id parameter"), 401
-
+        db_session = current_app.db_session
+        meat_id = safe_str(request.args.get("meatId"))
+        if meat_id:
+            return _updateRejectData(db_session, meat_id)
         else:
-            return jsonify({"msg": "Invalid Route, Please Try Again."}), 404
+            return jsonify("No meatId parameter"), 400
     except Exception as e:
-        logger.exception(str(e))
+        # logger.exception(str(e))
         return (
             jsonify(
                 {"msg": "Server Error", "time": datetime.now().strftime("%H:%M:%S")}
             ),
-            505,
+            500,
         )

--- a/test-backend/test-flask/db/db_controller.py
+++ b/test-backend/test-flask/db/db_controller.py
@@ -246,7 +246,9 @@ def create_specific_std_meat_data(db_session, s3_conn, firestore_conn, data, mea
 
         else: 
             existing_meat = db_session.query(Meat).get(meat_id)
-            
+            if existing_meat.statusType == 2:
+                raise Exception("Already accepted Meat Data")
+                
             new_category = db_session.query(CategoryInfo).filter(
                 CategoryInfo.primalValue == data.get("primalValue"),
                 CategoryInfo.secondaryValue == data.get("secondaryValue")
@@ -978,7 +980,7 @@ def _updateConfirmData(db_session, id):
         meat.statusType = 2
         db_session.merge(meat)
         db_session.commit()
-        return jsonify(id), 200
+        return jsonify({"msg": "Success to update StatusType"}), 200
     else:
         return jsonify({"msg": "No Data In Meat DB"}), 404
 
@@ -989,7 +991,7 @@ def _updateRejectData(db_session, id):
         meat.statusType = 1
         db_session.merge(meat)
         db_session.commit()
-        return jsonify(id), 200
+        return jsonify({"msg": "Success to update StatusType"}), 200
     else:
         return jsonify({"msg": "No Data In Meat DB"}), 404
 

--- a/test-backend/test-flask/db/db_controller.py
+++ b/test-backend/test-flask/db/db_controller.py
@@ -247,7 +247,7 @@ def create_specific_std_meat_data(db_session, s3_conn, firestore_conn, data, mea
         else: 
             existing_meat = db_session.query(Meat).get(meat_id)
             if existing_meat.statusType == 2:
-                raise Exception("Already accepted Meat Data")
+                raise Exception("Already Confirmed Meat Data")
                 
             new_category = db_session.query(CategoryInfo).filter(
                 CategoryInfo.primalValue == data.get("primalValue"),
@@ -976,24 +976,24 @@ def get_AI_SensoryEval(db_session, id, seqno):
 
 def _updateConfirmData(db_session, id):
     meat = db_session.query(Meat).get(id)  # DB에 있는 육류 정보
-    if meat:
+    if meat and meat.statusType != 2:
         meat.statusType = 2
         db_session.merge(meat)
         db_session.commit()
         return jsonify({"msg": "Success to update StatusType"}), 200
     else:
-        return jsonify({"msg": "No Data In Meat DB"}), 404
+        return jsonify({"msg": "No Data In Meat DB or Already Confirmed"}), 404
 
 
 def _updateRejectData(db_session, id):
     meat = db_session.query(Meat).get(id)  # DB에 있는 육류 정보
-    if meat:
+    if meat and meat.statusType != 1:
         meat.statusType = 1
         db_session.merge(meat)
         db_session.commit()
         return jsonify({"msg": "Success to update StatusType"}), 200
     else:
-        return jsonify({"msg": "No Data In Meat DB"}), 404
+        return jsonify({"msg": "No Data In Meat DB or Already Rejected"}), 404
 
 
 def _addSpecificPredictData(db_session, data):

--- a/test-backend/test-flask/db/db_controller.py
+++ b/test-backend/test-flask/db/db_controller.py
@@ -247,7 +247,7 @@ def create_specific_std_meat_data(db_session, s3_conn, firestore_conn, data, mea
         else: 
             existing_meat = db_session.query(Meat).get(meat_id)
             if existing_meat.statusType == 2:
-                raise Exception("Already Confirmed Meat Data")
+                return None
                 
             new_category = db_session.query(CategoryInfo).filter(
                 CategoryInfo.primalValue == data.get("primalValue"),


### PR DESCRIPTION
## 주요 수정 사항
### 1) /meat/update/confirm & /meat/update/reject
- DTO에 맞게 meatId 수정
- Server Error Status Code는 500번으로 수정
- 만약 이미 승인된/반려된 육류를 처리하고자 할 경우 에러 처리
<img width="400" alt="스크린샷 2024-07-17 오후 5 43 21" src="https://github.com/user-attachments/assets/5b6c37c8-ce4b-40f2-90f9-9adc40a7a249">
<img width="400" alt="스크린샷 2024-07-17 오후 5 43 31" src="https://github.com/user-attachments/assets/e3bbc3ad-c5c9-4c0e-ba33-5bcebc7b73f9">

### 2) /meat/add
- PATCH 메소드에서 기존의 육류가 이미 승인된 상태일 때 수정하지 못하도록 에러 처리

