### PR TITLE
fix: non-time-series statistic API

### DIFF
--- a/test-backend/test-flask/api/statistic_api.py
+++ b/test-backend/test-flask/api/statistic_api.py
@@ -5,8 +5,7 @@ from db.db_controller import (
     get_num_by_farmAddr,
     get_probexpt_of_rawmeat,
     get_probexpt_of_processedmeat,
-    get_sensory_of_rawmeat,
-    get_sensory_of_processedmeat,
+    get_sensory_of_meat,
     get_sensory_of_processed_heatedmeat,
     get_sensory_of_raw_heatedmeat,
     get_probexpt_of_processed_heatedmeat,
@@ -167,17 +166,17 @@ def getProbexptStatsOfProcessed():
 @statistic_api.route("/sensory-stats/fresh", methods=["GET"])
 def getSensoryStatsOfFresh():
     try:
-            db_session = current_app.db_session
-            start = safe_str(request.args.get("start"))
-            end = safe_str(request.args.get("end"))
-            animal_type = safe_str(request.args.get("animalType"))
-            grade = safe_int(request.args.get("grade"))
-            if start and end and species and grade is not None:
-                spceies_id = species.index(animal_type)
-                raw_sensory = get_sensory_of_rawmeat(db_session, start, end, spceies_id, grade)
-                return jsonify(raw_sensory), 200
-            else:
-                return jsonify({"msg": "Invalid Parameter"}), 400
+        db_session = current_app.db_session
+        start = safe_str(request.args.get("start"))
+        end = safe_str(request.args.get("end"))
+        animal_type = safe_str(request.args.get("animalType"))
+        grade = safe_int(request.args.get("grade"))
+        if start and end and species and grade is not None:
+            species_id = species.index(animal_type)
+            raw_sensory = get_sensory_of_meat(db_session, start, end, species_id, grade, is_raw = True)
+            return jsonify(raw_sensory), 200
+        else:
+            return jsonify({"msg": "Invalid Parameter"}), 400
     except Exception as e:
         logger.exception(str(e))
         return (
@@ -188,28 +187,27 @@ def getSensoryStatsOfFresh():
         )
 
 # 8. 가공육 관능검사 데이터 항목 별 평균, 최대, 최소
-@statistic_api.route("/sensory-stats/processed", methods=["GET", "POST"])
+@statistic_api.route("/sensory-stats/processed", methods=["GET"])
 def getSensoryStatsOfProcessed():
     try:
-        if request.method == "GET":
-            db_session = current_app.db_session
-            start = safe_str(request.args.get("start"))
-            end = safe_str(request.args.get("end"))
-            seqno = safe_int(request.args.get("seqno"))
-            if start and end:
-                return get_sensory_of_processedmeat(db_session, seqno, start, end)
-            else:
-                return jsonify("No id parameter"), 401
-
+        db_session = current_app.db_session
+        start = safe_str(request.args.get("start"))
+        end = safe_str(request.args.get("end"))
+        animal_type = safe_str(request.args.get("animalType"))
+        grade = safe_int(request.args.get("grade"))
+        if start and end and species and grade is not None:
+            species_id = species.index(animal_type)
+            processed_sensory = get_sensory_of_meat(db_session, start, end, species_id, grade, is_raw = False)
+            return jsonify(processed_sensory), 200
         else:
-            return jsonify({"msg": "Invalid Route, Please Try Again."}), 404
+            return jsonify({"msg": "Invalid Parameter"}), 400
     except Exception as e:
         logger.exception(str(e))
         return (
             jsonify(
                 {"msg": "Server Error", "time": datetime.now().strftime("%H:%M:%S")}
             ),
-            505,
+            500,
         )
 
 

--- a/test-backend/test-flask/api/statistic_api.py
+++ b/test-backend/test-flask/api/statistic_api.py
@@ -212,27 +212,27 @@ def getSensoryStatsOfProcessed():
 
 
 # 9. 가열된 신선육 관능 데이터 각 항목 별 평균, 최대, 최소
-@statistic_api.route("/sensory-stats/heated-fresh", methods=["GET", "POST"])
+@statistic_api.route("/sensory-stats/heated-fresh", methods=["GET"])
 def getSensoryStatsOfHeatedFresh():
     try:
-        if request.method == "GET":
-            db_session = current_app.db_session
-            start = safe_str(request.args.get("start"))
-            end = safe_str(request.args.get("end"))
-            if start and end:
-                return get_sensory_of_raw_heatedmeat(db_session, start, end)
-            else:
-                return jsonify("No id parameter"), 401
-
+        db_session = current_app.db_session
+        start = safe_str(request.args.get("start"))
+        end = safe_str(request.args.get("end"))
+        animal_type = safe_str(request.args.get("animalType"))
+        grade = safe_int(request.args.get("grade"))
+        if start and end and species and grade is not None:
+            species_id = species.index(animal_type)
+            raw_heated_sensory = get_sensory_of_raw_heatedmeat(db_session, start, end, species_id, grade, is_raw = True)
+            return jsonify(raw_heated_sensory), 200
         else:
-            return jsonify({"msg": "Invalid Route, Please Try Again."}), 404
+            return jsonify({"msg": "Invalid Parameter"}), 400
     except Exception as e:
         logger.exception(str(e))
         return (
             jsonify(
                 {"msg": "Server Error", "time": datetime.now().strftime("%H:%M:%S")}
             ),
-            505,
+            500,
         )
 
 

--- a/test-backend/test-flask/api/statistic_api.py
+++ b/test-backend/test-flask/api/statistic_api.py
@@ -164,27 +164,27 @@ def getProbexptStatsOfProcessed():
         )
 
 # 7. 신선육 관능검사 데이터 항목 별 평균, 최대, 최소
-@statistic_api.route("/sensory-stats/fresh", methods=["GET", "POST"])
+@statistic_api.route("/sensory-stats/fresh", methods=["GET"])
 def getSensoryStatsOfFresh():
     try:
-        if request.method == "GET":
             db_session = current_app.db_session
             start = safe_str(request.args.get("start"))
             end = safe_str(request.args.get("end"))
-            if start and end:
-                return get_sensory_of_rawmeat(db_session, start, end)
+            animal_type = safe_str(request.args.get("animalType"))
+            grade = safe_int(request.args.get("grade"))
+            if start and end and species and grade is not None:
+                spceies_id = species.index(animal_type)
+                raw_sensory = get_sensory_of_rawmeat(db_session, start, end, spceies_id, grade)
+                return jsonify(raw_sensory), 200
             else:
-                return jsonify("No id parameter"), 401
-
-        else:
-            return jsonify({"msg": "Invalid Route, Please Try Again."}), 404
+                return jsonify({"msg": "Invalid Parameter"}), 400
     except Exception as e:
         logger.exception(str(e))
         return (
             jsonify(
                 {"msg": "Server Error", "time": datetime.now().strftime("%H:%M:%S")}
             ),
-            505,
+            500,
         )
 
 # 8. 가공육 관능검사 데이터 항목 별 평균, 최대, 최소

--- a/test-backend/test-flask/db/db_controller.py
+++ b/test-backend/test-flask/db/db_controller.py
@@ -1840,70 +1840,78 @@ def get_sensory_of_meat(db_session, start, end, species, grade, is_raw):
 #     return jsonify(stats)
 
 
-def get_sensory_of_raw_heatedmeat(db_session, start, end):
+def get_sensory_of_raw_heatedmeat(db_session, start, end, species, grade, is_raw):
     # 기간 설정
     start = convert2datetime(start, 0)  # Start Time
     end = convert2datetime(end, 0)  # End Time
-    if start is None or end is None:
-        return jsonify({"msg": "Wrong start or end data"}), 404
 
     # 각 필드의 평균값, 최대값, 최소값 계산
     stats = {}
-    for field in ["flavor", "juiciness", "tenderness", "umami", "palability"]:
-        avg = (
-            db_session.query(func.avg(getattr(HeatedmeatSensoryEval, field)))
-            .join(Meat, Meat.id == HeatedmeatSensoryEval.id)
+    for field in ["flavor", "juiciness", "tenderness", "umami", "palatability"]:
+        query = (
+            db_session.query(
+                (func.avg(getattr(HeatedmeatSensoryEval, field)).label('average')),
+                (func.max(getattr(HeatedmeatSensoryEval, field)).label('maximum')),
+                (func.min(getattr(HeatedmeatSensoryEval, field)).label('minimum')),
+            )
+            .join(DeepAgingInfo, DeepAgingInfo.id == HeatedmeatSensoryEval.id and DeepAgingInfo.seqno == HeatedmeatSensoryEval.seqno)
+            .join(Meat, Meat.id == DeepAgingInfo.id)
+            .join(CategoryInfo, CategoryInfo.id == Meat.categoryId)
             .filter(
-                HeatedmeatSensoryEval.seqno == 0,
-                Meat.createdAt.between(start, end),
+                CategoryInfo.speciesId == species,
+                Meat.gradeNum == grade,
                 Meat.statusType == 2,
             )
-            .scalar()
         )
-        max_value = (
-            db_session.query(func.max(getattr(HeatedmeatSensoryEval, field)))
-            .join(Meat, Meat.id == HeatedmeatSensoryEval.id)
-            .filter(
+        query = (
+            query.filter(
                 HeatedmeatSensoryEval.seqno == 0,
                 Meat.createdAt.between(start, end),
-                Meat.statusType == 2,
+            ) 
+            if is_raw 
+            else query.filter(
+                HeatedmeatSensoryEval.seqno != 0,
+                HeatedmeatSensoryEval.createdAt.between(start, end),
             )
-            .scalar()
         )
-        min_value = (
-            db_session.query(func.min(getattr(HeatedmeatSensoryEval, field)))
-            .join(Meat, Meat.id == HeatedmeatSensoryEval.id)
-            .filter(
-                HeatedmeatSensoryEval.seqno == 0,
-                Meat.createdAt.between(start, end),
-                Meat.statusType == 2,
-            )
-            .scalar()
-        )
+        query = query.one()
+        average = query.average
+        maximum = query.maximum
+        minimum = query.minimum
 
         # 실제로 존재하는 값들 찾기
-        unique_values_query = (
+        uniques_query = (
             db_session.query(getattr(HeatedmeatSensoryEval, field))
-            .join(Meat, Meat.id == HeatedmeatSensoryEval.id)
+            .join(DeepAgingInfo, DeepAgingInfo.id == HeatedmeatSensoryEval.id and DeepAgingInfo.seqno == HeatedmeatSensoryEval.seqno)
+            .join(Meat, Meat.id == DeepAgingInfo.id)
+            .join(CategoryInfo, CategoryInfo.id == Meat.categoryId)
             .filter(
-                HeatedmeatSensoryEval.seqno == 0,
-                Meat.createdAt.between(start, end),
+                CategoryInfo.speciesId == species,
+                Meat.gradeNum == grade,
                 Meat.statusType == 2,
             )
-            .distinct()
         )
-        unique_values = [
-            value[0] for value in unique_values_query.all() if value[0] is not None
-        ]
+        uniques_query = (
+            uniques_query.filter(
+                HeatedmeatSensoryEval.seqno == 0,
+                Meat.createdAt.between(start, end),
+            )
+            if is_raw
+            else uniques_query.filter(
+                HeatedmeatSensoryEval.seqno != 0,
+                HeatedmeatSensoryEval.createdAt.between(start, end),
+            )
+        )
+        uniques = [value[0] for value in uniques_query.distinct().all()]
 
         stats[field] = {
-            "avg": avg,
-            "max": max_value,
-            "min": min_value,
-            "unique_values": sorted(unique_values),
+            "avg": average,
+            "max": maximum,
+            "min": minimum,
+            "unique_values": sorted(uniques),
         }
 
-    return jsonify(stats)
+    return stats
 
 
 def get_sensory_of_processed_heatedmeat(db_session, seqno, start, end):

--- a/test-backend/test-flask/db/db_controller.py
+++ b/test-backend/test-flask/db/db_controller.py
@@ -1715,129 +1715,129 @@ def get_sensory_of_meat(db_session, start, end, species, grade, is_raw):
     return stats
 
 
-def get_sensory_of_processedmeat(db_session, seqno, start, end):
-    # 기간 설정
-    start = convert2datetime(start, 0)  # Start Time
-    end = convert2datetime(end, 0)  # End Time
-    if start is None or end is None:
-        return jsonify({"msg": "Wrong start or end data"}), 404
+# def get_sensory_of_processedmeat(db_session, seqno, start, end):
+#     # 기간 설정
+#     start = convert2datetime(start, 0)  # Start Time
+#     end = convert2datetime(end, 0)  # End Time
+#     if start is None or end is None:
+#         return jsonify({"msg": "Wrong start or end data"}), 404
 
-    stats = {}
-    seqno = safe_int(seqno)
-    if seqno:
-        # 각 필드의 평균값, 최대값, 최소값 계산
-        for field in ["marbling", "color", "texture", "surfaceMoisture", "overall"]:
-            avg = (
-                db_session.query(func.avg(getattr(SensoryEval, field)))
-                .join(Meat, Meat.id == SensoryEval.id)
-                .filter(
-                    SensoryEval.seqno == seqno,
-                    Meat.createdAt.between(start, end),
-                    Meat.statusType == 2,
-                )
-                .scalar()
-            )
-            max_value = (
-                db_session.query(func.max(getattr(SensoryEval, field)))
-                .join(Meat, Meat.id == SensoryEval.id)
-                .filter(
-                    SensoryEval.seqno == seqno,
-                    Meat.createdAt.between(start, end),
-                    Meat.statusType == 2,
-                )
-                .scalar()
-            )
-            min_value = (
-                db_session.query(func.min(getattr(SensoryEval, field)))
-                .join(Meat, Meat.id == SensoryEval.id)
-                .filter(
-                    SensoryEval.seqno == seqno,
-                    Meat.createdAt.between(start, end),
-                    Meat.statusType == 2,
-                )
-                .scalar()
-            )
+#     stats = {}
+#     seqno = safe_int(seqno)
+#     if seqno:
+#         # 각 필드의 평균값, 최대값, 최소값 계산
+#         for field in ["marbling", "color", "texture", "surfaceMoisture", "overall"]:
+#             avg = (
+#                 db_session.query(func.avg(getattr(SensoryEval, field)))
+#                 .join(Meat, Meat.id == SensoryEval.id)
+#                 .filter(
+#                     SensoryEval.seqno == seqno,
+#                     Meat.createdAt.between(start, end),
+#                     Meat.statusType == 2,
+#                 )
+#                 .scalar()
+#             )
+#             max_value = (
+#                 db_session.query(func.max(getattr(SensoryEval, field)))
+#                 .join(Meat, Meat.id == SensoryEval.id)
+#                 .filter(
+#                     SensoryEval.seqno == seqno,
+#                     Meat.createdAt.between(start, end),
+#                     Meat.statusType == 2,
+#                 )
+#                 .scalar()
+#             )
+#             min_value = (
+#                 db_session.query(func.min(getattr(SensoryEval, field)))
+#                 .join(Meat, Meat.id == SensoryEval.id)
+#                 .filter(
+#                     SensoryEval.seqno == seqno,
+#                     Meat.createdAt.between(start, end),
+#                     Meat.statusType == 2,
+#                 )
+#                 .scalar()
+#             )
 
-            # 실제로 존재하는 값들 찾기
-            unique_values_query = (
-                db_session.query(getattr(SensoryEval, field))
-                .join(Meat, Meat.id == SensoryEval.id)
-                .filter(
-                    SensoryEval.seqno == seqno,
-                    Meat.createdAt.between(start, end),
-                    Meat.statusType == 2,
-                )
-                .distinct()
-            )
-            unique_values = [
-                value[0] for value in unique_values_query.all() if value[0] is not None
-            ]
+#             # 실제로 존재하는 값들 찾기
+#             unique_values_query = (
+#                 db_session.query(getattr(SensoryEval, field))
+#                 .join(Meat, Meat.id == SensoryEval.id)
+#                 .filter(
+#                     SensoryEval.seqno == seqno,
+#                     Meat.createdAt.between(start, end),
+#                     Meat.statusType == 2,
+#                 )
+#                 .distinct()
+#             )
+#             unique_values = [
+#                 value[0] for value in unique_values_query.all() if value[0] is not None
+#             ]
 
-            stats[field] = {
-                "avg": avg,
-                "max": max_value,
-                "min": min_value,
-                "unique_values": (
-                    sorted(unique_values) if unique_values else unique_values
-                ),
-            }
-    else:
-        # 각 필드의 평균값, 최대값, 최소값 계산
-        for field in ["marbling", "color", "texture", "surfaceMoisture", "overall"]:
-            avg = (
-                db_session.query(func.avg(getattr(SensoryEval, field)))
-                .join(Meat, Meat.id == SensoryEval.id)
-                .filter(
-                    SensoryEval.seqno != 0,
-                    Meat.createdAt.between(start, end),
-                    Meat.statusType == 2,
-                )
-                .scalar()
-            )
-            max_value = (
-                db_session.query(func.max(getattr(SensoryEval, field)))
-                .join(Meat, Meat.id == SensoryEval.id)
-                .filter(
-                    SensoryEval.seqno != 0,
-                    Meat.createdAt.between(start, end),
-                    Meat.statusType == 2,
-                )
-                .scalar()
-            )
-            min_value = (
-                db_session.query(func.min(getattr(SensoryEval, field)))
-                .join(Meat, Meat.id == SensoryEval.id)
-                .filter(
-                    SensoryEval.seqno != 0,
-                    Meat.createdAt.between(start, end),
-                    Meat.statusType == 2,
-                )
-                .scalar()
-            )
+#             stats[field] = {
+#                 "avg": avg,
+#                 "max": max_value,
+#                 "min": min_value,
+#                 "unique_values": (
+#                     sorted(unique_values) if unique_values else unique_values
+#                 ),
+#             }
+#     else:
+#         # 각 필드의 평균값, 최대값, 최소값 계산
+#         for field in ["marbling", "color", "texture", "surfaceMoisture", "overall"]:
+#             avg = (
+#                 db_session.query(func.avg(getattr(SensoryEval, field)))
+#                 .join(Meat, Meat.id == SensoryEval.id)
+#                 .filter(
+#                     SensoryEval.seqno != 0,
+#                     Meat.createdAt.between(start, end),
+#                     Meat.statusType == 2,
+#                 )
+#                 .scalar()
+#             )
+#             max_value = (
+#                 db_session.query(func.max(getattr(SensoryEval, field)))
+#                 .join(Meat, Meat.id == SensoryEval.id)
+#                 .filter(
+#                     SensoryEval.seqno != 0,
+#                     Meat.createdAt.between(start, end),
+#                     Meat.statusType == 2,
+#                 )
+#                 .scalar()
+#             )
+#             min_value = (
+#                 db_session.query(func.min(getattr(SensoryEval, field)))
+#                 .join(Meat, Meat.id == SensoryEval.id)
+#                 .filter(
+#                     SensoryEval.seqno != 0,
+#                     Meat.createdAt.between(start, end),
+#                     Meat.statusType == 2,
+#                 )
+#                 .scalar()
+#             )
 
-            # 실제로 존재하는 값들 찾기
-            unique_values_query = (
-                db_session.query(getattr(SensoryEval, field))
-                .join(Meat, Meat.id == SensoryEval.id)
-                .filter(
-                    SensoryEval.seqno != 0,
-                    Meat.createdAt.between(start, end),
-                    Meat.statusType == 2,
-                )
-                .distinct()
-            )
-            unique_values = [
-                value[0] for value in unique_values_query.all() if value[0] is not None
-            ]
+#             # 실제로 존재하는 값들 찾기
+#             unique_values_query = (
+#                 db_session.query(getattr(SensoryEval, field))
+#                 .join(Meat, Meat.id == SensoryEval.id)
+#                 .filter(
+#                     SensoryEval.seqno != 0,
+#                     Meat.createdAt.between(start, end),
+#                     Meat.statusType == 2,
+#                 )
+#                 .distinct()
+#             )
+#             unique_values = [
+#                 value[0] for value in unique_values_query.all() if value[0] is not None
+#             ]
 
-            stats[field] = {
-                "avg": avg,
-                "max": max_value,
-                "min": min_value,
-                "unique_values": sorted(unique_values),
-            }
+#             stats[field] = {
+#                 "avg": avg,
+#                 "max": max_value,
+#                 "min": min_value,
+#                 "unique_values": sorted(unique_values),
+#             }
 
-    return jsonify(stats)
+#     return jsonify(stats)
 
 
 def get_sensory_of_raw_heatedmeat(db_session, start, end):

--- a/test-backend/test-flask/db/db_controller.py
+++ b/test-backend/test-flask/db/db_controller.py
@@ -1641,68 +1641,61 @@ def get_probexpt_of_processedmeat(db_session, seqno, start, end):
     return jsonify(stats)
 
 
-def get_sensory_of_rawmeat(db_session, start, end):
+def get_sensory_of_rawmeat(db_session, start, end, species, grade):
     # 기간 설정
     start = convert2datetime(start, 0)  # Start Time
     end = convert2datetime(end, 0)  # End Time
-    if start is None or end is None:
-        return jsonify({"msg": "Wrong start or end data"}), 404
 
     # 각 필드의 평균값, 최대값, 최소값 계산
     stats = {}
     for field in ["marbling", "color", "texture", "surfaceMoisture", "overall"]:
-        avg = (
-            db_session.query(func.avg(getattr(SensoryEval, field)))
-            .join(Meat, Meat.id == SensoryEval.id)
+        query = (
+            db_session.query(
+                (func.avg(getattr(SensoryEval, field)).label('average')),
+                (func.max(getattr(SensoryEval, field)).label('maximum')),
+                (func.min(getattr(SensoryEval, field)).label('minimum')),
+            )
+            .join(DeepAgingInfo, DeepAgingInfo.id == SensoryEval.id and DeepAgingInfo.seqno == SensoryEval.seqno)
+            .join(Meat, Meat.id == DeepAgingInfo.id)
+            .join(CategoryInfo, CategoryInfo.id == Meat.categoryId)
             .filter(
-                SensoryEval.seqno == 0,
                 Meat.createdAt.between(start, end),
                 Meat.statusType == 2,
+                DeepAgingInfo.seqno == 0,
+                CategoryInfo.speciesId == species,
+                Meat.gradeNum == grade,
             )
-            .scalar()
+            .one()
         )
-        max_value = (
-            db_session.query(func.max(getattr(SensoryEval, field)))
-            .join(Meat, Meat.id == SensoryEval.id)
-            .filter(
-                SensoryEval.seqno == 0,
-                Meat.createdAt.between(start, end),
-                Meat.statusType == 2,
-            )
-            .scalar()
-        )
-        min_value = (
-            db_session.query(func.min(getattr(SensoryEval, field)))
-            .join(Meat, Meat.id == SensoryEval.id)
-            .filter(
-                SensoryEval.seqno == 0,
-                Meat.createdAt.between(start, end),
-                Meat.statusType == 2,
-            )
-            .scalar()
-        )
+        average = query.average
+        maximum = query.maximum
+        minimum = query.minimum
 
         # 실제로 존재하는 값들 찾기
         unique_values_query = (
             db_session.query(getattr(SensoryEval, field))
-            .join(Meat, Meat.id == SensoryEval.id)
+            .join(DeepAgingInfo, DeepAgingInfo.id == SensoryEval.id and DeepAgingInfo.seqno == SensoryEval.seqno)
+            .join(Meat, Meat.id == DeepAgingInfo.id)
+            .join(CategoryInfo, CategoryInfo.id == Meat.categoryId)
             .filter(
-                SensoryEval.seqno == 0,
                 Meat.createdAt.between(start, end),
                 Meat.statusType == 2,
+                DeepAgingInfo.seqno == 0,
+                CategoryInfo.speciesId == species,
+                Meat.gradeNum == grade,
             )
             .distinct()
         )
-        unique_values = [value[0] for value in unique_values_query.all()]
+        uniques = [value[0] for value in unique_values_query.all()]
 
         stats[field] = {
-            "avg": avg,
-            "max": max_value,
-            "min": min_value,
-            "unique_values": sorted(unique_values),
+            "avg": average,
+            "max": maximum,
+            "min": minimum,
+            "unique_values": sorted(uniques),
         }
 
-    return jsonify(stats)
+    return stats
 
 
 def get_sensory_of_processedmeat(db_session, seqno, start, end):


### PR DESCRIPTION
## 수정한 점
- Http 메서드 수정
- Status code 수정
- 미사용 컨트롤러 함수 1개 주석 처리

### statistic/sensory-stats/fresh & statistic/sensory-stats/processed
- 하나의 컨트롤러 함수 `get_sensory_of_meat`로 API 요청을 처리하도록 수정
- `req`에 추가된 `animalType`과 `grade`를 처리할 수 있도록 수정
- 변경된 DB에 맞춰 쿼리문의 join 관계 수정
- 각각의 scalar 요청값에 대해 별도의 쿼리문이 작성되어 있던 기존의 코드를 가독성이 좋도록 하나의 쿼리문으로 수정
  - 평균, 최대, 최소 scalar값을 조회하는 query와 개별 수치값을 조회하는 uniques_query로 구분

### statistic/sensory-stats/heated-fresh
- 상동
- 추가 가능성이 존재하는 `statistic/sensory-stats/heated-processed` API를 염두하여 컨트롤러 함수가 이 두 가지 API 요청을 모두 처리할 수 있도록 사전에 구조 변경 진행