### PR TITLE
feat: db-model에서 openCV 결과 테이블 추가 및 실험실 테이블에서 createdAt으로 수정

### DIFF
--- a/test-backend/test-flask/db/db_controller.py
+++ b/test-backend/test-flask/db/db_controller.py
@@ -475,7 +475,7 @@ def create_specific_probexpt_data(db_session, data, is_post):
                 return ({"msg": "Not Confirmed Data", "code": 400})
 
             probexpt_data["userId"] = existed_probexpt_data["userId"]
-            probexpt_data["updatedAt"] = existed_probexpt_data["updatedAt"]
+            probexpt_data["createdAt"] = existed_probexpt_data["createdAt"]
             new_probexpt_data = create_ProbexptData(probexpt_data, id, seqno, is_heated)
             db_session.merge(new_probexpt_data)
             db_session.commit()
@@ -484,7 +484,7 @@ def create_specific_probexpt_data(db_session, data, is_post):
             if not is_post: # 생성이지만 PATCH 메서드
                 return ({"msg": "Probexpt Data Does NOT Exists", "code": 400})
             probexpt_data["userId"] = data["userId"]
-            probexpt_data["updatedAt"] = convert2string(datetime.now(), 1) # updatedAt -> createdAt으로 수정 예정
+            probexpt_data["createdAt"] = convert2string(datetime.now(), 1) # updatedAt -> createdAt으로 수정 예정
             probexpt_data["period"] = calculate_period(db_session, id)
             new_probexpt_data = create_ProbexptData(probexpt_data, id, seqno, is_heated)
             db_session.add(new_probexpt_data)
@@ -622,7 +622,7 @@ def get_ProbexptData(db_session, id, seqno, is_heated):
     if probexpt_data:
         probexpt = to_dict(probexpt_data)
         probexpt["meatId"] = probexpt.pop("id")
-        probexpt["updatedAt"] = convert2string(probexpt["updatedAt"], 1)
+        probexpt["createdAt"] = convert2string(probexpt["createdAt"], 1)
         probexpt["userName"] = get_user(db_session, probexpt["userId"]).name
         del probexpt["isHeated"]
         return probexpt


### PR DESCRIPTION
## DB model 수정 사항
### 1) OpenCV 결과 테이블 추가
- 벡터값인 컬러팔레트들과 LBP images, gabor filter images는 s3 image path로 구성된 JSONB 타입으로 지정

### 2) probexpt_data 테이블에서 updatedAt -> createdAt 수정
- 이전 리팩토링 당시 수정하기로 한 probexpt_data.updatedAt을 그 용도에 알맞게 createdAt으로 수정함
- db_controller.py에서 updatedAt으로 쓰였던 코드들도 모두 createdAt으로 수정함

## 논의할 점
- 현재 openCV 테이블에서 id, seqno, createdAt을 제외한 나머지들은 nullable하게 지정하였음. 근데 이걸 not null 조건을 걸어주는게 맞을지? (단면 이미지가 존재한다면 나머지 결과들은 반드시 생성된다고 함)

## db table 생성 이미지
<img width="600" alt="스크린샷 2024-07-30 오전 10 50 15" src="https://github.com/user-attachments/assets/1682cc72-565c-4b3b-84dd-028d6ba12e4d">
<img width="600" alt="스크린샷 2024-07-30 오전 10 50 25" src="https://github.com/user-attachments/assets/fb43e0f7-8d6b-47ce-a8df-a1524b759857">
<img width="600" alt="스크린샷 2024-07-30 오전 10 50 38" src="https://github.com/user-attachments/assets/da51cad0-3fca-45f4-b7d3-75c44b168350">
