### PR TITLE
fix: /meat/delete API 수정

### DIFF
--- a/test-backend/test-flask/api/delete_api.py
+++ b/test-backend/test-flask/api/delete_api.py
@@ -4,7 +4,7 @@ from flask import (
     request,
     current_app,
 )
-from db.db_controller import _deleteSpecificMeatData, _deleteSpecificDeepAgingData
+from db.db_controller import _deleteSpecificMeatData, _deleteSpecificDeepAgingData, deleteMeatByIDList
 from utils import *
 
 
@@ -12,30 +12,26 @@ delete_api = Blueprint("delete_api", __name__)
 
 
 # 전체 육류 데이터 삭제
-@delete_api.route("/", methods=["GET", "POST", "DELETE"])
+@delete_api.route("/", methods=["DELETE"])
 def deleteTotalMeatData():
     try:
-        if request.method == "DELETE":
-            db_session = current_app.db_session
-            s3_conn = current_app.s3_conn
-            id_list = request.get_json().get("id")
-            if id_list:
-                for id in id_list:
-                    result = _deleteSpecificMeatData(
-                        db_session, s3_conn, id
-                    )
-                return jsonify({"delete_success": id_list}), 200
+        db_session = current_app.db_session
+        s3_conn = current_app.s3_conn
+        id_list = request.get_json().get("id")
+        
+        if id_list:
+            _, fail = deleteMeatByIDList(db_session, s3_conn, id_list)
+            if not fail:
+                return jsonify({"msg": "Success to Delete ID List"}), 200
             else:
-                return jsonify("No Data in Request"), 404
-        else:
-            return jsonify({"msg": "Invalid Route, Please Try Again."}), 404
+                return jsonify({"msg": f"Fail to Delete ID List: {', '.join([id for id in fail])}"}), 400
     except Exception as e:
         logger.exception(str(e))
         return (
             jsonify(
                 {"msg": "Server Error", "time": datetime.now().strftime("%H:%M:%S")}
             ),
-            505,
+            500,
         )
 
 # 특정 육류 데이터 삭제


### PR DESCRIPTION
## 주요 수정 사항
### 1. /meat/delete
- DELETE 메소드로 수정
- 테이블 간 참조 관계를 지정해줬기 때문에 meat 테이블에서만 delete를 하면 참조 관계로 엮인 sensory_eval, heatedmeat_sensory_eval, proexpt_data, ai_sensory_eval, ai_heatedmeat_sensory_eval 모두 자동으로 삭제됨
- id_list를 받아오기 때문에 해당 list 내부에서 육류 정보 삭제가 실패한 id가 하나라도 있을 경우 400번 에러 발생
<img width="400" alt="스크린샷 2024-07-19 오후 3 05 08" src="https://github.com/user-attachments/assets/d5a80474-e228-4250-8b2b-a1c82e10495d">
<img width="400" alt="스크린샷 2024-07-19 오후 3 05 37" src="https://github.com/user-attachments/assets/071a0c6f-a992-4ddc-94a0-ac78573d8e2d">


### 2. s3_connect.py
- 해당 id를 갖는 육류 이미지를 s3에서 삭제하기 위해서 해당 id로 시작하는 파일명을 갖는 이미지 리스트를 불러와서 해당 리스트를 순회하면서 이미지를 삭제하는 것으로 로직 수정
- 각각의 이미지 삭제를 성공할 때마다 콘솔 로그로 프린트하게 됨
<img width="743" alt="스크린샷 2024-07-19 오후 3 05 58" src="https://github.com/user-attachments/assets/f77734a9-d423-4817-85e0-9ec0073ace5d">

