### PR TITLE
hotfix: meat/get/by-status에서 status_type 조건문 에러 수정

### DIFF
--- a/test-backend/test-flask/api/get_api.py
+++ b/test-backend/test-flask/api/get_api.py
@@ -253,7 +253,7 @@ def getMeatDataByRangeStatusType():
 
         start = convert2datetime(start_str, 0)
         end = convert2datetime(end_str, 0)
-        if status_type and specie_value:
+        if status_type is not None and specie_value is not None:
             return _getMeatDataByRangeStatusType(
                 db_session, status_type, offset, count, specie_value, start, end
             )


### PR DESCRIPTION
/meat/get/by-status 에서 status_type과 specie_value가 0으로 들어올 때 조건문 잘못 처리된 부분 수정함