### PR TITLE
fix: 대시보드 ux/ui 일부 수정

### DIFF
--- a/test-web/src/components/DataDetailPage/DataConfirmView.js
+++ b/test-web/src/components/DataDetailPage/DataConfirmView.js
@@ -129,6 +129,10 @@ function DataView({ dataProps }) {
   const len = processed_data_seq.length;
 
   const [isLimitedToChangeImage, setIsLimitedToChangeImage] = useState(false);
+  //로그인한 유저 정보
+
+  const userInfo = JSON.parse(localStorage.getItem('UserInfo'));
+  console.log('type:', userInfo);
 
   // 수정 완료 버튼 클릭 시 ,수정된 data api로 전송
   const onClickSubmitBtn = async () => {
@@ -256,22 +260,30 @@ function DataView({ dataProps }) {
 
   return (
     <div style={{ width: '100%', marginTop: '40px' }}>
-      <div style={style.confirmEditBtnWrapper}>
-        <IconButton
-          style={style.acceptBtn}
-          onClick={() => setConfirmVal('confirm')}
-        >
-          <FaRegCheckCircle />
-          승인
-        </IconButton>
-        <IconButton
-          style={style.rejectBtn}
-          onClick={() => setConfirmVal('reject')}
-        >
-          <FaRegTimesCircle />
-          반려
-        </IconButton>
-      </div>
+      {!isUploadingDone && (
+        <div style={divStyle.loadingBackground}>
+          <Spinner />
+          <span style={divStyle.loadingText}>이미지를 업로드 중 입니다..</span>
+        </div>
+      )}
+      {userInfo.type === 'Manager' && (
+        <div style={style.confirmEditBtnWrapper}>
+          <IconButton
+            style={style.acceptBtn}
+            onClick={() => setConfirmVal('confirm')}
+          >
+            <FaRegCheckCircle />
+            승인
+          </IconButton>
+          <IconButton
+            style={style.rejectBtn}
+            onClick={() => setConfirmVal('reject')}
+          >
+            <FaRegTimesCircle />
+            반려
+          </IconButton>
+        </div>
+      )}
 
       {
         // 승인 팝업 페이지
@@ -293,12 +305,6 @@ function DataView({ dataProps }) {
           />
         )
       }
-      {!isUploadingDone && (
-        <div style={divStyle.loadingBackground}>
-          <Spinner />
-          <span style={divStyle.loadingText}>이미지를 업로드 중 입니다..</span>
-        </div>
-      )}
       {
         // 이미지 수정 불가능 팝업 - 일반 사용자임을 알리거나 서버를 확인하라는 경고 메시지
         isLimitedToChangeImage && (

--- a/test-web/src/components/DataListView/DataListComp.js
+++ b/test-web/src/components/DataListView/DataListComp.js
@@ -21,10 +21,9 @@ const DataListComp = ({
   // 한 페이지당 보여줄 개수
   const [count, setCount] = useState(5);
 
-
   // API fetch 데이터 전처리
   const processMeatDatas = (data) => {
-    if (!data || !data['DB Total len'] || !data.id_list || !data.meat_dict) {
+    if (!data || !data.id_list || !data.meat_dict) {
       console.error('올바르지 않은 데이터 형식:', data);
       return;
     }

--- a/test-web/src/components/DataListView/SearchById.js
+++ b/test-web/src/components/DataListView/SearchById.js
@@ -1,26 +1,38 @@
 import React, { useState } from 'react';
 import { apiIP } from '../../config';
-import { HiOutlineSearch } from "react-icons/hi";
+import { HiOutlineSearch } from 'react-icons/hi';
 import { TextField, IconButton, Box } from '@mui/material';
 
 function SearchById({ onDataFetch, onValueChange }) {
   const [id, setId] = useState('');
+  const [error, setError] = useState(false);
 
   const handleChange = (e) => {
-    setId(e.target.value);
+    const { value } = e.target;
+    // 정규식으로 영어/숫자만 허용
+    const regex = /^[a-zA-Z0-9]*$/;
+    if (regex.test(value)) {
+      setId(value);
+      setError(false);
+    } else {
+      setId(value);
+      setError(true);
+    }
   };
 
   const handleSearch = async () => {
+    if (error || !id) return; // error가 있거나 id가 없으면 검색하지 않음
     try {
-      const response = await fetch(`http://${apiIP}/meat/get/by-meat-id?meatId=${id}`);
-      
+      const response = await fetch(
+        `http://${apiIP}/meat/get/by-meat-id?meatId=${id}`
+      );
+
       if (!response.ok) {
         throw new Error('Network response was not ok');
       }
       const data = await response.json();
       onDataFetch(data);
       onValueChange('single');
-
     } catch (error) {
       console.error('Error fetching data:', error);
       onDataFetch(null); // 에러 발생 시 데이터 초기화
@@ -28,38 +40,39 @@ function SearchById({ onDataFetch, onValueChange }) {
   };
 
   return (
-    <Box 
+    <Box
       sx={{
         display: 'flex',
         alignItems: 'center',
         gap: 1, // 간격을 추가하여 인풋과 버튼 사이에 여유 공간을 둡니다.
-        backgroundColor: '#f0f0f0', // 배경색을 설정합니다.
+        backgroundColor: '#ffffff', // 배경색을 설정합니다.
         borderRadius: '4px', // 모서리를 둥글게 설정합니다.
         padding: '5px', // 안쪽 여백을 설정합니다.
       }}
     >
-      <TextField 
-        type="number" 
-        value={id} 
-        onChange={handleChange} 
+      <TextField
+        value={id}
+        onChange={handleChange}
         placeholder="ID"
-        variant="outlined" 
-        size="small" 
-        sx={{ 
+        variant="outlined"
+        size="small"
+        error={error}
+        helperText={error ? '영어와 숫자만 입력할 수 있습니다.' : ''}
+        sx={{
           flex: 1, // 인풋이 가능한 한 넓게 차지하도록 설정합니다.
           backgroundColor: 'white', // 인풋의 배경색을 설정합니다.
           borderRadius: '4px', // 인풋의 모서리를 둥글게 설정합니다.
-        }} 
+        }}
       />
-      <IconButton 
-        onClick={handleSearch} 
-        color="primary" 
-        sx={{ 
+      <IconButton
+        onClick={handleSearch}
+        color="primary"
+        sx={{
           backgroundColor: '#115293', // 버튼의 배경색을 설정합니다.
           color: 'white', // 버튼 아이콘의 색상을 설정합니다.
           '&:hover': {
             backgroundColor: 'Navy', // 호버 시 버튼의 배경색을 설정합니다.
-          }
+          },
         }}
       >
         <HiOutlineSearch />

--- a/test-web/src/routes/Dashboard.js
+++ b/test-web/src/routes/Dashboard.js
@@ -200,21 +200,25 @@ function Dashboard() {
             setStartDate={setStartDate}
             setEndDate={setEndDate}
           />
-          <SearchById
-            onDataFetch={handleDataFetch}
-            onValueChange={handleValueChange}
-          />
-          <Select
-            labelId="species"
-            id="species"
-            value={specieValue}
-            onChange={handleSpeciesChange}
-            label="종류"
-          >
-            <MenuItem value="전체">전체</MenuItem>
-            <MenuItem value="소">소</MenuItem>
-            <MenuItem value="돼지">돼지</MenuItem>
-          </Select>
+          {value === 'list' && (
+            <>
+              <SearchById
+                onDataFetch={handleDataFetch}
+                onValueChange={handleValueChange}
+              />
+              <Select
+                labelId="species"
+                id="species"
+                value={specieValue}
+                onChange={handleSpeciesChange}
+                label="종류"
+              >
+                <MenuItem value="전체">전체</MenuItem>
+                <MenuItem value="소">소</MenuItem>
+                <MenuItem value="돼지">돼지</MenuItem>
+              </Select>
+            </>
+          )}
         </Box>
         <div
           style={{


### PR DESCRIPTION
1. 대시보드 내 "현황" 탭에서 ID 검색, 전체/소/돼지 등 종 선택 필터 보이지 않도록 수정
2. 데이터 승인/반려 페이지에서 로그인 한 유저가 매니저가 아닌 경우 승인/반려 버튼 보이지 않도록 수정 
3. 필터 적용 후 다른 필터로 돌아갈 때, 불러오는 데이터가 없으면(**오류 아니고, 기간 내 육류가 없을때**) 데이터가 업데이트 되지 않고 이전 필터 내 리스트 유지하던 오류 수정
- 필터를 '1개월'에서 '1주'로 바꾸면, 일주일 내 데이터가 없을 시, '1개월' 내 데이터를 계속 유지
- 테스트를 위해 일시적 수정. 데이터가 없을 경우 '데이터 없음'을 출력하도록 최종 수정해야
4. id 검색 기능에 영어, 숫자가 입력되었을 때만 넘어갈 수 있도록 수정. 이외의 값을 입력할 수는 있으나, 에러 헬퍼 메시지 출력 및 값이 클릭해도 전달되지 않음.
![화면 캡처 2024-07-23 141131](https://github.com/user-attachments/assets/6648f66b-8b38-442a-a09f-57054ddfbbc0)
