### PR TITLE
fix: 원육 승인되지 않았을 때 특정값만 수정 가능하도록

### DIFF
--- a/test-web/src/API/update/updateProcessedData.js
+++ b/test-web/src/API/update/updateProcessedData.js
@@ -4,13 +4,11 @@ import { apiIP } from '../../config';
 // 처리육 수정 POST API
 export default async function updateProcessedData(
   processedInput, // 처리육 데이터 (수정값)
-  processed_data, // 처리육 데이터
-  processedMinute, // 처리(딥에이징) 시간
+  // processed_data, // 처리육 데이터
+  // processedMinute, // 처리(딥에이징) 시간
   i, // 처리육 seqno
   meatId, // 이력번호
-  userId, // 로그인한 사용자 id
-  createdDate, // 생성 날짜
-  elapsedHour //경과 시간
+  
 ) {
   const [yy, mm, dd] = computeCurrentDate();
   //console.log("CHECK",processedInput)

--- a/test-web/src/API/update/updateRawData.js
+++ b/test-web/src/API/update/updateRawData.js
@@ -1,42 +1,43 @@
-import { apiIP } from "../../config";
+import { apiIP } from '../../config';
+import { computeCurrentDate } from '../../components/DataDetailPage/computePeriod';
+export default async function updateRawData(rawInput, i, meatId) {
+  const [yy, mm, dd] = computeCurrentDate();
+  const dataSet = {
+    marbling: parseFloat(rawInput.marbling),
+    color: parseFloat(rawInput.color),
+    texture: parseFloat(rawInput.texture),
+    surfaceMoisture: parseFloat(rawInput.surfaceMoisture),
+    overall: parseFloat(rawInput.overall),
+  };
 
-// 원육 수정 POST API (이미지 수정)
-export default async function updateRawData(
-  raw_data, // 원육 데이터
-  id, // 이력번호
-  userId, // 로그인한 사용자 id
-  createdDate, // 생성 시간
-  elapsedHour // 경과 시간
-) {
-  //request body에 보낼 데이터 전처리
   let req = {
-    ...raw_data,
+    ['meatId']: meatId,
+    ['seqno']: i,
+    ['imgAdded']: false,
+    ['filmedAt']: '2024-07-08T12:12:12',
+    ['sensoryData']: dataSet,
   };
-  req = {
-    ...req,
-    ["id"]: id,
-    ["createdAt"]: createdDate,
-    ["userId"]: userId,
-    ["seqno"]: 0,
-    ["period"]: Math.round(elapsedHour),
-  };
+  console.log(req)
 
-  // /meat/add/sensory-eval로 원육 수정 데이터 API 전송
   try {
     const response = await fetch(`http://${apiIP}/meat/add/sensory-eval`, {
-      method: "PATCH",
+      method: 'PATCH',
       headers: {
-        "Content-Type": "application/json",
+        'Content-Type': 'application/json',
       },
       body: JSON.stringify(req),
     });
-    /*if (!response.ok) {
-            throw new Error('sensory_eval 서버에서 응답 코드가 성공(2xx)이 아닙니다.');
-        }
-        */
-    return response;
+    if (!response.ok) {
+      throw new Error(
+        'sensory_eval 서버에서 응답 코드가 성공(2xx)이 아닙니다.'
+      );
+    }
+    // 서버에서 받은 JSON 응답 데이터를 parse
+    const responseData = await response.json();
+    return responseData;
   } catch (err) {
-    console.log("error");
+    console.log('error');
     console.error(err);
   }
 }
+

--- a/test-web/src/API/update/updateRawImg.js
+++ b/test-web/src/API/update/updateRawImg.js
@@ -1,0 +1,42 @@
+import { apiIP } from "../../config";
+
+// 원육 수정 POST API (이미지 수정)
+export default async function updateRawImg(
+  raw_data, // 원육 데이터
+  id, // 이력번호
+  userId, // 로그인한 사용자 id
+  createdDate, // 생성 시간
+  elapsedHour // 경과 시간
+) {
+  //request body에 보낼 데이터 전처리
+  let req = {
+    ...raw_data,
+  };
+  req = {
+    ...req,
+    ["id"]: id,
+    ["createdAt"]: createdDate,
+    ["userId"]: userId,
+    ["seqno"]: 0,
+    ["period"]: Math.round(elapsedHour),
+  };
+
+  // /meat/add/sensory-eval로 원육 수정 데이터 API 전송
+  try {
+    const response = await fetch(`http://${apiIP}/meat/add/sensory-eval`, {
+      method: "PATCH",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(req),
+    });
+    /*if (!response.ok) {
+            throw new Error('sensory_eval 서버에서 응답 코드가 성공(2xx)이 아닙니다.');
+        }
+        */
+    return response;
+  } catch (err) {
+    console.log("error");
+    console.error(err);
+  }
+}

--- a/test-web/src/components/DataDetailPage/DataConfirmView.js
+++ b/test-web/src/components/DataDetailPage/DataConfirmView.js
@@ -21,6 +21,7 @@ import Spinner from 'react-bootstrap/Spinner';
 import updateHeatedData from '../../API/update/updateHeatedData';
 import updateProbexptData from '../../API/update/updateProbexptData';
 import updateProcessedData from '../../API/update/updateProcessedData';
+import updateRawData from '../../API/update/updateRawData';
 import RestrictedModal from './restrictedModal';
 // import card
 import QRInfoCard from './cardComps/QRInfoCard';
@@ -34,6 +35,7 @@ import RejectModal from './rejectModal';
 import { FaRegCheckCircle, FaRegTimesCircle } from 'react-icons/fa';
 // mui
 import { IconButton, TextField, Autocomplete } from '@mui/material';
+
 // import tables
 // import RawTable from './tablesComps/rawTable';
 import ProcessedTableStatic from './tablesComps/processedTableStatic';
@@ -146,65 +148,71 @@ function DataView({ dataProps }) {
     //로그인한 유저 정보
     const userId = JSON.parse(localStorage.getItem('UserInfo'))['userId'];
 
-    // 1. 가열육 관능검사 데이터 수정 API POST
-    for (let i = 0; i < len; i++) {
-      updateHeatedData(
-        heatInput[i],
-        i,
-        meatId,
-        createdDate,
-        userId,
-        elapsedHour
-      )
-        .then((response) => {
-          console.log('가열육 수정 POST요청 성공:', response);
-        })
-        .catch((error) => {
-          // 오류 발생 시의 처리
-          console.error('가열육 수정 POST 요청 오류:', error);
-        });
-    }
-    // 2. 실험실 데이터 수정 API POST
-    for (let i = 0; i < len; i++) {
-      updateProbexptData(
-        labInput[i],
-        i,
-        meatId,
-        createdDate,
-        userId,
-        elapsedHour
-      )
-        .then((response) => {
-          console.log('실험실 수정 POST요청 성공:', response);
-        })
-        .catch((error) => {
-          // 오류 발생 시의 처리
-          console.error('실험실 수정 POST 요청 오류:', error);
-        });
-    }
+    // 1. 가열육 관능검사 데이터 수정 API POST **승인되지 않은 데이터
+    // for (let i = 0; i < len; i++) {
+    //   updateHeatedData(
+    //     heatInput[i],
+    //     i,
+    //     meatId,
+    //     createdDate,
+    //     userId,
+    //     elapsedHour
+    //   )
+    //     .then((response) => {
+    //       console.log('가열육 수정 POST요청 성공:', response);
+    //     })
+    //     .catch((error) => {
+    //       // 오류 발생 시의 처리
+    //       console.error('가열육 수정 POST 요청 오류:', error);
+    //     });
+    // }
+    // 2. 실험실 데이터 수정 API POST ** 승인되지 않은 데이터
+    // for (let i = 0; i < len; i++) {
+    //   updateProbexptData(
+    //     labInput[i],
+    //     i,
+    //     meatId,
+    //     createdDate,
+    //     userId,
+    //     elapsedHour
+    //   )
+    //     .then((response) => {
+    //       console.log('실험실 수정 POST요청 성공:', response);
+    //     })
+    //     .catch((error) => {
+    //       // 오류 발생 시의 처리
+    //       console.error('실험실 수정 POST 요청 오류:', error);
+    //     });
+    // }
 
-    // 3. 처리육 관능검사 데이터 수정 API POST
-    const pro_len = len === 1 ? len : len - 1;
-    console.log('pro', pro_len);
-    for (let i = 0; i < pro_len; i++) {
-      updateProcessedData(
-        processedInput[i],
-        processed_data[i],
-        processedMinute[i],
-        i,
-        meatId,
-        userId,
-        createdDate,
-        elapsedHour
-      )
-        .then((response) => {
-          console.log('처리육 수정 POST요청 성공:', response);
-        })
-        .catch((error) => {
-          // 오류 발생 시의 처리
-          console.error('처리육 수정 POST 요청 오류:', error);
-        });
-    }
+    // 3. 처리육 관능검사 데이터 수정 API POST **승인되지 않은 육류데이터
+    // const pro_len = len === 1 ? len : len - 1;
+    // console.log('pro', pro_len);
+    // for (let i = 0; i < pro_len; i++) {
+    //   updateProcessedData(
+    //     processedInput[i],
+    //     // processed_data[i],
+    //     // processedMinute[i],
+    //     i,
+    //     meatId
+    //   )
+    //     .then((response) => {
+    //       console.log('처리육 수정 POST요청 성공:', response);
+    //     })
+    //     .catch((error) => {
+    //       // 오류 발생 시의 처리
+    //       console.error('처리육 수정 POST 요청 오류:', error);
+    //     });
+    // }
+    //4. 원육 데이터 수정 API
+    updateRawData(rawInput, 0, meatId)
+      .then((response) => {
+        console.log('원육 수정 POST요청 성공:', response);
+      })
+      .catch((error) => {
+        // 오류 발생 시의 처리
+        console.error('원육 수정 POST 요청 오류:', error);
+      });
   };
 
   // 처리육 이미지 먼저 업로드 경고 창 필요 여부
@@ -236,6 +244,13 @@ function DataView({ dataProps }) {
       }));
       console.log('result', temp, valueIdx);
     }
+  };
+  const handleRawInputChange = (e, field) => {
+    const { name, value } = e.target;
+    setRawInput((prev) => ({
+      ...prev,
+      [name]: value,
+    }));
   };
 
   const [imgArr, setImgArr] = useState([raw_img_path]);
@@ -358,7 +373,11 @@ function DataView({ dataProps }) {
             style={{ backgroundColor: 'white', width: '100%' }}
           >
             <Tab value="raw" eventKey="rawMeat" title="원육">
-              <RawTable data={rawInput} />
+              <RawTable
+                data={rawInput}
+                edited={edited}
+                handleRawInputChange={handleRawInputChange}
+              />
             </Tab>
             <Tab
               value="proc"

--- a/test-web/src/components/DataDetailPage/cardComps/MeatImgsCard.js
+++ b/test-web/src/components/DataDetailPage/cardComps/MeatImgsCard.js
@@ -6,7 +6,7 @@ import { FaArrowLeft, FaArrowRight, FaUpload } from 'react-icons/fa';
 // mui
 import { IconButton } from '@mui/material';
 // 이미지 수정 api 호출
-import updateRawData from '../../../API/update/updateRawData';
+import updateRawImg from '../../../API/update/updateRawImg';
 import updateProcessedData from '../../../API/update/updateProcessedData';
 import uploadNewImgToFirebase from '../../../API/firebase/uploadNewImgToFirebase';
 
@@ -95,7 +95,7 @@ const MeatImgsCard = ({
 
         // 원육 이미지 수정 api 호출 currentIdx == 0
         if (currentIdx === 0) {
-          const response = updateRawData(
+          const response = updateRawImg(
             raw_data,
             id,
             userId,

--- a/test-web/src/components/DataDetailPage/tablesComps/rawTable.js
+++ b/test-web/src/components/DataDetailPage/tablesComps/rawTable.js
@@ -1,14 +1,63 @@
+// import {
+//   Paper,
+//   Table,
+//   TableBody,
+//   TableCell,
+//   TableContainer,
+//   TableHead,
+//   TableRow,
+// } from '@mui/material';
+
+// const RawTable = ({ data }) => {
+//   return (
+//     <TableContainer
+//       key="rawmeat"
+//       component={Paper}
+//       sx={{ width: 'fitContent', overflow: 'auto' }}
+//     >
+//       <Table sx={{ minWidth: 300 }} size="small" aria-label="a dense table">
+//         <TableHead></TableHead>
+//         <TableBody>
+//           {rawField.map((f, idx) => {
+//             return (
+//               <TableRow key={'raw-Row' + idx}>
+//                 <TableCell key={'raw-' + idx + 'col1'}>
+//                   {rawDBFieldToSematicWord[f]}
+//                 </TableCell>
+//                 <TableCell key={'raw-' + idx + 'col2'}>
+//                   {data[f] ? data[f] : ''}
+//                 </TableCell>
+//               </TableRow>
+//             );
+//           })}
+//         </TableBody>
+//       </Table>
+//     </TableContainer>
+//   );
+// };
+
+// export default RawTable;
+
+// const rawField = ['marbling', 'color', 'texture', 'surfaceMoisture', 'overall'];
+// const rawDBFieldToSematicWord = {
+//   marbling: '마블링',
+//   color: '육색',
+//   texture: '조직감',
+//   surfaceMoisture: '표면육즙',
+//   overall: '기호도',
+// };
+
 import {
   Paper,
   Table,
   TableBody,
   TableCell,
   TableContainer,
-  TableHead,
   TableRow,
+  TextField,
 } from '@mui/material';
 
-const RawTable = ({ data }) => {
+const RawTable = ({ data, edited, handleRawInputChange }) => {
   return (
     <TableContainer
       key="rawmeat"
@@ -16,7 +65,6 @@ const RawTable = ({ data }) => {
       sx={{ width: 'fitContent', overflow: 'auto' }}
     >
       <Table sx={{ minWidth: 300 }} size="small" aria-label="a dense table">
-        <TableHead></TableHead>
         <TableBody>
           {rawField.map((f, idx) => {
             return (
@@ -25,7 +73,17 @@ const RawTable = ({ data }) => {
                   {rawDBFieldToSematicWord[f]}
                 </TableCell>
                 <TableCell key={'raw-' + idx + 'col2'}>
-                  {data[f] ? data[f] : ''}
+                  {edited ? (
+                    <TextField
+                      name={f}
+                      value={data[f] || ''}
+                      onChange={(e) => handleRawInputChange(e, f)}
+                      variant="outlined"
+                      size="small"
+                    />
+                  ) : (
+                    data[f] || ''
+                  )}
                 </TableCell>
               </TableRow>
             );


### PR DESCRIPTION
<img width="1248" alt="image" src="https://github.com/user-attachments/assets/14829555-61d3-424d-bcdd-21089dfdb154">


- 승인되지 않은 데이터에 대해서 원육은 수정 가능 나머지는 수정가능하지 않도록 함.
- rawdata를 수정하는 기존코드가 이미지를 처리하는 것으로 새로 만든 원육 데이터 수정 api를 보내는 것을 rawdata로 하고, 기조 것을 rawimg 파일로 이름 변경.
- 일단 구현은 되는데 여러가지 테스트로 에러핸들링 해야함.