### PR TITLE
fix: updatedAt, createdAt의 용도 수정

### DIFF
--- a/test-backend/test-flask/db/db_controller.py
+++ b/test-backend/test-flask/db/db_controller.py
@@ -162,7 +162,6 @@ def create_SensoryEval(db_session, meat_data: dict, sensory_data, seqno, id, use
     item_encoder(meat_data, "seqno", seqno)
     meat_data['id'] = id
     meat_data.pop('meatId')
-    meat_data['createdAt'] = datetime.now().strftime('%Y-%m-%d')
     meat_data['period'] = calculate_period(db_session, id)
     meat_data.pop('sensoryData')
     meat_data['userId'] = userId
@@ -350,6 +349,7 @@ def create_specific_sensory_eval(db_session, s3_conn, firestore_conn, data, is_p
             user_id = safe_str(data.get("userId"))
             # sensory_eval 생성
             if any(value is not None for value in sensory_data.values()):
+                sensory_data["createdAt"] = convert2string(datetime.now(), 1)
                 new_sensory_eval = create_SensoryEval(db_session, data, sensory_data, seqno, meat_id, user_id)
                 db_session.add(new_sensory_eval)
                 db_session.commit()
@@ -383,6 +383,7 @@ def create_specific_sensory_eval(db_session, s3_conn, firestore_conn, data, is_p
                 
             # sensory_eval 생성
             if any(value is not None for value in sensory_data.values()):
+                sensory_data["createdAt"] = convert2string(existing_sensory.createdAt, 1)
                 new_sensory_eval = create_SensoryEval(db_session, data, sensory_data, seqno, meat_id, existing_user)
                 db_session.merge(new_sensory_eval)
 
@@ -418,7 +419,6 @@ def create_specific_heatedmeat_seonsory_eval(db_session, firestore_conn, s3_conn
     try:
         sensory_data = data["heatedmeatSensoryData"]
         sensory_data["filmedAt"] = data["filmedAt"]
-        sensory_data["createdAt"] = convert2string(datetime.now(), 1)
         existed_sensory_data = get_HeatedmeatSensoryEval(db_session, id, seqno)
 
         if existed_sensory_data: # 수정
@@ -431,6 +431,7 @@ def create_specific_heatedmeat_seonsory_eval(db_session, firestore_conn, s3_conn
                 meat.statusType = 0
                 db_session.merge(meat)
             sensory_data["userId"] = existed_sensory_data["userId"]
+            sensory_data["createdAt"] = existed_sensory_data["createdAt"]
             new_sensory_data = create_HeatemeatSensoryEval(sensory_data, id, seqno)
             db_session.merge(new_sensory_data)
             
@@ -438,6 +439,7 @@ def create_specific_heatedmeat_seonsory_eval(db_session, firestore_conn, s3_conn
             if not is_post: # 생성인데 PATCH 메서드
                 return ({"msg": "Heatedmeat Sensory Data Does NOT Exists", "code": 400})
             sensory_data["userId"] = data["userId"]
+            sensory_data["createdAt"] = convert2string(datetime.now(), 1)
             sensory_data["period"] = calculate_period(db_session, id)
             new_sensory_data = create_HeatemeatSensoryEval(sensory_data, id, seqno)
             db_session.add(new_sensory_data)
@@ -471,7 +473,6 @@ def create_specific_probexpt_data(db_session, data, is_post):
     
     try:
         probexpt_data = data["probexptData"]
-        probexpt_data["updatedAt"] = convert2string(datetime.now(), 1)
         existed_probexpt_data = get_ProbexptData(db_session, id, seqno, is_heated)
 
         if existed_probexpt_data: # 수정
@@ -482,6 +483,7 @@ def create_specific_probexpt_data(db_session, data, is_post):
                 return ({"msg": "Not Confirmed Data", "code": 400})
 
             probexpt_data["userId"] = existed_probexpt_data["userId"]
+            probexpt_data["updatedAt"] = existed_probexpt_data["updatedAt"]
             new_probexpt_data = create_ProbexptData(probexpt_data, id, seqno, is_heated)
             db_session.merge(new_probexpt_data)
             db_session.commit()
@@ -490,6 +492,7 @@ def create_specific_probexpt_data(db_session, data, is_post):
             if not is_post: # 생성이지만 PATCH 메서드
                 return ({"msg": "Probexpt Data Does NOT Exists", "code": 400})
             probexpt_data["userId"] = data["userId"]
+            probexpt_data["updatedAt"] = convert2string(datetime.now(), 1) # updatedAt -> createdAt으로 수정 예정
             probexpt_data["period"] = calculate_period(db_session, id)
             new_probexpt_data = create_ProbexptData(probexpt_data, id, seqno, is_heated)
             db_session.add(new_probexpt_data)

--- a/test-backend/test-flask/utils.py
+++ b/test-backend/test-flask/utils.py
@@ -312,8 +312,8 @@ def calId(id, s_id, type):
 
 
 def item_encoder(data_dict, item, input_data=None):
-    datetime0_cvr = ["filmedAt", "createdAt", "updatedAt"]
-    datetime1_cvr = ["loginAt"]
+    datetime0_cvr = ["filmedAt", "createdAt"]
+    datetime1_cvr = ["loginAt", "updatedAt"]
     datetime2_cvr = ["butcheryYmd", "birthYmd", "date"]
     str_cvr = [
         "id",

--- a/test-backend/test-flask/utils.py
+++ b/test-backend/test-flask/utils.py
@@ -236,8 +236,8 @@ def convert2string(date_object, format):
 
 
 def item_encoder(data_dict, item, input_data=None):
-    datetime0_cvr = ["filmedAt"]
-    datetime1_cvr = ["createdAt", "loginAt", "updatedAt"]
+    datetime0_cvr = ["filmedAt", "createdAt"]
+    datetime1_cvr = ["loginAt", "updatedAt"]
     datetime2_cvr = ["butcheryYmd", "birthYmd", "date"]
     str_cvr = [
         "id",
@@ -312,8 +312,8 @@ def calId(id, s_id, type):
 
 
 def item_encoder(data_dict, item, input_data=None):
-    datetime0_cvr = ["filmedAt"]
-    datetime1_cvr = ["createdAt", "loginAt", "updatedAt"]
+    datetime0_cvr = ["filmedAt", "createdAt", "updatedAt"]
+    datetime1_cvr = ["loginAt"]
     datetime2_cvr = ["butcheryYmd", "birthYmd", "date"]
     str_cvr = [
         "id",


### PR DESCRIPTION
## 수정한 점
- `probexpt_data`의 `updatedAt`이 기존의 목적인 데이터 생성일자를 나타내는 `createdAt`로써 사용되도록 수정
  - 최종 리팩토링에서 db model의 column명 변경 예정
- `sensory_eval`과 `heatedmeat_sensory_eval`의 `createdAt`이 POST와 PATCH 메서드 모두에서 호출 당시 시각으로 업데이트되던 로직을 수정
  - POST: 기존과 동일하게 생성 시간 기준
  - PATCH: 이미 DB에 등록되어 있는 데이터의 `createdAt`을 불러와 그대로 유지
- `utils.py`에서 `createdAt`에 대해 항상 현재 시각으로 변경하던 것을 수정하기 위해 타입 수정
  - 현재 `probexpt_data`의 `updatedAt` column명을 변경하지 않았으므로 기능 수행 시 목표와 다른 결과가 나올 수 있으나, 이는 최종 리팩토링에서 진행할 예정이므로 주의 요망