### PR TITLE
refac: snackbar 사용 커스텀 스낵바로 통일

### DIFF
--- a/test-web/src/components/Base/CustomSnackbar.js
+++ b/test-web/src/components/Base/CustomSnackbar.js
@@ -16,6 +16,7 @@ function CustomSnackbar({ open, message, severity, onClose }) {
       autoHideDuration={6000}
       onClose={handleSnackbarClose}
       anchorOrigin={{ vertical: 'top', horizontal: 'right' }} // Set the anchorOrigin to top-right
+      style={{ marginTop: '70px' }} // margin for toolbar
     >
       <MuiAlert
         elevation={6}

--- a/test-web/src/components/Base/Sidebar.js
+++ b/test-web/src/components/Base/Sidebar.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
+import CustomSnackbar from '../Base/CustomSnackbar';
 import PropTypes from 'prop-types';
 import { styled, createTheme, ThemeProvider } from '@mui/material/styles';
 // import mui component
@@ -13,7 +14,6 @@ import {
   IconButton,
   Toolbar,
   Tooltip,
-  Snackbar,
   Alert as MuiAlert,
 } from '@mui/material';
 import MuiDrawer from '@mui/material/Drawer';
@@ -119,13 +119,13 @@ function Sidebar() {
       }
     }
   };
-  let typeColor = ''
+  let typeColor = '';
   if (UserInfo.type === 'Manager') {
-     typeColor = '#70E391';
+    typeColor = '#70E391';
   } else if (UserInfo.type === 'Researcher') {
-     typeColor = '#D9C2FF';
+    typeColor = '#D9C2FF';
   } else {
-     typeColor = '#FFF856';
+    typeColor = '#FFF856';
   }
 
   return (
@@ -159,7 +159,7 @@ function Sidebar() {
             <div
               style={{
                 //backgroundColor: '#E8E8E8',
-                backgroundColor : typeColor,
+                backgroundColor: typeColor,
                 width: '40px',
                 height: '40px',
                 borderRadius: '12px',
@@ -190,7 +190,7 @@ function Sidebar() {
                   component="h2"
                   variant="h3"
                   noWrap
-                  sx={{ flexGrow: 1, fontSize: '12px'}}
+                  sx={{ flexGrow: 1, fontSize: '12px' }}
                 >
                   {UserInfo.type}
                 </Typography>
@@ -280,15 +280,12 @@ function Sidebar() {
           </IconButton>
         </Toolbar>
       </Drawer>
-      <Snackbar
+      <CustomSnackbar
         open={snackbarOpen}
-        autoHideDuration={3000}
+        message={snackbarMessage}
+        severity={'error'}
         onClose={handleSnackbarClose}
-      >
-        <Alert onClose={handleSnackbarClose} severity="error">
-          {snackbarMessage}
-        </Alert>
-      </Snackbar>
+      />
     </ThemeProvider>
   );
 }

--- a/test-web/src/components/User/UserList.js
+++ b/test-web/src/components/User/UserList.js
@@ -105,7 +105,7 @@ function UserList() {
     setSnackbarOpen(true);
   };
 
-  const closeSnackbar = () => {
+  const handleSnackbarClose = () => {
     setSnackbarOpen(false);
   };
 
@@ -446,7 +446,7 @@ function UserList() {
         open={snackbarOpen}
         message={snackbarMessage}
         severity={snackbarSeverity}
-        onClose={closeSnackbar}
+        onClose={handleSnackbarClose}
       />
     </div>
   );

--- a/test-web/src/routes/Home.js
+++ b/test-web/src/routes/Home.js
@@ -6,7 +6,7 @@ import Grid from '@mui/material/Grid';
 import Typography from '@mui/material/Typography';
 import CardActionArea from '@mui/material/CardActionArea';
 import Container from '@mui/material/Container';
-import Snackbar from '@mui/material/Snackbar';
+import CustomSnackbar from '../components/Base/CustomSnackbar';
 import MuiAlert from '@mui/material/Alert';
 import { useNavigate } from 'react-router-dom';
 
@@ -73,10 +73,7 @@ function Home() {
     }
   };
 
-  const handleCloseSnackbar = (event, reason) => {
-    if (reason === 'clickaway') {
-      return;
-    }
+  const handleSnackbarClose = () => {
     setOpenSnackbar(false);
   };
 
@@ -94,7 +91,7 @@ function Home() {
       }}
     >
       <Container maxWidth="md">
-      <Typography
+        <Typography
           variant="h4" // Typography의 variant를 조정하여 원하는 스타일과 크기를 선택할 수 있습니다.
           sx={{
             color: '#151D48',
@@ -160,15 +157,12 @@ function Home() {
             </Grid>
           ))}
         </Grid>
-        <Snackbar
+        <CustomSnackbar
           open={openSnackbar}
-          autoHideDuration={3000}
-          onClose={handleCloseSnackbar}
-        >
-          <Alert onClose={handleCloseSnackbar} severity="error">
-            권한이 없습니다
-          </Alert>
-        </Snackbar>
+          message={'권한이 없습니다'}
+          severity={'error'}
+          onClose={handleSnackbarClose}
+        />
       </Container>
     </div>
   );


### PR DESCRIPTION
스낵바 사용하는 컴포넌트 모두 이미 정의되어 있던 customsnackbar로 작동하도록 수정
snackbar 닫을 시 handleSnackbarClose로 닫도록 통일
![화면 캡처 2024-08-05 111746](https://github.com/user-attachments/assets/4f6ad6ed-4d6b-4f08-83db-454d897d1435) 적용 전
![화면 캡처 2024-08-05 111644](https://github.com/user-attachments/assets/ecbec759-94d3-486a-81a7-e9b737ea5570) 적용 후
