### PR TITLE
hotfix: pending rollback error를 해결하기 위해서 db_session을 명시적으로 종료하는 로직 추가

### DIFF
--- a/test-backend/test-flask/api/user_api.py
+++ b/test-backend/test-flask/api/user_api.py
@@ -94,7 +94,7 @@ def login_user():
         )
 
     except Exception as e:
-        logger.exception("Exception: %s", e)
+        logger.exception(str(e))
         return (
             jsonify(
                 {"msg": "Server Error", "time": datetime.now().strftime("%H:%M:%S")}
@@ -209,7 +209,7 @@ def update_user_data():
             200,
         )
     except Exception as e:
-        # logger.exception(str(e))
+        logger.exception(str(e))
         return (
             jsonify(
                 {"msg": "Server Error", "time": datetime.now().strftime("%H:%M:%S")}
@@ -230,7 +230,7 @@ def check_duplicate():
         else:
             return jsonify({"isDuplicated": True}), 200
     except Exception as e:
-        # logger.exception(str(e))
+        logger.exception(str(e))
         return (
             jsonify(
                 {"msg": "Server Error", "time": datetime.now().strftime("%H:%M:%S")}
@@ -254,13 +254,14 @@ def delete_user_data():
                         "userId": user_id,
                     }
                 ),
-                401,
+                400,
             )
+        delete_user(db_session, user)
+        
         # Firebase에서 유저 삭제
         user_record = firebase_auth.get_user_by_email(user_id)
         firebase_auth.delete_user(user_record.uid)
         
-        delete_user(db_session, user)
         return (
             jsonify(
                 {
@@ -271,7 +272,7 @@ def delete_user_data():
             200,
         )
     except Exception as e:
-        # logger.exception(str(e))
+        logger.exception(str(e))
         return (
             jsonify(
                 {"msg": "Server Error", "time": datetime.now().strftime("%H:%M:%S")}


### PR DESCRIPTION
## 주요 수정 사항
- pending rollback error를 해결하기 위해서 commit이나 rollback이 이루어지지 않는 곳에 db_session을 명시적으로 종료하는 db_session.close() 추가함
- user/delete 할 때 firebase에서는 정상적으로 삭제되지만, DB에서는 삭제되지 않는 에러가 발생하여 DB에서 성공적으로 삭제한 후 firebase에서 유저 정보를 삭제하도록 설정함
- create_user() 할 때 user table에 존재하는 모든 칼럼을 지정해주지 않아서 pending rollback error의 원인 중 하나로 작용되었을 것이라 생각하여 명시적으로 user.loginAt과 user.updatedAt 필드 값을 지정함