### PR TITLE
feat: /meat/statistic/time 시계열 API 작성

### DIFF
--- a/test-backend/test-flask/api/statistic_api.py
+++ b/test-backend/test-flask/api/statistic_api.py
@@ -148,7 +148,6 @@ def getProbexptStatsOfProcessed():
         end = safe_str(request.args.get("end"))
         animal_type = safe_str(request.args.get("animalType"))
         grade = safe_int(request.args.get("grade"))
-        seqno = safe_int(request.args.get("seqno"))
             
         if start and end and animal_type and (grade is not None):
             specie_id = species.index(animal_type)

--- a/test-backend/test-flask/api/statistic_api.py
+++ b/test-backend/test-flask/api/statistic_api.py
@@ -4,11 +4,11 @@ from db.db_controller import (
     get_num_of_primal_part,
     get_num_by_farmAddr,
     get_probexpt_of_meat,
-    get_probexpt_of_processedmeat,
     get_sensory_of_meat,
     get_sensory_of_processed_heatedmeat,
     get_sensory_of_raw_heatedmeat,
     get_probexpt_of_processed_heatedmeat,
+    get_timeseries_of_cattle_data,
 )
 from flask import (
     Blueprint,
@@ -290,4 +290,28 @@ def getProbexptStatsOfHeatedProcessed():
                 {"msg": "Server Error", "time": datetime.now().strftime("%H:%M:%S")}
             ),
             505,
+        )
+
+
+# 12. 시계열 데이터 조회
+@statistic_api.route("/time", methods=["GET"])
+def getTimeSeriesData():
+    try:
+        db_session = current_app.db_session
+        start = safe_str(request.args.get("start"))
+        end = safe_str(request.args.get("end"))
+        meat_value = safe_str(request.args.get("meatValue"))
+        
+        if start and end and meat_value:
+            timeseries_data = get_timeseries_of_cattle_data(db_session, start, end, meat_value)
+            return jsonify(timeseries_data), 200
+        else:
+            return jsonify("Invalid parameter"), 400
+    except Exception as e:
+        logger.exception(str(e))
+        return (
+            jsonify(
+                {"msg": "Server Error", "time": datetime.now().strftime("%H:%M:%S")}
+            ),
+            500,
         )

--- a/test-backend/test-flask/db/db_controller.py
+++ b/test-backend/test-flask/db/db_controller.py
@@ -1674,6 +1674,7 @@ def get_sensory_of_meat(db_session, start, end, species, grade, is_raw):
                 .join(Meat, Meat.id == DeepAgingInfo.id)
                 .join(CategoryInfo, CategoryInfo.id == Meat.categoryId)
                 .filter(
+                    Meat.createdAt.between(start, end),
                     CategoryInfo.speciesId == species,
                     Meat.statusType == 2,
                 )
@@ -1681,12 +1682,10 @@ def get_sensory_of_meat(db_session, start, end, species, grade, is_raw):
             query = (
                 query.filter(
                     SensoryEval.seqno == 0,
-                    Meat.createdAt.between(start, end),
                 ) 
                 if is_raw 
                 else query.filter(
                     SensoryEval.seqno != 0,
-                    SensoryEval.createdAt.between(start, end),
                 )
             )
             query = (
@@ -1708,17 +1707,16 @@ def get_sensory_of_meat(db_session, start, end, species, grade, is_raw):
                 .filter(
                     CategoryInfo.speciesId == species,
                     Meat.statusType == 2,
+                    Meat.createdAt.between(start, end),
                 )
             )
             uniques_query = (
                 uniques_query.filter(
                     SensoryEval.seqno == 0,
-                    Meat.createdAt.between(start, end),
                 )
                 if is_raw
                 else uniques_query.filter(
                     SensoryEval.seqno != 0,
-                    SensoryEval.createdAt.between(start, end),
                 )
             )
             uniques_query = (
@@ -1885,17 +1883,16 @@ def get_sensory_of_raw_heatedmeat(db_session, start, end, species, grade, is_raw
                 .filter(
                     CategoryInfo.speciesId == species,
                     Meat.statusType == 2,
+                    Meat.createdAt.between(start, end),
                 )
             )
             query = (
                 query.filter(
                     HeatedmeatSensoryEval.seqno == 0,
-                    Meat.createdAt.between(start, end),
                 ) 
                 if is_raw 
                 else query.filter(
                     HeatedmeatSensoryEval.seqno != 0,
-                    HeatedmeatSensoryEval.createdAt.between(start, end),
                 )
             )
             query = (
@@ -1916,17 +1913,16 @@ def get_sensory_of_raw_heatedmeat(db_session, start, end, species, grade, is_raw
                 .filter(
                     CategoryInfo.speciesId == species,
                     Meat.statusType == 2,
+                    Meat.createdAt.between(start, end),
                 )
             )
             uniques_query = (
                 uniques_query.filter(
                     HeatedmeatSensoryEval.seqno == 0,
-                    Meat.createdAt.between(start, end),
                 )
                 if is_raw
                 else uniques_query.filter(
                     HeatedmeatSensoryEval.seqno != 0,
-                    HeatedmeatSensoryEval.createdAt.between(start, end),
                 )
             )
             uniques_query = (
@@ -2159,7 +2155,7 @@ def get_timeseries_of_cattle_data(db_session, start, end, meat_value):
                 HeatedmeatSensoryEval.seqno == i,
                 Meat.categoryId.in_(meat_id_list),
                 Meat.statusType == 2,
-                HeatedmeatSensoryEval.createdAt.between(start, end)
+                Meat.createdAt.between(start, end)
             )
         )
         query = query.one()


### PR DESCRIPTION
## `/meat/statistic/time` 주요 로직
1. 소고기 부위가 parameter로 들어왔을 때 해당 부위의 category_id를 list로 반환 
-> 2번의 관능검사 결과의 필터링으로 쓰임
2. seqno에 따라 가열육의 관능검사 결과를 불러옴
3. 마지막에 json으로 반환할 때 None 값이라면 0으로 변환 
<img width="600" alt="image" src="https://github.com/user-attachments/assets/5d73e974-2f18-4538-8e7d-7ffa264b34e1">

### 추가 수정 사항
- Statistic API에서 날짜 기준 필터링할 때 해당 관능 평가의 원육이 생성된 날짜 기준으로 필터링하는 것으로 수정
