### PR TITLE
hotfix: user의 createdAt의 타입을 시간을 포함한 문자열로 변경

### DIFF
--- a/test-backend/test-flask/api/user_api.py
+++ b/test-backend/test-flask/api/user_api.py
@@ -115,7 +115,6 @@ def register_user_data():
         existing_user = get_user(db_session, user_id)
         if existing_user:
             return jsonify({"msg": "User already exists"}), 400
-        data["createdAt"] = datetime.now()
 
         create_user(db_session, data)
 

--- a/test-backend/test-flask/db/db_controller.py
+++ b/test-backend/test-flask/db/db_controller.py
@@ -742,6 +742,7 @@ def delete_user(db_session, user):
 # USER
 def create_user(db_session, user_data: dict):
     try:
+        user_data['createdAt'] = convert2string(datetime.now(), 1)
         for field, value in user_data.items():
             if field == "type":
                 user_type = db_session.query(UserTypeInfo).filter_by(name=value).first()


### PR DESCRIPTION
## 수정한 점
- `user`의 `createdAt`의 타입이 일자와 시간을 포함한 문자열 형식으로 저장되도록 수정