### PR TITLE
fix: meat api 수정 및 추가

### DIFF
--- a/test-backend/test-flask/api/get_api.py
+++ b/test-backend/test-flask/api/get_api.py
@@ -144,25 +144,26 @@ def getMeatDataByRangeData():
 
 
 # 유저 아이디에 해당하는 육류 데이터 출력
-@get_api.route("/by-user-id", methods=["GET", "POST"])
+@get_api.route("/by-user-id", methods=["GET"])
 def getMeatDataByUserId():
     try:
-        if request.method == "GET":
-            db_session = current_app.db_session
-            userId = request.args.get("userId")
-            if not userId:
-                return jsonify("No userId in parameter"), 401
-            else:
-                return _getMeatDataByUserId(db_session, userId)
-        else:
-            return jsonify({"msg": "Invalid Route, Please Try Again."}), 404
+        db_session = current_app.db_session
+        userId = request.args.get("userId")
+        offset = safe_int(request.args.get("offset"))
+        count = safe_int(request.args.get("count"))
+        start = request.args.get("start")
+        end = request.args.get("end")
+        if not (userId and start and end) or offset is None or count is None:
+            return jsonify("Invalid parameter"), 400
+        meat_by_user = _getMeatDataByUserId(db_session, userId, offset, count, start, end)
+        return jsonify(meat_by_user), 200
     except Exception as e:
         logger.exception(str(e))
         return (
             jsonify(
                 {"msg": "Server Error", "time": datetime.now().strftime("%H:%M:%S")}
             ),
-            505,
+            500,
         )
 
 

--- a/test-backend/test-flask/db/db_controller.py
+++ b/test-backend/test-flask/db/db_controller.py
@@ -802,7 +802,7 @@ def get_all_user(db_session):
     try:
         users = db_session.query(User).all()
         for user in users:
-            user.createdAt = convert2string(user.createdAt, 0)
+            user.createdAt = convert2string(user.createdAt, 1)
         return users
     except Exception as e:
         raise Exception(str(e))
@@ -811,7 +811,7 @@ def get_user(db_session, user_id):
     try:
         user_data = db_session.query(User).filter(User.userId == user_id).first()
         if user_data is not None:
-            user_data.createdAt = convert2string(user_data.createdAt, 0)
+            user_data.createdAt = convert2string(user_data.createdAt, 1)
         return user_data
     except Exception as e:
         raise Exception(str(e))

--- a/test-backend/test-flask/db/db_controller.py
+++ b/test-backend/test-flask/db/db_controller.py
@@ -552,12 +552,11 @@ def get_meat(db_session, id):
         result["deepAgingInfo"].append({
             "date": convert2string(deep_aging_data.date, 2) if sequence != 0 and deep_aging_data else None,
             "minute": deep_aging_data.minute if sequence != 0 and deep_aging_data else None,
-            f"{sequence}":{
-                "sensory_eval": get_SensoryEval(db_session, id, sequence),
-                "heatedmeat_sensory_eval": get_HeatedmeatSensoryEval(db_session, id, sequence),
-                "probexpt_data": get_ProbexptData(db_session, id, sequence, False),
-                "heatedmeat_probexpt_data": get_ProbexptData(db_session, id, sequence, True),
-            }
+            "seqno": f"{sequence}",
+            "sensory_eval": get_SensoryEval(db_session, id, sequence),
+            "heatedmeat_sensory_eval": get_HeatedmeatSensoryEval(db_session, id, sequence),
+            "probexpt_data": get_ProbexptData(db_session, id, sequence, False),
+            "heatedmeat_probexpt_data": get_ProbexptData(db_session, id, sequence, True),
         })
 
     return result


### PR DESCRIPTION
## 추가한 점
### meat/get/by-user-id
- userId에 따라 원하는 범위 내의 육류 데이터(meatId, createdAt, statusType) 조회
  <img width="1107" alt="스크린샷 2024-07-22 오후 5 14 26" src="https://github.com/user-attachments/assets/30a76f26-68ac-4e19-8470-6c61c9ac7b22">


## 수정한 점
- user 및 meat 등의 createdAt 데이터가 문자열로 변환되어 넘겨질 때, "%Y-%m-%dT%H:%M:%S" 형식을 가지도록 통일

### meat/get/by-meat-id
- API의 DTO가 변경됨에 따라 response의 format을 변경
  <img width="1106" alt="스크린샷 2024-07-22 오후 5 12 50" src="https://github.com/user-attachments/assets/49298bd3-55c0-44ba-b446-87d915e49a48">
