### PR TITLE
fix: 분포 데이터 값 처리 방식 수정

### DIFF
--- a/test-web/src/components/Stats/Charts/Corr/Sens_Fresh_Corr.js
+++ b/test-web/src/components/Stats/Charts/Corr/Sens_Fresh_Corr.js
@@ -112,6 +112,20 @@ export default function Sense_Fresh_Corr({
       height: 450,
       width: '100%',
       type: 'heatmap',
+      // events: {
+      //   mounted: function(chart) {
+      //     const styleTag = document.createElement('style');
+      //     styleTag.innerHTML = `
+      //       .custom-tooltip {
+      //         background: #fff;
+      //         border: 1px solid #ccc;
+      //         padding: 5px 10px;
+      //         font-size: 12px;
+      //       }
+      //     `;
+      //     document.head.appendChild(styleTag);
+      //   }
+      // }
     },
     grid: {
       padding: {
@@ -134,12 +148,40 @@ export default function Sense_Fresh_Corr({
         right: 20,
       },
     },
+    // tooltip: {
+    //   enabled: true,
+    //   y: {
+    //     formatter: function (value) {
+    //       const decimalValue = value / 100;
+    //       return decimalValue.toFixed(3);
+    //     },
+    //   },
+    // },
+    // tooltip: {
+    //   enabled: true,
+    //   custom: function ({ series, seriesIndex, dataPointIndex, w }) {
+    //     const xLabel = w.globals.labels[dataPointIndex];
+    //     const yLabel = w.config.series[seriesIndex].name;
+    //     const value = series[seriesIndex][dataPointIndex];
+    //     const decimalValue = (value / 100).toFixed(3);
+    //     return `<div class="custom-tooltip">
+    //       <span>${yLabel} - ${xLabel}: ${decimalValue}</span>
+    //     </div>`;
+    //   },
+    // },
     tooltip: {
       enabled: true,
       y: {
+        title: {
+          formatter: function (value, { seriesIndex, dataPointIndex, w }) {
+            const xLabel = w.globals.labels[dataPointIndex];
+            const yLabel = w.config.series[seriesIndex].name;
+            return `${yLabel} - ${xLabel}:`;
+          },
+        },
         formatter: function (value) {
-          const decimalValue = value / 100;
-          return decimalValue.toFixed(3);
+          const decimalValue = (value / 100).toFixed(3);
+          return `${decimalValue}`;
         },
       },
     },

--- a/test-web/src/components/Stats/Charts/Corr/Sens_Heated_Corr.js
+++ b/test-web/src/components/Stats/Charts/Corr/Sens_Heated_Corr.js
@@ -132,9 +132,16 @@ export default function Sense_Heated_Corr({
     tooltip: {
       enabled: true,
       y: {
+        title: {
+          formatter: function (value, { seriesIndex, dataPointIndex, w }) {
+            const xLabel = w.globals.labels[dataPointIndex];
+            const yLabel = w.config.series[seriesIndex].name;
+            return `${yLabel} - ${xLabel}:`;
+          },
+        },
         formatter: function (value) {
-          const decimalValue = value / 100;
-          return decimalValue.toFixed(3);
+          const decimalValue = (value / 100).toFixed(3);
+          return `${decimalValue}`;
         },
       },
     },

--- a/test-web/src/components/Stats/Charts/Corr/Sens_Proc_Corr.js
+++ b/test-web/src/components/Stats/Charts/Corr/Sens_Proc_Corr.js
@@ -131,9 +131,16 @@ export default function Sense_Proc_Corr({
     tooltip: {
       enabled: true,
       y: {
+        title: {
+          formatter: function (value, { seriesIndex, dataPointIndex, w }) {
+            const xLabel = w.globals.labels[dataPointIndex];
+            const yLabel = w.config.series[seriesIndex].name;
+            return `${yLabel} - ${xLabel}:`;
+          },
+        },
         formatter: function (value) {
-          const decimalValue = value / 100;
-          return decimalValue.toFixed(3);
+          const decimalValue = (value / 100).toFixed(3);
+          return `${decimalValue}`;
         },
       },
     },

--- a/test-web/src/components/Stats/Charts/Corr/Taste_Fresh_Corr.js
+++ b/test-web/src/components/Stats/Charts/Corr/Taste_Fresh_Corr.js
@@ -138,9 +138,16 @@ export default function Taste_Fresh_Corr({
     tooltip: {
       enabled: true,
       y: {
+        title: {
+          formatter: function (value, { seriesIndex, dataPointIndex, w }) {
+            const xLabel = w.globals.labels[dataPointIndex];
+            const yLabel = w.config.series[seriesIndex].name;
+            return `${yLabel} - ${xLabel}:`;
+          },
+        },
         formatter: function (value) {
-          const decimalValue = value / 100;
-          return decimalValue.toFixed(3);
+          const decimalValue = (value / 100).toFixed(3);
+          return `${decimalValue}`;
         },
       },
     },

--- a/test-web/src/components/Stats/Charts/Corr/Taste_Proc_Corr.js
+++ b/test-web/src/components/Stats/Charts/Corr/Taste_Proc_Corr.js
@@ -131,9 +131,16 @@ export default function Taste_Proc_Corr({
     tooltip: {
       enabled: true,
       y: {
+        title: {
+          formatter: function (value, { seriesIndex, dataPointIndex, w }) {
+            const xLabel = w.globals.labels[dataPointIndex];
+            const yLabel = w.config.series[seriesIndex].name;
+            return `${yLabel} - ${xLabel}:`;
+          },
+        },
         formatter: function (value) {
-          const decimalValue = value / 100;
-          return decimalValue.toFixed(3);
+          const decimalValue = (value / 100).toFixed(3);
+          return `${decimalValue}`;
         },
       },
     },

--- a/test-web/src/components/Stats/Charts/HeatMap/Sens_Fresh_Map.js
+++ b/test-web/src/components/Stats/Charts/HeatMap/Sens_Fresh_Map.js
@@ -1,5 +1,6 @@
 import ApexCharts from 'react-apexcharts';
 import React, { useEffect, useState } from 'react';
+import CircularProgress from '@mui/material/CircularProgress';
 import { statisticSensoryFresh } from '../../../../API/statistic/statisticSensoryFresh';
 
 export default function Sens_Fresh_Map({
@@ -47,11 +48,17 @@ export default function Sens_Fresh_Map({
     ChartSeries = prop
       .map((property) => {
         const uniqueValues = chartData[property].values;
-        const frequencies = new Array(9).fill(0);
+        const frequencies = new Array(11).fill(0);
 
         uniqueValues.forEach((value) => {
-          const index = Math.floor(value);
-          frequencies[index - 1] += 1;
+          if (value > 10) {
+            frequencies[10] += 1;
+          } else if (value < 1) {
+            frequencies[0] += 1;
+          } else {
+            const index = Math.floor(value);
+            frequencies[index] += 1;
+          }
         });
 
         return {
@@ -72,9 +79,9 @@ export default function Sens_Fresh_Map({
     },
     xaxis: {
       type: 'numeric',
-      tickAmount: 9,
-      min: 1,
-      max: 10,
+      tickAmount: 11,
+      min: 0,
+      max: 11,
     },
     title: {
       text: '원육 관능데이터 범위별 분포(빈도수)',

--- a/test-web/src/components/Stats/Charts/HeatMap/Sens_Fresh_Map.js
+++ b/test-web/src/components/Stats/Charts/HeatMap/Sens_Fresh_Map.js
@@ -104,6 +104,15 @@ export default function Sens_Fresh_Map({
     tooltip: {
       enabled: true,
       y: {
+        title: {
+          formatter: function (value, { seriesIndex }) {
+            const axisName = ChartSeries[seriesIndex].name;
+            const originalProperty = Object.keys(y_axis).find(
+              (key) => y_axis[key] === axisName
+            );
+            return `${axisName}(${originalProperty}):`;
+          },
+        },
         formatter: function (value, { seriesIndex, dataPointIndex }) {
           const count = ChartSeries[seriesIndex].data[dataPointIndex] || 0;
           const total =

--- a/test-web/src/components/Stats/Charts/HeatMap/Sens_Fresh_Map.js
+++ b/test-web/src/components/Stats/Charts/HeatMap/Sens_Fresh_Map.js
@@ -1,6 +1,5 @@
 import ApexCharts from 'react-apexcharts';
 import React, { useEffect, useState } from 'react';
-import CircularProgress from '@mui/material/CircularProgress';
 import { statisticSensoryFresh } from '../../../../API/statistic/statisticSensoryFresh';
 
 export default function Sens_Fresh_Map({
@@ -78,10 +77,21 @@ export default function Sens_Fresh_Map({
       enabled: false,
     },
     xaxis: {
-      type: 'numeric',
-      tickAmount: 11,
-      min: 0,
-      max: 11,
+      type: 'category',
+      categories: [
+        '1 미만',
+        '1 ~ 2',
+        '2 ~ 3',
+        '3 ~ 4',
+        '4 ~ 5',
+        '5 ~ 6',
+        '6 ~ 7',
+        '7 ~ 8',
+        '8 ~ 9',
+        '9 ~ 10',
+        '10 이상',
+      ],
+      tickPlacement: 'between',
     },
     title: {
       text: '원육 관능데이터 범위별 분포(빈도수)',
@@ -104,10 +114,23 @@ export default function Sens_Fresh_Map({
       },
       x: {
         show: true,
-        formatter: function (value, { seriesIndex }) {
+        formatter: function (value, { dataPointIndex, seriesIndex }) {
+          const categories = [
+            '1 미만',
+            '1.0 ~ 2.0',
+            '2.0 ~ 3.0',
+            '3.0 ~ 4.0',
+            '4.0 ~ 5.0',
+            '5.0 ~ 6.0',
+            '6.0 ~ 7.0',
+            '7.0 ~ 8.0',
+            '8.0 ~ 9.0',
+            '9.0 ~ 10.0',
+            '10 이상',
+          ];
           const total =
             ChartSeries[seriesIndex]?.data?.reduce((a, b) => a + b, 0) || 0;
-          return `${value} ~ ${value + 1}점 [전체 ${total}개]`;
+          return `${categories[dataPointIndex]} [전체 ${total}개]`;
         },
       },
     },

--- a/test-web/src/components/Stats/Charts/HeatMap/Sens_Heated_Map.js
+++ b/test-web/src/components/Stats/Charts/HeatMap/Sens_Heated_Map.js
@@ -76,10 +76,21 @@ export default function Sens_Heated_Map({
       enabled: false,
     },
     xaxis: {
-      type: 'numeric',
-      tickAmount: 11,
-      min: 0,
-      max: 11,
+      type: 'category',
+      categories: [
+        '1 미만',
+        '1 ~ 2',
+        '2 ~ 3',
+        '3 ~ 4',
+        '4 ~ 5',
+        '5 ~ 6',
+        '6 ~ 7',
+        '7 ~ 8',
+        '8 ~ 9',
+        '9 ~ 10',
+        '10 이상',
+      ],
+      tickPlacement: 'between',
     },
     title: {
       text: '가열육 관능데이터 범위별 분포(빈도수)',
@@ -102,10 +113,23 @@ export default function Sens_Heated_Map({
       },
       x: {
         show: true,
-        formatter: function (value, { seriesIndex }) {
+        formatter: function (value, { dataPointIndex, seriesIndex }) {
+          const categories = [
+            '1 미만',
+            '1.0 ~ 2.0',
+            '2.0 ~ 3.0',
+            '3.0 ~ 4.0',
+            '4.0 ~ 5.0',
+            '5.0 ~ 6.0',
+            '6.0 ~ 7.0',
+            '7.0 ~ 8.0',
+            '8.0 ~ 9.0',
+            '9.0 ~ 10.0',
+            '10 이상',
+          ];
           const total =
             ChartSeries[seriesIndex]?.data?.reduce((a, b) => a + b, 0) || 0;
-          return `${value} ~ ${value + 1}점 [전체 ${total}개]`;
+          return `${categories[dataPointIndex]} [전체 ${total}개]`;
         },
       },
     },

--- a/test-web/src/components/Stats/Charts/HeatMap/Sens_Heated_Map.js
+++ b/test-web/src/components/Stats/Charts/HeatMap/Sens_Heated_Map.js
@@ -1,6 +1,5 @@
 import ApexCharts from 'react-apexcharts';
 import React, { useEffect, useState } from 'react';
-import CircularProgres from '@mui/material/CircularProgress';
 import { statisticSensoryHeated } from '../../../../API/statistic/statisticSensoryHeated';
 
 export default function Sens_Heated_Map({
@@ -103,6 +102,15 @@ export default function Sens_Heated_Map({
     tooltip: {
       enabled: true,
       y: {
+        title: {
+          formatter: function (value, { seriesIndex }) {
+            const axisName = ChartSeries[seriesIndex].name;
+            const originalProperty = Object.keys(y_axis).find(
+              (key) => y_axis[key] === axisName
+            );
+            return `${axisName}(${originalProperty}):`;
+          },
+        },
         formatter: function (value, { seriesIndex, dataPointIndex }) {
           const count = ChartSeries[seriesIndex].data[dataPointIndex] || 0;
           const total =

--- a/test-web/src/components/Stats/Charts/HeatMap/Sens_Heated_Map.js
+++ b/test-web/src/components/Stats/Charts/HeatMap/Sens_Heated_Map.js
@@ -1,5 +1,6 @@
 import ApexCharts from 'react-apexcharts';
 import React, { useEffect, useState } from 'react';
+import CircularProgres from '@mui/material/CircularProgress';
 import { statisticSensoryHeated } from '../../../../API/statistic/statisticSensoryHeated';
 
 export default function Sens_Heated_Map({
@@ -46,12 +47,16 @@ export default function Sens_Heated_Map({
   let ChartSeries = prop
     .map((property) => {
       const uniqueValues = chartData[property].values;
-      const frequencies = new Array(9).fill(0);
+      const frequencies = new Array(11).fill(0);
 
       uniqueValues.forEach((value) => {
-        const index = Math.floor(value);
-        if (index >= 1 && index <= 9) {
-          frequencies[index - 1] += 1;
+        if (value > 10) {
+          frequencies[10] += 1;
+        } else if (value < 1) {
+          frequencies[0] += 1;
+        } else {
+          const index = Math.floor(value);
+          frequencies[index] += 1;
         }
       });
 
@@ -72,9 +77,9 @@ export default function Sens_Heated_Map({
     },
     xaxis: {
       type: 'numeric',
-      tickAmount: 9,
-      min: 1,
-      max: 10,
+      tickAmount: 11,
+      min: 0,
+      max: 11,
     },
     title: {
       text: '가열육 관능데이터 범위별 분포(빈도수)',

--- a/test-web/src/components/Stats/Charts/HeatMap/Sens_Proc_Map.js
+++ b/test-web/src/components/Stats/Charts/HeatMap/Sens_Proc_Map.js
@@ -105,6 +105,15 @@ export default function Sens_Proc_Map({
     tooltip: {
       enabled: true,
       y: {
+        title: {
+          formatter: function (value, { seriesIndex }) {
+            const axisName = ChartSeries[seriesIndex].name;
+            const originalProperty = Object.keys(y_axis).find(
+              (key) => y_axis[key] === axisName
+            );
+            return `${axisName}(${originalProperty}):`;
+          },
+        },
         formatter: function (value, { seriesIndex, dataPointIndex }) {
           const count = ChartSeries[seriesIndex].data[dataPointIndex] || 0;
           const total =

--- a/test-web/src/components/Stats/Charts/HeatMap/Sens_Proc_Map.js
+++ b/test-web/src/components/Stats/Charts/HeatMap/Sens_Proc_Map.js
@@ -48,11 +48,17 @@ export default function Sens_Proc_Map({
     ChartSeries = prop
       .map((property) => {
         const uniqueValues = chartData[property].values;
-        const frequencies = new Array(9).fill(0);
+        const frequencies = new Array(11).fill(0);
 
         uniqueValues.forEach((value) => {
-          const index = Math.floor(value);
-          frequencies[index - 1] += 1;
+          if (value > 10) {
+            frequencies[10] += 1;
+          } else if (value < 1) {
+            frequencies[0] += 1;
+          } else {
+            const index = Math.floor(value);
+            frequencies[index] += 1;
+          }
         });
 
         return {
@@ -73,9 +79,9 @@ export default function Sens_Proc_Map({
     },
     xaxis: {
       type: 'numeric',
-      tickAmount: 9,
-      min: 1,
-      max: 10,
+      tickAmount: 11,
+      min: 0,
+      max: 11,
     },
     title: {
       text: '처리육 관능데이터 범위별 분포(빈도수)',

--- a/test-web/src/components/Stats/Charts/HeatMap/Sens_Proc_Map.js
+++ b/test-web/src/components/Stats/Charts/HeatMap/Sens_Proc_Map.js
@@ -78,10 +78,21 @@ export default function Sens_Proc_Map({
       enabled: false,
     },
     xaxis: {
-      type: 'numeric',
-      tickAmount: 11,
-      min: 0,
-      max: 11,
+      type: 'category',
+      categories: [
+        '1 미만',
+        '1 ~ 2',
+        '2 ~ 3',
+        '3 ~ 4',
+        '4 ~ 5',
+        '5 ~ 6',
+        '6 ~ 7',
+        '7 ~ 8',
+        '8 ~ 9',
+        '9 ~ 10',
+        '10 이상',
+      ],
+      tickPlacement: 'between',
     },
     title: {
       text: '처리육 관능데이터 범위별 분포(빈도수)',
@@ -104,10 +115,23 @@ export default function Sens_Proc_Map({
       },
       x: {
         show: true,
-        formatter: function (value, { seriesIndex }) {
+        formatter: function (value, { dataPointIndex, seriesIndex }) {
+          const categories = [
+            '1 미만',
+            '1.0 ~ 2.0',
+            '2.0 ~ 3.0',
+            '3.0 ~ 4.0',
+            '4.0 ~ 5.0',
+            '5.0 ~ 6.0',
+            '6.0 ~ 7.0',
+            '7.0 ~ 8.0',
+            '8.0 ~ 9.0',
+            '9.0 ~ 10.0',
+            '10 이상',
+          ];
           const total =
             ChartSeries[seriesIndex]?.data?.reduce((a, b) => a + b, 0) || 0;
-          return `${value} ~ ${value + 1}점 [전체 ${total}개]`;
+          return `${categories[dataPointIndex]} [전체 ${total}개]`;
         },
       },
     },

--- a/test-web/src/components/Stats/Charts/HeatMap/Taste_Fresh_Map.js
+++ b/test-web/src/components/Stats/Charts/HeatMap/Taste_Fresh_Map.js
@@ -47,11 +47,17 @@ export default function Taste_Fresh_Map({
     ChartSeries = prop
       .map((property) => {
         const uniqueValues = chartData[property].values;
-        const frequencies = new Array(9).fill(0);
+        const frequencies = new Array(11).fill(0);
 
         uniqueValues.forEach((value) => {
-          const index = Math.floor(value);
-          frequencies[index - 1] += 1;
+          if (value > 10) {
+            frequencies[10] += 1;
+          } else if (value < 1) {
+            frequencies[0] += 1;
+          } else {
+            const index = Math.floor(value);
+            frequencies[index] += 1;
+          }
         });
 
         return {
@@ -72,9 +78,9 @@ export default function Taste_Fresh_Map({
     },
     xaxis: {
       type: 'numeric',
-      tickAmount: 9,
-      min: 1,
-      max: 10,
+      tickAmount: 11,
+      min: 0,
+      max: 11,
     },
     title: {
       text: '원육 맛데이터 범위별 분포(빈도수)',

--- a/test-web/src/components/Stats/Charts/HeatMap/Taste_Fresh_Map.js
+++ b/test-web/src/components/Stats/Charts/HeatMap/Taste_Fresh_Map.js
@@ -104,6 +104,15 @@ export default function Taste_Fresh_Map({
     tooltip: {
       enabled: true,
       y: {
+        title: {
+          formatter: function (value, { seriesIndex }) {
+            const axisName = ChartSeries[seriesIndex].name;
+            const originalProperty = Object.keys(y_axis).find(
+              (key) => y_axis[key] === axisName
+            );
+            return `${axisName}(${originalProperty}):`;
+          },
+        },
         formatter: function (value, { seriesIndex, dataPointIndex }) {
           const count = ChartSeries[seriesIndex].data[dataPointIndex] || 0;
           const total =

--- a/test-web/src/components/Stats/Charts/HeatMap/Taste_Fresh_Map.js
+++ b/test-web/src/components/Stats/Charts/HeatMap/Taste_Fresh_Map.js
@@ -77,10 +77,21 @@ export default function Taste_Fresh_Map({
       enabled: false,
     },
     xaxis: {
-      type: 'numeric',
-      tickAmount: 11,
-      min: 0,
-      max: 11,
+      type: 'category',
+      categories: [
+        '1 미만',
+        '1 ~ 2',
+        '2 ~ 3',
+        '3 ~ 4',
+        '4 ~ 5',
+        '5 ~ 6',
+        '6 ~ 7',
+        '7 ~ 8',
+        '8 ~ 9',
+        '9 ~ 10',
+        '10 이상',
+      ],
+      tickPlacement: 'between',
     },
     title: {
       text: '원육 맛데이터 범위별 분포(빈도수)',
@@ -103,11 +114,23 @@ export default function Taste_Fresh_Map({
       },
       x: {
         show: true,
-        formatter: function (value, { seriesIndex }) {
+        formatter: function (value, { dataPointIndex, seriesIndex }) {
+          const categories = [
+            '1 미만',
+            '1.0 ~ 2.0',
+            '2.0 ~ 3.0',
+            '3.0 ~ 4.0',
+            '4.0 ~ 5.0',
+            '5.0 ~ 6.0',
+            '6.0 ~ 7.0',
+            '7.0 ~ 8.0',
+            '8.0 ~ 9.0',
+            '9.0 ~ 10.0',
+            '10 이상',
+          ];
           const total =
             ChartSeries[seriesIndex]?.data?.reduce((a, b) => a + b, 0) || 0;
-
-          return `${value} ~ ${value + 1}점 [전체 ${total}개]`;
+          return `${categories[dataPointIndex]} [전체 ${total}개]`;
         },
       },
     },

--- a/test-web/src/components/Stats/Charts/HeatMap/Taste_Proc_Map.js
+++ b/test-web/src/components/Stats/Charts/HeatMap/Taste_Proc_Map.js
@@ -104,6 +104,15 @@ export default function Taste_Proc_Map({
     tooltip: {
       enabled: true,
       y: {
+        title: {
+          formatter: function (value, { seriesIndex }) {
+            const axisName = ChartSeries[seriesIndex].name;
+            const originalProperty = Object.keys(y_axis).find(
+              (key) => y_axis[key] === axisName
+            );
+            return `${axisName}(${originalProperty}):`;
+          },
+        },
         formatter: function (value, { seriesIndex, dataPointIndex }) {
           const count = ChartSeries[seriesIndex].data[dataPointIndex] || 0;
           const total =

--- a/test-web/src/components/Stats/Charts/HeatMap/Taste_Proc_Map.js
+++ b/test-web/src/components/Stats/Charts/HeatMap/Taste_Proc_Map.js
@@ -47,11 +47,17 @@ export default function Taste_Proc_Map({
     ChartSeries = prop
       .map((property) => {
         const uniqueValues = chartData[property].values;
-        const frequencies = new Array(9).fill(0);
+        const frequencies = new Array(11).fill(0);
 
         uniqueValues.forEach((value) => {
-          const index = Math.floor(value);
-          frequencies[index - 1] += 1;
+          if (value > 10) {
+            frequencies[10] += 1;
+          } else if (value < 1) {
+            frequencies[0] += 1;
+          } else {
+            const index = Math.floor(value);
+            frequencies[index] += 1;
+          }
         });
 
         return {
@@ -72,9 +78,9 @@ export default function Taste_Proc_Map({
     },
     xaxis: {
       type: 'numeric',
-      tickAmount: 9, // Number of ticks on the x-axis
-      min: 1,
-      max: 10, // Adjust the max value as needed
+      tickAmount: 11, // Number of ticks on the x-axis
+      min: 0,
+      max: 11, // Adjust the max value as needed
     },
     title: {
       text: '처리육 맛데이터 범위별 분포(빈도수)',

--- a/test-web/src/components/Stats/Charts/HeatMap/Taste_Proc_Map.js
+++ b/test-web/src/components/Stats/Charts/HeatMap/Taste_Proc_Map.js
@@ -77,10 +77,21 @@ export default function Taste_Proc_Map({
       enabled: false,
     },
     xaxis: {
-      type: 'numeric',
-      tickAmount: 11, // Number of ticks on the x-axis
-      min: 0,
-      max: 11, // Adjust the max value as needed
+      type: 'category',
+      categories: [
+        '1 미만',
+        '1 ~ 2',
+        '2 ~ 3',
+        '3 ~ 4',
+        '4 ~ 5',
+        '5 ~ 6',
+        '6 ~ 7',
+        '7 ~ 8',
+        '8 ~ 9',
+        '9 ~ 10',
+        '10 이상',
+      ],
+      tickPlacement: 'between',
     },
     title: {
       text: '처리육 맛데이터 범위별 분포(빈도수)',
@@ -103,10 +114,23 @@ export default function Taste_Proc_Map({
       },
       x: {
         show: true,
-        formatter: function (value, { seriesIndex }) {
+        formatter: function (value, { dataPointIndex, seriesIndex }) {
+          const categories = [
+            '1 미만',
+            '1.0 ~ 2.0',
+            '2.0 ~ 3.0',
+            '3.0 ~ 4.0',
+            '4.0 ~ 5.0',
+            '5.0 ~ 6.0',
+            '6.0 ~ 7.0',
+            '7.0 ~ 8.0',
+            '8.0 ~ 9.0',
+            '9.0 ~ 10.0',
+            '10 이상',
+          ];
           const total =
             ChartSeries[seriesIndex]?.data?.reduce((a, b) => a + b, 0) || 0;
-          return `${value} ~ ${value + 1}점 [전체 ${total}개]`;
+          return `${categories[dataPointIndex]} [전체 ${total}개]`;
         },
       },
     },


### PR DESCRIPTION
1. 분포 데이터 값 처리 방식 수정
fetch해온 데이터 값이 1\~10 값이 아니면 제대로 작동하지 않던 오류 수정
우선 1미만, 11 이상을 0\~1, 10\~11로 표현
![화면 캡처 2024-08-01 001714](https://github.com/user-attachments/assets/2d354421-3f5a-45b7-8521-fc1a46101e61) 

2. 범례 수정. 분포, 상관관계
1미만, 11 이상을 x축 눈금에 반영. 
분포, 상관관계에서 각 히트맵에 마우스 오버할 경우 나오는 범례 일부 수정.
tooltip title 활용하여 표현, 
![화면 캡처 2024-08-01 001948](https://github.com/user-attachments/assets/acee543a-3071-4abd-9134-5372b884f930) 
상관관계 수정 전
![화면 캡처 2024-08-01 001429](https://github.com/user-attachments/assets/a07d027d-b90e-460d-bbf7-ddbfd1564d08)
상관관계 수정 후
![화면 캡처 2024-08-01 001335](https://github.com/user-attachments/assets/5e049e84-bdaa-4e00-b025-d6ff43e9fe91)
