### PR TITLE
fix: /meat/add/sensory-eval API 수정

### DIFF
--- a/test-backend/test-flask/api/add_api.py
+++ b/test-backend/test-flask/api/add_api.py
@@ -95,15 +95,14 @@ def add_specific_sensory_eval():
     try:
         db_session = current_app.db_session
         data = request.get_json()
+        s3_conn = current_app.s3_conn
+        firestore_conn = current_app.firestore_conn
         
         if request.method == "POST":
-            s3_conn = current_app.s3_conn
-            firestore_conn = current_app.firestore_conn
             sensory_data = create_specific_sensory_eval(db_session, s3_conn, firestore_conn, data, is_post=1)
-            return {"msg": sensory_data["msg"], "code": sensory_data["code"]}
         else:
             sensory_data = create_specific_sensory_eval(db_session, s3_conn, firestore_conn, data, is_post=0)
-            return {"msg": sensory_data["msg"], "code": sensory_data["code"]}
+        return {"msg": sensory_data["msg"], "code": sensory_data["code"]}
     except Exception as e:
         logger.exception(str(e))
         return (

--- a/test-backend/test-flask/api/add_api.py
+++ b/test-backend/test-flask/api/add_api.py
@@ -109,7 +109,7 @@ def add_specific_sensory_eval():
             jsonify(
                 {"msg": "Server Error", "time": datetime.now().strftime("%H:%M:%S")}
             ),
-            505,
+            500,
         )
 
 

--- a/test-backend/test-flask/api/add_api.py
+++ b/test-backend/test-flask/api/add_api.py
@@ -6,8 +6,9 @@ from flask import (
 )
 from db.db_controller import (
     create_raw_meat_deep_aging_info,
+    create_specific_sensory_eval,
     create_specific_std_meat_data,
-    create_specific_sensoryEval,
+    # create_specific_sensoryEval,
     create_specific_probexpt_data,
     create_specific_deep_aging_data,
     create_specific_heatedmeat_seonsory_data,
@@ -15,7 +16,6 @@ from db.db_controller import (
     get_meat,
 )
 from utils import *
-import uuid
 
 add_api = Blueprint("add_api", __name__)
 
@@ -39,7 +39,7 @@ def add_specific_meat_data():
                 db_session, s3_conn, firestore_conn, data, meat_id, is_post=1
             )
             if new_meat_id:
-                create_raw_meat_deep_aging_info(db_session, new_meat_id)
+                create_raw_meat_deep_aging_info(db_session, new_meat_id, seqno=0)
                 return jsonify({"msg": "Success to store Raw Meat and Initial DeepAging Information"}), 200
                 
         else: # 기본 원육 정보 수정(PATCH)
@@ -76,9 +76,9 @@ def add_specific_deepAging_data():
         if deep_aging_id:
             return jsonify({"msg": f"Success to Create Deep Aging Data {deep_aging_id}"}), 200
         elif deep_aging_id is None:
-            return jsonify({"msg": f"Meat {data["meatId"]} Does NOT Exists"}), 404
+            return jsonify({"msg": f"Meat {data['meatId']} Does NOT Exists"}), 404
         else:
-            return jsonify({"msg": f"Seqno {data["seqno"]} Deep Aging Info. Already Exists"}), 400
+            return jsonify({"msg": f"Seqno {data['seqno']} Deep Aging Info. Already Exists"}), 400
     except Exception as e:
         logger.exception(str(e))
         return (
@@ -90,24 +90,20 @@ def add_specific_deepAging_data():
 
 
 # 특정 육류의 관능 검사 결과 생성 및 수정
-@add_api.route("/sensory-eval", methods=["GET", "POST"])
+@add_api.route("/sensory-eval", methods=["POST", "PATCH"])
 def add_specific_sensory_eval():
     try:
+        db_session = current_app.db_session
+        data = request.get_json()
+        
         if request.method == "POST":
-            db_session = current_app.db_session
             s3_conn = current_app.s3_conn
             firestore_conn = current_app.firestore_conn
-            data = request.get_json()
-            try:
-                return (
-                    create_specific_sensoryEval(db_session, s3_conn, firestore_conn, data),
-                    200,
-                )
-            except Exception as e:
-                return jsonify({"msg": "Image Path Not Found", "details": str(e)}), 400
-                
+            sensory_data = create_specific_sensory_eval(db_session, s3_conn, firestore_conn, data, is_post=1)
+            return {"msg": sensory_data["msg"], "code": sensory_data["code"]}
         else:
-            return jsonify({"msg": "Invalid Route, Please Try Again."}), 404
+            sensory_data = create_specific_sensory_eval(db_session, s3_conn, firestore_conn, data, is_post=0)
+            return {"msg": sensory_data["msg"], "code": sensory_data["code"]}
     except Exception as e:
         logger.exception(str(e))
         return (

--- a/test-backend/test-flask/api/user_api.py
+++ b/test-backend/test-flask/api/user_api.py
@@ -257,6 +257,10 @@ def delete_user_data():
                 ),
                 401,
             )
+        # Firebase에서 유저 삭제
+        user_record = firebase_auth.get_user_by_email(id)
+        firebase_auth.delete_user(user_record.uid)
+        
         delete_user(db_session, user)
         return (
             jsonify(

--- a/test-backend/test-flask/db/db_controller.py
+++ b/test-backend/test-flask/db/db_controller.py
@@ -354,7 +354,7 @@ def create_specific_sensory_eval(db_session, s3_conn, firestore_conn, data, is_p
                 new_sensory_eval = create_SensoryEval(db_session, data, sensory_data, seqno, meat_id, user_id)
                 db_session.add(new_sensory_eval)
                 db_session.commit()
-                
+
                 if need_img:
                     transfer_folder_image(
                         s3_conn,
@@ -364,6 +364,7 @@ def create_specific_sensory_eval(db_session, s3_conn, firestore_conn, data, is_p
                         new_sensory_eval,
                         "sensory_evals",
                     )
+                db_session.commit()
                 return {"msg": f"Success to Create Sensory Evaluation {meat_id}-{seqno}", "code": 200}
             else:
                 return {"msg": f"No Sensory Data to Create Sensory Evaluation", "code": 400}
@@ -385,8 +386,7 @@ def create_specific_sensory_eval(db_session, s3_conn, firestore_conn, data, is_p
             if any(value is not None for value in sensory_data.values()):
                 new_sensory_eval = create_SensoryEval(db_session, data, sensory_data, seqno, meat_id, existing_user)
                 db_session.merge(new_sensory_eval)
-                db_session.commit()
-                
+
                 if need_img:
                     transfer_folder_image(
                         s3_conn,
@@ -396,6 +396,7 @@ def create_specific_sensory_eval(db_session, s3_conn, firestore_conn, data, is_p
                         new_sensory_eval,
                         "sensory_evals",
                     )
+                db_session.commit()
                 return {"msg": f"Success to Update Sensory Evaluation {meat_id}-{seqno}", "code": 200}
             else:
                 return {"msg": f"No Sensory Data to Update Sensory Evaluation", "code": 400}


### PR DESCRIPTION
## 주요 수정 사항
### 1. `/meat/add/sensory-eval`
#### - POST, PATCH 공통 사항
1) 에러 처리
- POST, PATCH 공통의 에러로 400번
- meat_id가 넘어오지 않았을 때 / 없는 meat_id일 때
<img width="450" src="https://github.com/user-attachments/assets/d4af9f35-adc5-436a-be98-14ab8cb8577d">

- 해당 회차의 deepAging_info 레코드가 존재하는지 확인
<img width="450" src="https://github.com/user-attachments/assets/1fc0a414-d6d5-46f3-ab6e-689c7518a0d5">

- 만약 관능 데이터가 하나도 안 들어올 경우 에러 처리
<img width="450" alt="스크린샷 2024-07-18 오후 3 29 52" src="https://github.com/user-attachments/assets/ff083c56-d2bd-421f-a72d-b9498c1d5a36">

#### - POST 메소드 처리
- 새로운 관능 검사 데이터를 DB에 추가하고, imgAdded = True일 경우 이미지 처리
- 성공할 경우 200번
<img width="450" src="https://github.com/user-attachments/assets/a5d09841-1e05-4917-b56b-9888431345cd">

#### - PATCH 메소드 처리
- 원육일 경우, 승인되지 않은 데이터에 대해서만 처리
- 새로운 관능 검사 데이터를 DB에 추가하고, imgAdded = True일 경우 이미지 처리
- 성공할 경우 200번
<img width="450" src="https://github.com/user-attachments/assets/7973c48e-74bd-4d18-a836-e78e48733beb">

### 2. `calculate_period()`
- 관능 데이터, 실험실 데이터, 가열육 관능 데이터를 추가하고자 할 때 not null 필드인 period를 계산하기 위한 함수 추가

### 3. `/user/delete`
- 유저 삭제할 때 firebase에서 유저 정보를 삭제하는 로직 추가
- db_controller로 옮기려고 하려면 추가적으로 firestore_conn, firebase_admin 등 import할 것들이 여러 개라서 비효율적이라 판단하여 그냥 api 단에서 처리함
