### PR TITLE
fix:상관관계 일부 수정

### DIFF
--- a/test-web/src/components/Stats/Charts/BoxPlot/Sens_FreshMeat.js
+++ b/test-web/src/components/Stats/Charts/BoxPlot/Sens_FreshMeat.js
@@ -55,6 +55,14 @@ export default function Sens_FreshMeat({
     title: {
       text: '원육 관능데이터 박스 플롯(Box Plot) 분포',
     },
+    // plotOptions: {
+    //   boxPlot: {
+    //     colors: {
+    //       upper: '#7BD758',
+    //       lower: '#BFE692',
+    //     },
+    //   },
+    // },
   };
 
   // Conditionally render the chart only when chartData is not empty

--- a/test-web/src/components/Stats/Charts/Corr/Sens_Fresh_Corr.js
+++ b/test-web/src/components/Stats/Charts/Corr/Sens_Fresh_Corr.js
@@ -134,6 +134,15 @@ export default function Sense_Fresh_Corr({
         right: 20,
       },
     },
+    tooltip: {
+      enabled: true,
+      y: {
+        formatter: function (value) {
+          const decimalValue = value / 100;
+          return decimalValue.toFixed(3);
+        },
+      },
+    },
     plotOptions: {
       heatmap: {
         colorScale: {
@@ -141,67 +150,67 @@ export default function Sense_Fresh_Corr({
             {
               from: -100,
               to: -99,
-              name: '-100% ~',
+              name: '-1 ~',
               color: '#26578B', // 군청색
             },
             {
               from: -99,
               to: -96,
-              name: '-99% ~',
+              name: '-0.99 ~',
               color: '#456F9B', // 덜 진한 군청색
             },
             {
               from: -96,
               to: -93,
-              name: '-96% ~',
+              name: '-0.96 ~',
               color: '#6487AC', // 중간 군청색
             },
             {
               from: -93,
               to: -80,
-              name: '-93% ~',
+              name: '-0.93 ~',
               color: '#839FBC', // 연한 군청색
             },
             {
               from: -80,
               to: -0.00001,
-              name: '-80% ~ 0%',
+              name: '-0.80 ~ 0',
               color: '#A2B7CD', // 아주 연한 군청색
             },
             {
               from: 0,
               to: 80,
-              name: '0% ~ 80%',
+              name: '0 ~ 0.80',
               color: '#C89191', // 아주 연한 진홍색
             },
             {
               from: 80,
               to: 93,
-              name: '~ 93%',
+              name: '~ 0.93',
               color: '#B66D6D', // 연한 진홍색
             },
             {
               from: 93,
               to: 96,
-              name: '~ 96%',
+              name: '~ 0.96',
               color: '#A44848', // 중간 진홍색
             },
             {
               from: 96,
               to: 99,
-              name: '~ 99%',
+              name: '~ 0.99',
               color: '#922424', // 덜 진한 진홍색
             },
             {
               from: 99,
               to: 99.99999,
-              name: '~ 100%',
+              name: '~ 1',
               color: '#800000', // 진한 진홍색
             },
             {
               from: 99.99999,
               to: 100,
-              name: '100%',
+              name: '1',
               color: '#000000', // 검정색(자기자신과의 상관계수)
             },
           ],

--- a/test-web/src/components/Stats/Charts/Corr/Sens_Heated_Corr.js
+++ b/test-web/src/components/Stats/Charts/Corr/Sens_Heated_Corr.js
@@ -129,6 +129,15 @@ export default function Sense_Heated_Corr({
         right: 20,
       },
     },
+    tooltip: {
+      enabled: true,
+      y: {
+        formatter: function (value) {
+          const decimalValue = value / 100;
+          return decimalValue.toFixed(3);
+        },
+      },
+    },
     plotOptions: {
       heatmap: {
         colorScale: {
@@ -136,67 +145,67 @@ export default function Sense_Heated_Corr({
             {
               from: -100,
               to: -99,
-              name: '-100% ~',
+              name: '-1 ~',
               color: '#26578B', // 군청색
             },
             {
               from: -99,
               to: -96,
-              name: '-99% ~',
+              name: '-0.99 ~',
               color: '#456F9B', // 덜 진한 군청색
             },
             {
               from: -96,
               to: -93,
-              name: '-96% ~',
+              name: '-0.96 ~',
               color: '#6487AC', // 중간 군청색
             },
             {
               from: -93,
               to: -80,
-              name: '-93% ~',
+              name: '-0.93 ~',
               color: '#839FBC', // 연한 군청색
             },
             {
               from: -80,
               to: -0.00001,
-              name: '-80% ~ 0%',
+              name: '-0.80 ~ 0',
               color: '#A2B7CD', // 아주 연한 군청색
             },
             {
               from: 0,
               to: 80,
-              name: '0% ~ 80%',
+              name: '0 ~ 0.80',
               color: '#C89191', // 아주 연한 진홍색
             },
             {
               from: 80,
               to: 93,
-              name: '~ 93%',
+              name: '~ 0.93',
               color: '#B66D6D', // 연한 진홍색
             },
             {
               from: 93,
               to: 96,
-              name: '~ 96%',
+              name: '~ 0.96',
               color: '#A44848', // 중간 진홍색
             },
             {
               from: 96,
               to: 99,
-              name: '~ 99%',
+              name: '~ 0.99',
               color: '#922424', // 덜 진한 진홍색
             },
             {
               from: 99,
-              to: 100,
-              name: '~ 100%',
+              to: 99.99999,
+              name: '~ 1',
               color: '#800000', // 진한 진홍색
             },
             {
               from: 99.99999,
               to: 100,
-              name: '100%',
+              name: '1',
               color: '#000000', // 검정색(자기자신과의 상관계수)
             },
           ],

--- a/test-web/src/components/Stats/Charts/Corr/Sens_Proc_Corr.js
+++ b/test-web/src/components/Stats/Charts/Corr/Sens_Proc_Corr.js
@@ -128,6 +128,15 @@ export default function Sense_Proc_Corr({
         right: 20,
       },
     },
+    tooltip: {
+      enabled: true,
+      y: {
+        formatter: function (value) {
+          const decimalValue = value / 100;
+          return decimalValue.toFixed(3);
+        },
+      },
+    },
     plotOptions: {
       heatmap: {
         colorScale: {
@@ -135,67 +144,67 @@ export default function Sense_Proc_Corr({
             {
               from: -100,
               to: -99,
-              name: '-100% ~',
+              name: '-1 ~',
               color: '#26578B', // 군청색
             },
             {
               from: -99,
               to: -96,
-              name: '-99% ~',
+              name: '-0.99 ~',
               color: '#456F9B', // 덜 진한 군청색
             },
             {
               from: -96,
               to: -93,
-              name: '-96% ~',
+              name: '-0.96 ~',
               color: '#6487AC', // 중간 군청색
             },
             {
               from: -93,
               to: -80,
-              name: '-93% ~',
+              name: '-0.93 ~',
               color: '#839FBC', // 연한 군청색
             },
             {
               from: -80,
               to: -0.00001,
-              name: '-80% ~ 0%',
+              name: '-0.80 ~ 0',
               color: '#A2B7CD', // 아주 연한 군청색
             },
             {
               from: 0,
               to: 80,
-              name: '0% ~ 80%',
+              name: '0 ~ 0.80',
               color: '#C89191', // 아주 연한 진홍색
             },
             {
               from: 80,
               to: 93,
-              name: '~ 93%',
+              name: '~ 0.93',
               color: '#B66D6D', // 연한 진홍색
             },
             {
               from: 93,
               to: 96,
-              name: '~ 96%',
+              name: '~ 0.96',
               color: '#A44848', // 중간 진홍색
             },
             {
               from: 96,
               to: 99,
-              name: '~ 99%',
+              name: '~ 0.99',
               color: '#922424', // 덜 진한 진홍색
             },
             {
               from: 99,
-              to: 100,
-              name: '~ 100%',
+              to: 99.99999,
+              name: '~ 1',
               color: '#800000', // 진한 진홍색
             },
             {
               from: 99.99999,
               to: 100,
-              name: '100%',
+              name: '1',
               color: '#000000', // 검정색(자기자신과의 상관계수)
             },
           ],

--- a/test-web/src/components/Stats/Charts/Corr/Taste_Fresh_Corr.js
+++ b/test-web/src/components/Stats/Charts/Corr/Taste_Fresh_Corr.js
@@ -135,6 +135,15 @@ export default function Taste_Fresh_Corr({
         right: 20,
       },
     },
+    tooltip: {
+      enabled: true,
+      y: {
+        formatter: function (value) {
+          const decimalValue = value / 100;
+          return decimalValue.toFixed(3);
+        },
+      },
+    },
     plotOptions: {
       heatmap: {
         colorScale: {
@@ -142,67 +151,67 @@ export default function Taste_Fresh_Corr({
             {
               from: -100,
               to: -99,
-              name: '-100% ~',
+              name: '-1 ~',
               color: '#26578B', // 군청색
             },
             {
               from: -99,
               to: -96,
-              name: '-99% ~',
+              name: '-0.99 ~',
               color: '#456F9B', // 덜 진한 군청색
             },
             {
               from: -96,
               to: -93,
-              name: '-96% ~',
+              name: '-0.96 ~',
               color: '#6487AC', // 중간 군청색
             },
             {
               from: -93,
               to: -80,
-              name: '-93% ~',
+              name: '-0.93 ~',
               color: '#839FBC', // 연한 군청색
             },
             {
               from: -80,
               to: -0.00001,
-              name: '-80% ~ 0%',
+              name: '-0.80 ~ 0',
               color: '#A2B7CD', // 아주 연한 군청색
             },
             {
               from: 0,
               to: 80,
-              name: '0% ~ 80%',
+              name: '0 ~ 0.80',
               color: '#C89191', // 아주 연한 진홍색
             },
             {
               from: 80,
               to: 93,
-              name: '~ 93%',
+              name: '~ 0.93',
               color: '#B66D6D', // 연한 진홍색
             },
             {
               from: 93,
               to: 96,
-              name: '~ 96%',
+              name: '~ 0.96',
               color: '#A44848', // 중간 진홍색
             },
             {
               from: 96,
               to: 99,
-              name: '~ 99%',
+              name: '~ 0.99',
               color: '#922424', // 덜 진한 진홍색
             },
             {
               from: 99,
-              to: 100,
-              name: '~ 100%',
+              to: 99.99999,
+              name: '~ 1',
               color: '#800000', // 진한 진홍색
             },
             {
               from: 99.99999,
               to: 100,
-              name: '100%',
+              name: '1',
               color: '#000000', // 검정색(자기자신과의 상관계수)
             },
           ],

--- a/test-web/src/components/Stats/Charts/Corr/Taste_Proc_Corr.js
+++ b/test-web/src/components/Stats/Charts/Corr/Taste_Proc_Corr.js
@@ -128,6 +128,15 @@ export default function Taste_Proc_Corr({
         right: 20,
       },
     },
+    tooltip: {
+      enabled: true,
+      y: {
+        formatter: function (value) {
+          const decimalValue = value / 100;
+          return decimalValue.toFixed(3);
+        },
+      },
+    },
     plotOptions: {
       heatmap: {
         colorScale: {
@@ -135,67 +144,67 @@ export default function Taste_Proc_Corr({
             {
               from: -100,
               to: -99,
-              name: '-100% ~',
+              name: '-1 ~',
               color: '#26578B', // 군청색
             },
             {
               from: -99,
               to: -96,
-              name: '-99% ~',
+              name: '-0.99 ~',
               color: '#456F9B', // 덜 진한 군청색
             },
             {
               from: -96,
               to: -93,
-              name: '-96% ~',
+              name: '-0.96 ~',
               color: '#6487AC', // 중간 군청색
             },
             {
               from: -93,
               to: -80,
-              name: '-93% ~',
+              name: '-0.93 ~',
               color: '#839FBC', // 연한 군청색
             },
             {
               from: -80,
               to: -0.00001,
-              name: '-80% ~ 0%',
+              name: '-0.80 ~ 0',
               color: '#A2B7CD', // 아주 연한 군청색
             },
             {
               from: 0,
               to: 80,
-              name: '0% ~ 80%',
+              name: '0 ~ 0.80',
               color: '#C89191', // 아주 연한 진홍색
             },
             {
               from: 80,
               to: 93,
-              name: '~ 93%',
+              name: '~ 0.93',
               color: '#B66D6D', // 연한 진홍색
             },
             {
               from: 93,
               to: 96,
-              name: '~ 96%',
+              name: '~ 0.96',
               color: '#A44848', // 중간 진홍색
             },
             {
               from: 96,
               to: 99,
-              name: '~ 99%',
+              name: '~ 0.99',
               color: '#922424', // 덜 진한 진홍색
             },
             {
               from: 99,
-              to: 100,
-              name: '~ 100%',
+              to: 99.99999,
+              name: '~ 1',
               color: '#800000', // 진한 진홍색
             },
             {
               from: 99.99999,
               to: 100,
-              name: '100%',
+              name: '1',
               color: '#000000', // 검정색(자기자신과의 상관계수)
             },
           ],


### PR DESCRIPTION
상관관계는 %가 아닌 소수점 값이므로 이를 반영함.
하지만 값이 0보다 작을 경우 히트맵 차트에서 범례별로 마우스 오버했을 때, 확인 안 되는 오류
이를 툴팁에서만 소수점으로 다시 보이게 수정 -> 직관적으로 보이도록 수정
![화면 캡처 2024-07-30 171154](https://github.com/user-attachments/assets/680f5fb9-2075-43ea-b794-c073fc07435e)
