### PR TITLE
hotfix: probexpt-data 추가 시 로직 수정

### DIFF
--- a/test-backend/test-flask/api/statistic_api.py
+++ b/test-backend/test-flask/api/statistic_api.py
@@ -291,3 +291,26 @@ def getProbexptStatsOfHeatedProcessed():
             ),
             505,
         )
+
+
+# 12. 시계열 데이터 조회
+@statistic_api.route("/time", methods=["GET"])
+def getTimeSeriesData():
+    try:
+        db_session = current_app.db_session
+        start = safe_str(request.args.get("start"))
+        end = safe_str(request.args.get("end"))
+        meat_value = safe_str(request.args.get("meatValue"))
+        
+        if start and end:
+            return get_probexpt_of_processed_heatedmeat(db_session, start, end)
+        else:
+            return jsonify("No id parameter"), 400
+    except Exception as e:
+        logger.exception(str(e))
+        return (
+            jsonify(
+                {"msg": "Server Error", "time": datetime.now().strftime("%H:%M:%S")}
+            ),
+            500,
+        )

--- a/test-backend/test-flask/api/statistic_api.py
+++ b/test-backend/test-flask/api/statistic_api.py
@@ -291,26 +291,3 @@ def getProbexptStatsOfHeatedProcessed():
             ),
             505,
         )
-
-
-# 12. 시계열 데이터 조회
-@statistic_api.route("/time", methods=["GET"])
-def getTimeSeriesData():
-    try:
-        db_session = current_app.db_session
-        start = safe_str(request.args.get("start"))
-        end = safe_str(request.args.get("end"))
-        meat_value = safe_str(request.args.get("meatValue"))
-        
-        if start and end:
-            return get_probexpt_of_processed_heatedmeat(db_session, start, end)
-        else:
-            return jsonify("No id parameter"), 400
-    except Exception as e:
-        logger.exception(str(e))
-        return (
-            jsonify(
-                {"msg": "Server Error", "time": datetime.now().strftime("%H:%M:%S")}
-            ),
-            500,
-        )

--- a/test-backend/test-flask/db/db_controller.py
+++ b/test-backend/test-flask/db/db_controller.py
@@ -478,11 +478,9 @@ def create_specific_probexpt_data(db_session, data, is_post):
             if is_post: # 수정이지만 POST 메서드
                 return ({"msg": "Probexpt Data Already Exists", "code": 400})
             
-            if seqno == 0 and meat.statusType == 2:
-                return ({"msg": "Already Confirmed Data", "code": 400})
-            elif seqno == 0 and meat.statusType != 2:
-                meat.statusType = 0
-                db_session.merge(meat)
+            if meat.statusType != 2:
+                return ({"msg": "Not Confirmed Data", "code": 400})
+
             probexpt_data["userId"] = existed_probexpt_data["userId"]
             new_probexpt_data = create_ProbexptData(probexpt_data, id, seqno, is_heated)
             db_session.merge(new_probexpt_data)


### PR DESCRIPTION
## /meat/add/probexpt-data API
- 실험실 데이터를 추가하는 로직에서 승인되지 않은 상태일 때의 육류만 수정 가능하도록 로직 수정