### PR TITLE
fix: /meat/add/deep-aging-data API 수정

### DIFF
--- a/test-backend/test-flask/api/add_api.py
+++ b/test-backend/test-flask/api/add_api.py
@@ -62,7 +62,7 @@ def add_specific_meat_data():
         )
 
 
-# 특정 육류의 딥 에이징 이력 생성 및 수정
+# 특정 육류의 딥 에이징 이력 생성
 @add_api.route("/deep-aging-data", methods=["POST"])
 def add_specific_deepAging_data():
     try:

--- a/test-backend/test-flask/api/add_api.py
+++ b/test-backend/test-flask/api/add_api.py
@@ -9,7 +9,7 @@ from db.db_controller import (
     create_specific_std_meat_data,
     create_specific_sensoryEval,
     create_specific_probexpt_data,
-    create_specific_deep_aging_meat_data,
+    create_specific_deep_aging_data,
     create_specific_heatedmeat_seonsory_data,
     _addSpecificPredictData,
     get_meat,
@@ -63,33 +63,27 @@ def add_specific_meat_data():
 
 
 # 특정 육류의 딥 에이징 이력 생성 및 수정
-@add_api.route("/deep-aging-data", methods=["GET", "POST"])
+@add_api.route("/deep-aging-data", methods=["POST"])
 def add_specific_deepAging_data():
     try:
-        if request.method == "POST":
-            db_session = current_app.db_session
-            s3_conn = current_app.s3_conn
-            firestore_conn = current_app.firestore_conn
-            data = request.get_json()
-            # print(data)
-            try:
-                return (
-                    create_specific_deep_aging_meat_data(
-                        db_session, s3_conn, firestore_conn, data
-                    ),
-                    200,
-                )
-            except Exception as e:
-                return jsonify({"msg": "Image Path Not Found", "details": str(e)}), 400
+        db_session = current_app.db_session
+        data = request.get_json()
+        if not (data["meatId"] and data["seqno"] and data["deepAging"]):
+            return jsonify({"msg": "Failed to Create Deep Aging Data"}), 400
+        deep_aging_id = create_specific_deep_aging_data(db_session, data)
+        if deep_aging_id:
+            return jsonify({"msg": f"Success to Create Deep Aging Data {deep_aging_id}"}), 200
+        elif deep_aging_id is None:
+            return jsonify({"msg": f"Meat {data["meatId"]} Does NOT Exists"}), 404
         else:
-            return jsonify({"msg": "Invalid Route, Please Try Again."}), 404
+            return jsonify({"msg": f"Seqno {data["seqno"]} Deep Aging Info. Already Exists"}), 400
     except Exception as e:
         logger.exception(str(e))
         return (
             jsonify(
                 {"msg": "Server Error", "time": datetime.now().strftime("%H:%M:%S")}
             ),
-            505,
+            500,
         )
 
 

--- a/test-backend/test-flask/db/db_controller.py
+++ b/test-backend/test-flask/db/db_controller.py
@@ -280,59 +280,32 @@ def create_raw_meat_deep_aging_info(db_session, meat_id):
         raise e
 
 
-def create_specific_deep_aging_meat_data(db_session, s3_conn, firestore_conn, data):
+def create_specific_deep_aging_data(db_session, data):
     # 2. 기본 데이터 받아두기
-    id = data.get("id")
-    seqno = data.get("seqno")
-    deepAging_data = data.get("deepAging")
-    data.pop("deepAging", None)
-    meat = db_session.query(Meat).get(id)  # DB에 있는 육류 정보
-    if id == None:  # 1. 애초에 id가 없는 request
-        raise Exception("No Id in Request Data")
-    sensory_eval = (
-        db_session.query(SensoryEval).filter_by(id=id, seqno=seqno).first()
-    )  # DB에 있는 육류 정보
-    try:
-        if deepAging_data is not None:
-            if meat:  # 승인 정보 확인
-                if meat.statusType != 2:
-                    raise Exception("Not Confirmed Meat Data")
-            if sensory_eval:  # 기존 Deep Aging을 수정하는 경우
-                deepAgingId = sensory_eval.deepAgingId
-                existing_DeepAging = db_session.query(DeepAgingInfo).get(deepAgingId)
-                if existing_DeepAging:
-                    for key, value in deepAging_data.items():
-                        setattr(existing_DeepAging, key, value)
-                    # for key, value in data.items():
-                    #     setattr(sensory_eval, key, value)
-                    new_SensoryEval = create_SensoryEval(data, seqno, id, deepAgingId)
-                    db_session.merge(new_SensoryEval)
-                else:
-                    raise Exception("No Deep Aging Data found for update")
-            else:  # 새로운 Deep aging을 추가하는 경우
-                new_DeepAging = create_DeepAging(deepAging_data)
-                deepAgingId = new_DeepAging.deepAgingId
-                db_session.add(new_DeepAging)
-                db_session.commit()
-                new_SensoryEval = create_SensoryEval(data, seqno, id, deepAgingId)
-                db_session.merge(new_SensoryEval)
+    id = data["meatId"]
+    seqno = data["seqno"]
 
-            db_session.commit()
-            transfer_folder_image(
-                s3_conn,
-                firestore_conn,
-                db_session,
-                f"{id}-{seqno}",
-                new_SensoryEval,
-                "sensory_evals",
-            )
-            
-        else:
-            raise Exception("No deepaging data in request")
+    meat = db_session.query(Meat).get(id) # DB에 있는 육류 정보
+    deep_aging = db_session.query(DeepAgingInfo).filter_by(id=id, seqno=seqno).first() # DB에 있는 딥에이징 정보
+    if not meat:
+        return None
+    if deep_aging:
+        return False
+    
+    new_deep_aging = {
+        "id": id,
+        "seqno": seqno,
+        "date": data["deepAging"]["date"],
+        "minute": data["deepAging"]["minute"]
+    }
+    try:
+        deep_aging_data = DeepAgingInfo(**new_deep_aging)
+        db_session.add(deep_aging_data)
+        db_session.commit()
+        return f"{id}-{seqno}"
     except Exception as e:
         db_session.rollback()
         raise e
-    return jsonify(id)
 
 
 def create_specific_sensoryEval(db_session, s3_conn, firestore_conn, data):


### PR DESCRIPTION
## 수정한 점
### /meat/add/deep-aging-data
- 딥에이징 정보만 추가하는 것으로 로직이 변경되어 s3, firebase 등 불필요한 변수 제거
  - 더 이상 이미지 데이터에 대한 처리를 이 API에서 수행하지 않음
- `create_specifi_deep_aging_meat_data` → `create_specific_deep_aging_data`로 함수명 변경
  - 더 이상 관능데이터 입력 및 수정을 수행하지 않고, 딥에이징 정보만 추가하도록 변경
- 에러 메세지에 따른 Status code 설정
<img width="1616" alt="스크린샷 2024-07-18 오전 1 04 10" src="https://github.com/user-attachments/assets/b14f5445-ea62-4f4b-8904-31297e4cb44d">

