### PR TITLE
fix: merge() 대신 setattr()를 활용하여 imagePath를 업데이트하도록 수정

### DIFF
--- a/test-backend/test-flask/db/db_controller.py
+++ b/test-backend/test-flask/db/db_controller.py
@@ -237,7 +237,7 @@ def create_specific_std_meat_data(db_session, s3_conn, firestore_conn, data, mea
             new_meat = create_meat(db_session=db_session, meat_data=data)
             new_meat.statusType = 0
             
-            db_session.merge(new_meat)
+            db_session.add(new_meat)
             
             # 2. Firestore -> S3
             transfer_folder_image(
@@ -260,10 +260,11 @@ def create_specific_std_meat_data(db_session, s3_conn, firestore_conn, data, mea
             ).first()
             existing_meat.categoryId = new_category.id
             
-            db_session.add(existing_meat)
+            db_session.merge(existing_meat)
         db_session.commit()
 
     except Exception as e:
+        # logger.info(str(e))
         db_session.rollback()
         raise e
 
@@ -424,7 +425,7 @@ def create_specific_heatedmeat_seonsory_eval(db_session, firestore_conn, s3_conn
             sensory_data["createdAt"] = existed_sensory_data["createdAt"]
             new_sensory_data = create_HeatemeatSensoryEval(sensory_data, id, seqno)
             db_session.merge(new_sensory_data)
-            
+
         else: # 생성
             if not is_post: # 생성인데 PATCH 메서드
                 return ({"msg": "Heatedmeat Sensory Data Does NOT Exists", "code": 400})

--- a/test-backend/test-flask/utils.py
+++ b/test-backend/test-flask/utils.py
@@ -402,8 +402,9 @@ def transfer_folder_image(s3_conn, firestore_conn, db_session, id, new_meat, fol
             new_meat.imagePath = None
             raise Exception("Failed to transfer meat image")
 
-        new_meat.imagePath = s3_conn.get_image_url(s3_conn.bucket, f"{folder}/{id}")
-        db_session.merge(new_meat)
+        # new_meat.imagePath = s3_conn.get_image_url(s3_conn.bucket, f"{folder}/{id}")
+        # db_session.merge(new_meat)
+        setattr(new_meat, 'imagePath', s3_conn.get_image_url(s3_conn.bucket, f"{folder}/{id}"))
         db_session.commit()
     except Exception as e:
         db_session.rollback()


### PR DESCRIPTION
## 수정한 점
- `transfer_folder_image`에서 imagePath가 업데이트된 `new_meat` 객체를 merge하던 것을 setattr를 통해 imagePath column만 업데이트하도록 수정
- 이미지 처리 등에서 에러가 발생할 경우 transaction을 rollback할 수 있도록 commit()을 일괄적으로 처리