### PR TITLE
fix: /meat/add/heatedmeat-eval API 수정

### DIFF
--- a/test-backend/test-flask/api/add_api.py
+++ b/test-backend/test-flask/api/add_api.py
@@ -112,8 +112,6 @@ def add_specific_sensory_eval():
         )
 
 
-# POST일 때는 app - imagePath, createdAt, period 새로 추가
-# PATCH일 때는 app, web - 현재 코드 그대로
 # 특정 육류의 가열육 관능 검사 결과 생성 및 수정
 @add_api.route("/heatedmeat-eval", methods=["POST", "PATCH"])
 def add_specific_heatedmeat_sensory_eval():

--- a/test-backend/test-flask/api/add_api.py
+++ b/test-backend/test-flask/api/add_api.py
@@ -124,20 +124,21 @@ def add_specific_sensory_eval():
 @add_api.route("/heatedmeat-eval", methods=["POST", "PATCH"])
 def add_specific_heatedmeat_sensory_data():
     try:
+        db_session = current_app.db_session
+        data = request.get_json()
         if request.method == "POST":
-            db_session = current_app.db_session
-            data = request.get_json()
-            if data:
-                return create_specific_heatedmeat_seonsory_data(db_session, data), 200
-        else:
-            return jsonify({"msg": "Invalid Route, Please Try Again."}), 404
+            return jsonify({"msg": "Failed to POST Heatedmeat Sensory Data"}), 400
+        elif request.method == "PATCH":
+            return jsonify({"msg": "Failed to PATCH Heatedmeat Sensory Data"}), 400
+        
+        return create_specific_heatedmeat_seonsory_data(db_session, data), 200
     except Exception as e:
         logger.exception(str(e))
         return (
             jsonify(
                 {"msg": "Server Error", "time": datetime.now().strftime("%H:%M:%S")}
             ),
-            505,
+            500,
         )
 
 

--- a/test-backend/test-flask/db/db_controller.py
+++ b/test-backend/test-flask/db/db_controller.py
@@ -882,11 +882,11 @@ def _getMeatDataByUserType(db_session, userType):
         result = []
         for meat in meats:
             temp = get_meat(db_session, meat.id)
-            userTemp = get_user(db_session, temp.get("userId"))
-            if userTemp:
-                temp["name"] = userTemp.get("name")
+            user_temp = get_user(db_session, temp.get("userId"))
+            if user_temp:
+                temp["name"] = user_temp.get("name")
             else:
-                temp["name"] = userTemp
+                temp["name"] = user_temp
             del temp["processedmeat"]
             del temp["rawmeat"]
             result.append(temp)

--- a/test-backend/test-flask/db/db_controller.py
+++ b/test-backend/test-flask/db/db_controller.py
@@ -434,7 +434,7 @@ def create_specific_heatedmeat_seonsory_eval(db_session, firestore_conn, s3_conn
             
         else: # 생성
             if not is_post: # 생성인데 PATCH 메서드
-                return ({"msg": "Probexpt Data Does NOT Exists", "code": 400})
+                return ({"msg": "Heatedmeat Sensory Data Does NOT Exists", "code": 400})
             sensory_data["userId"] = data["userId"]
             sensory_data["period"] = calculate_period(db_session, id)
             new_sensory_data = create_HeatemeatSensoryEval(sensory_data, id, seqno)
@@ -450,7 +450,7 @@ def create_specific_heatedmeat_seonsory_eval(db_session, firestore_conn, s3_conn
                 "heatedmeat_sensory_evals",
             )
         db_session.commit()
-        return ({"msg": f"Success to {'POST' if is_post else 'PATCH'} Probexpt Data {id}-{seqno}", "code": 200})
+        return ({"msg": f"Success to {'POST' if is_post else 'PATCH'} Heatedmeat Sensory Data {id}-{seqno}", "code": 200})
     except Exception as e:
         db_session.rollback()
         raise e


### PR DESCRIPTION
## 수정한 점
### /meat/add/heatedmeat-eval
- POST, PATCH 메서드 적용
  <img width="1616" alt="스크린샷 2024-07-19 오전 10 29 58" src="https://github.com/user-attachments/assets/96d3e521-ce4b-45ad-ad3e-0dbaa9526707">

- 이미 승인된 원육의 가열 관능데이터를 수정하지 못하도록 설정
  - 대기 중이거나 반려된 원육의 경우 데이터 수정 시 다시 대기 중인 상태로 변경
  <img width="1614" alt="스크린샷 2024-07-19 오전 10 31 18" src="https://github.com/user-attachments/assets/eda9d34d-b325-49b0-afc6-4180e952873c">

- 특정 처리육 혹은 가열육의 원육 데이터와 딥에이징 데이터가 없을 경우 해당 데이터를 생성 및 수정하지 못하도록 설정 
  <img width="1615" alt="스크린샷 2024-07-19 오전 10 33 16" src="https://github.com/user-attachments/assets/75de344a-b3d2-426e-b24e-8022c3d4bdd2">

- 이미 가열 관능데이터가 생성되어 있는 상태이거나 존재하지 않을 때 각각 생성 및 수정하지 못하도록 설정
  <img width="1610" alt="스크린샷 2024-07-19 오전 10 35 24" src="https://github.com/user-attachments/assets/4e82d135-d7c0-4a55-a3bd-fa171a7392cd">



