### PR TITLE
fix: data format and treat transaction

### DIFF
--- a/test-backend/test-flask/db/db_controller.py
+++ b/test-backend/test-flask/db/db_controller.py
@@ -90,7 +90,7 @@ def create_meat(db_session, meat_data: dict):
         db_session.query(GradeInfo).filter_by(value=meat_data.get("gradeNum")).first()
     )
     # 3. meat_data에 없는 not null 필드 추가
-    meat_data['createdAt'] = datetime.now().strftime('%Y-%m-%d')
+    meat_data['createdAt'] = convert2string(datetime.now(), 1)
     
     # 4, meat_data에 있는 필드 수정
     meat_data['id'] = meat_data.pop('meatId')
@@ -238,7 +238,6 @@ def create_specific_std_meat_data(db_session, s3_conn, firestore_conn, data, mea
             new_meat.statusType = 0
             
             db_session.merge(new_meat)
-            db_session.commit()
             
             # 2. Firestore -> S3
             transfer_folder_image(
@@ -262,7 +261,7 @@ def create_specific_std_meat_data(db_session, s3_conn, firestore_conn, data, mea
             existing_meat.categoryId = new_category.id
             
             db_session.add(existing_meat)
-            db_session.commit()
+        db_session.commit()
 
     except Exception as e:
         db_session.rollback()
@@ -352,7 +351,6 @@ def create_specific_sensory_eval(db_session, s3_conn, firestore_conn, data, is_p
                 sensory_data["createdAt"] = convert2string(datetime.now(), 1)
                 new_sensory_eval = create_SensoryEval(db_session, data, sensory_data, seqno, meat_id, user_id)
                 db_session.add(new_sensory_eval)
-                db_session.commit()
 
                 if need_img:
                     transfer_folder_image(
@@ -379,7 +377,6 @@ def create_specific_sensory_eval(db_session, s3_conn, firestore_conn, data, is_p
                     return {"msg": "Already Confirmed Meat", "code": 400}
                 meat.statusType == 0
                 db_session.merge(meat)
-                db_session.commit()
                 
             # sensory_eval 생성
             if any(value is not None for value in sensory_data.values()):
@@ -432,7 +429,6 @@ def create_specific_heatedmeat_seonsory_eval(db_session, firestore_conn, s3_conn
             sensory_data["createdAt"] = existed_sensory_data["createdAt"]
             new_sensory_data = create_HeatemeatSensoryEval(sensory_data, id, seqno)
             db_session.merge(new_sensory_data)
-            db_session.commit()
             
         else: # 생성
             if not is_post: # 생성인데 PATCH 메서드

--- a/test-backend/test-flask/db/db_controller.py
+++ b/test-backend/test-flask/db/db_controller.py
@@ -347,24 +347,21 @@ def create_specific_sensory_eval(db_session, s3_conn, firestore_conn, data, is_p
             
             user_id = safe_str(data.get("userId"))
             # sensory_eval 생성
-            if any(value is not None for value in sensory_data.values()):
-                sensory_data["createdAt"] = convert2string(datetime.now(), 1)
-                new_sensory_eval = create_SensoryEval(db_session, data, sensory_data, seqno, meat_id, user_id)
-                db_session.add(new_sensory_eval)
+            sensory_data["createdAt"] = convert2string(datetime.now(), 1)
+            new_sensory_eval = create_SensoryEval(db_session, data, sensory_data, seqno, meat_id, user_id)
+            db_session.add(new_sensory_eval)
 
-                if need_img:
-                    transfer_folder_image(
-                        s3_conn,
-                        firestore_conn,
-                        db_session,
-                        f"{meat_id}-{seqno}",
-                        new_sensory_eval,
-                        "sensory_evals",
-                    )
-                db_session.commit()
-                return {"msg": f"Success to Create Sensory Evaluation {meat_id}-{seqno}", "code": 200}
-            else:
-                return {"msg": f"No Sensory Data to Create Sensory Evaluation", "code": 400}
+            if need_img:
+                transfer_folder_image(
+                    s3_conn,
+                    firestore_conn,
+                    db_session,
+                    f"{meat_id}-{seqno}",
+                    new_sensory_eval,
+                    "sensory_evals",
+                )
+            db_session.commit()
+            return {"msg": f"Success to Create Sensory Evaluation {meat_id}-{seqno}", "code": 200}
         # PATCH 요청
         else:
             # 기존 관능 평가 데이터가 존재하지 않을 때 에러 처리
@@ -379,24 +376,22 @@ def create_specific_sensory_eval(db_session, s3_conn, firestore_conn, data, is_p
                 db_session.merge(meat)
                 
             # sensory_eval 생성
-            if any(value is not None for value in sensory_data.values()):
-                sensory_data["createdAt"] = convert2string(existing_sensory.createdAt, 1)
-                new_sensory_eval = create_SensoryEval(db_session, data, sensory_data, seqno, meat_id, existing_user)
-                db_session.merge(new_sensory_eval)
+            sensory_data["createdAt"] = convert2string(existing_sensory.createdAt, 1)
+            new_sensory_eval = create_SensoryEval(db_session, data, sensory_data, seqno, meat_id, existing_user)
+            db_session.merge(new_sensory_eval)
 
-                if need_img:
-                    transfer_folder_image(
-                        s3_conn,
-                        firestore_conn,
-                        db_session,
-                        f"{meat_id}-{seqno}",
-                        new_sensory_eval,
-                        "sensory_evals",
-                    )
-                db_session.commit()
-                return {"msg": f"Success to Update Sensory Evaluation {meat_id}-{seqno}", "code": 200}
-            else:
-                return {"msg": f"No Sensory Data to Update Sensory Evaluation", "code": 400}
+            if need_img:
+                transfer_folder_image(
+                    s3_conn,
+                    firestore_conn,
+                    db_session,
+                    f"{meat_id}-{seqno}",
+                    new_sensory_eval,
+                    "sensory_evals",
+                )
+            db_session.commit()
+            return {"msg": f"Success to Update Sensory Evaluation {meat_id}-{seqno}", "code": 200}
+            
     except Exception as e:
         db_session.rollback()
         raise e


### PR DESCRIPTION
## 수정한 점
- `createdAt` 데이터가 날짜와 시간을 포함한 문자열 포맷으로 dictionary에 저장되도록 수정
- DB 쿼리의 transaction을 정리하여 이미지 경로 수정 단계에서 에러가 발생하였을 때 전체 쿼리문이 rollback되도록 수정
- 처리육의 이미지만 등록되고 관능데이터는 입력되지 않을수도 있으므로 모든 `sensory_data`의 값이 null이더라도 POST/PATCH가 이루어지도록 수정