### PR TITLE
fix: /statistic/probexpt-stats/ 의 신선육, 처리육 API 수정

### DIFF
--- a/test-backend/test-flask/api/statistic_api.py
+++ b/test-backend/test-flask/api/statistic_api.py
@@ -123,13 +123,11 @@ def getProbexptStatsOfFresh():
         animal_type = safe_str(request.args.get("animalType"))
         grade = safe_int(request.args.get("grade"))
         
-        print(start, end, animal_type, grade)
-        
         if start and end and animal_type and (grade is not None):
             specie_id = species.index(animal_type)
-            probexpt_data = get_probexpt_of_meat(db_session, start, end, specie_id, grade, is_raw=1)
+            probexpt_raw_data = get_probexpt_of_meat(db_session, start, end, specie_id, grade, is_raw=1)
             
-            return jsonify(probexpt_data), 200
+            return jsonify(probexpt_raw_data), 200
         else:
             return jsonify({"msg": "Invalid Parameter"}), 400
     except Exception as e:
@@ -143,28 +141,30 @@ def getProbexptStatsOfFresh():
 
 
 # 6. 처리육 맛데이터 항목 별 평균, 최대, 최소
-@statistic_api.route("/probexpt-stats/processed", methods=["GET", "POST"])
+@statistic_api.route("/probexpt-stats/processed", methods=["GET"])
 def getProbexptStatsOfProcessed():
     try:
-        if request.method == "GET":
-            db_session = current_app.db_session
-            start = safe_str(request.args.get("start"))
-            end = safe_str(request.args.get("end"))
-            seqno = safe_int(request.args.get("seqno"))
-            if start and end and seqno:
-                return get_probexpt_of_processedmeat(db_session, seqno, start, end)
-            else:
-                return jsonify("No id parameter"), 401
-
+        db_session = current_app.db_session
+        start = safe_str(request.args.get("start"))
+        end = safe_str(request.args.get("end"))
+        animal_type = safe_str(request.args.get("animalType"))
+        grade = safe_int(request.args.get("grade"))
+        seqno = safe_int(request.args.get("seqno"))
+            
+        if start and end and animal_type and (grade is not None):
+            specie_id = species.index(animal_type)
+            probexpt_processed_data = get_probexpt_of_meat(db_session, start, end, specie_id, grade, is_raw=0)
+                
+            return jsonify(probexpt_processed_data), 200
         else:
-            return jsonify({"msg": "Invalid Route, Please Try Again."}), 404
+            return jsonify({"msg": "Invalid Parameter"}), 400
     except Exception as e:
         logger.exception(str(e))
         return (
             jsonify(
                 {"msg": "Server Error", "time": datetime.now().strftime("%H:%M:%S")}
             ),
-            505,
+            500,
         )
 
 # 7. 신선육 관능검사 데이터 항목 별 평균, 최대, 최소

--- a/test-backend/test-flask/api/statistic_api.py
+++ b/test-backend/test-flask/api/statistic_api.py
@@ -3,7 +3,7 @@ from db.db_controller import (
     get_num_of_cattle_pig,
     get_num_of_primal_part,
     get_num_by_farmAddr,
-    get_probexpt_of_rawmeat,
+    get_probexpt_of_meat,
     get_probexpt_of_processedmeat,
     get_sensory_of_rawmeat,
     get_sensory_of_processedmeat,
@@ -114,27 +114,31 @@ def getCountsByFarmLocation():
 
 
 # 5. 신선육 맛데이터 항목 별 평균, 최대, 최소
-@statistic_api.route("/probexpt-stats/fresh", methods=["GET", "POST"])
+@statistic_api.route("/probexpt-stats/fresh", methods=["GET"])
 def getProbexptStatsOfFresh():
     try:
-        if request.method == "GET":
-            db_session = current_app.db_session
-            start = safe_str(request.args.get("start"))
-            end = safe_str(request.args.get("end"))
-            if start and end:
-                return get_probexpt_of_rawmeat(db_session, start, end)
-            else:
-                return jsonify("No id parameter"), 401
-
+        db_session = current_app.db_session
+        start = safe_str(request.args.get("start"))
+        end = safe_str(request.args.get("end"))
+        animal_type = safe_str(request.args.get("animalType"))
+        grade = safe_int(request.args.get("grade"))
+        
+        print(start, end, animal_type, grade)
+        
+        if start and end and animal_type and (grade is not None):
+            specie_id = species.index(animal_type)
+            probexpt_data = get_probexpt_of_meat(db_session, start, end, specie_id, grade, is_raw=1)
+            
+            return jsonify(probexpt_data), 200
         else:
-            return jsonify({"msg": "Invalid Route, Please Try Again."}), 404
+            return jsonify({"msg": "Invalid Parameter"}), 400
     except Exception as e:
         logger.exception(str(e))
         return (
             jsonify(
                 {"msg": "Server Error", "time": datetime.now().strftime("%H:%M:%S")}
             ),
-            505,
+            500,
         )
 
 

--- a/test-backend/test-flask/db/db_controller.py
+++ b/test-backend/test-flask/db/db_controller.py
@@ -1460,67 +1460,84 @@ def get_num_by_farmAddr(db_session, start, end):
         raise Exception("Something Wrong with DB" + str(e))
 
 
-def get_probexpt_of_rawmeat(db_session, start, end):
+def get_probexpt_of_meat(db_session, start, end, specie_id, grade, is_raw):
     # 기간 설정
     start = convert2datetime(start, 0)  # Start Time
     end = convert2datetime(end, 0)  # End Time
-    if start is None or end is None:
-        return jsonify({"msg": "Wrong start or end data"}), 404
+    
     # 각 필드의 평균값, 최대값, 최소값 계산
     stats = {}
     for field in ["sourness", "bitterness", "umami", "richness"]:
-        avg = (
-            db_session.query(func.avg(getattr(ProbexptData, field)))
-            .join(Meat, Meat.id == ProbexptData.id)
-            .filter(
-                ProbexptData.seqno == 0,
-                Meat.createdAt.between(start, end),
-                Meat.statusType == 2,
+        query = (
+                db_session.query(
+                    (func.avg(getattr(ProbexptData, field)).label('average')),
+                    (func.max(getattr(ProbexptData, field)).label('maximum')),
+                    (func.min(getattr(ProbexptData, field)).label('minimum')),
+                )
+                .join(DeepAgingInfo, DeepAgingInfo.id == ProbexptData.id and DeepAgingInfo.seqno == ProbexptData.seqno)
+                .join(Meat, Meat.id == DeepAgingInfo.id)
+                .join(CategoryInfo, CategoryInfo.id == Meat.categoryId)
+                .filter(
+                    ProbexptData.isHeated == False,
+                    CategoryInfo.speciesId == specie_id,
+                    Meat.statusType == 2,
+                )
             )
-            .scalar()
-        )
-        max_value = (
-            db_session.query(func.max(getattr(ProbexptData, field)))
-            .join(Meat, Meat.id == ProbexptData.id)
-            .filter(
-                ProbexptData.seqno == 0,
-                Meat.createdAt.between(start, end),
-                Meat.statusType == 2,
-            )
-            .scalar()
-        )
-        min_value = (
-            db_session.query(func.min(getattr(ProbexptData, field)))
-            .join(Meat, Meat.id == ProbexptData.id)
-            .filter(
-                ProbexptData.seqno == 0,
-                Meat.createdAt.between(start, end),
-                Meat.statusType == 2,
-            )
-            .scalar()
-        )
 
+        query = (
+                query.filter(
+                    ProbexptData.seqno == 0,
+                    Meat.createdAt.between(start, end),
+                ) 
+                if is_raw 
+                else query.filter(
+                    ProbexptData.seqno != 0,
+                    ProbexptData.createdAt.between(start, end),
+                )
+            )
+
+        query = query.filter(Meat.gradeNum == grade) if grade < 5 else query
+        
+        query = query.one()
+        average = query.average
+        maximum = query.maximum
+        minimum = query.minimum
+        
         # 실제로 존재하는 값들 찾기
-        unique_values_query = (
+        unique_query = (
             db_session.query(getattr(ProbexptData, field))
-            .join(Meat, Meat.id == ProbexptData.id)
+            .join(DeepAgingInfo, DeepAgingInfo.id == ProbexptData.id and DeepAgingInfo.seqno == ProbexptData.seqno)
+            .join(Meat, Meat.id == DeepAgingInfo.id)
+            .join(CategoryInfo, CategoryInfo.id == Meat.categoryId)
             .filter(
-                ProbexptData.seqno == 0,
+                ProbexptData.isHeated == False,
+                CategoryInfo.speciesId == specie_id,
                 Meat.createdAt.between(start, end),
                 Meat.statusType == 2,
             )
-            .distinct()
         )
-        unique_values = [value[0] for value in unique_values_query.all()]
+        
+        unique_query = (
+                unique_query.filter(
+                    ProbexptData.seqno == 0,
+                ) 
+                if is_raw 
+                else query.filter(
+                    ProbexptData.seqno != 0,
+                )
+            )
+        
+        unique_query = unique_query.filter(Meat.gradeNum == grade) if grade < 5 else unique_query
+        
+        unique_values = [value[0] for value in unique_query.distinct().all()[-4:]]
 
         stats[field] = {
-            "avg": avg,
-            "max": max_value,
-            "min": min_value,
+            "avg": average,
+            "max": maximum,
+            "min": minimum,
             "unique_values": unique_values,
         }
-
-    return jsonify(stats)
+    return stats
 
 
 def get_probexpt_of_processedmeat(db_session, seqno, start, end):

--- a/test-backend/test-flask/db/db_controller.py
+++ b/test-backend/test-flask/db/db_controller.py
@@ -1481,18 +1481,17 @@ def get_probexpt_of_meat(db_session, start, end, specie_id, grade, is_raw):
                     ProbexptData.isHeated == False,
                     CategoryInfo.speciesId == specie_id,
                     Meat.statusType == 2,
+                    Meat.createdAt.between(start, end),
                 )
             )
 
         query = (
                 query.filter(
                     ProbexptData.seqno == 0,
-                    Meat.createdAt.between(start, end),
                 ) 
                 if is_raw 
                 else query.filter(
                     ProbexptData.seqno != 0,
-                    ProbexptData.createdAt.between(start, end),
                 )
             )
 
@@ -1522,7 +1521,7 @@ def get_probexpt_of_meat(db_session, start, end, specie_id, grade, is_raw):
                     ProbexptData.seqno == 0,
                 ) 
                 if is_raw 
-                else query.filter(
+                else unique_query.filter(
                     ProbexptData.seqno != 0,
                 )
             )


### PR DESCRIPTION
## 수정 사항
### /statistic/probexpt-stats/
- 메소드 수정
- 다른 statistic API와 동일하게 로직 수정
- fresh와 processed를 하나의 controller에서 처리하기 위해 is_raw 메소드로 구분함