### PR TITLE
hotfix: meat/get/by-user-id에서 specie_id를 불러오지 못하는 에러 수정

### DIFF
--- a/test-backend/test-flask/db/db_controller.py
+++ b/test-backend/test-flask/db/db_controller.py
@@ -920,11 +920,12 @@ def _getMeatDataByUserId(db_session, userId, offset, count, start, end):
         result = []
         if meats:
             for meat in meats:
+                meat_obj, specie_id = meat
                 result.append({
-                    "meatId": meat.id,
-                    "createdAt": convert2string(meat.createdAt, 1),
-                    "statusType": statusType[meat.statusType],
-                    "specieValue": species[meat.speciesId]
+                    "meatId": meat_obj.id,
+                    "createdAt": convert2string(meat_obj.createdAt, 1),
+                    "statusType": statusType[meat_obj.statusType],
+                    "specieValue": species[specie_id]
                 })
                 
         db_session.close()    


### PR DESCRIPTION
## 주요 수정 사항
- CategoryInfo와의 조인 조건을 추가하면서 object를 불러올 때 object 안에 포함되는 것이 아니라 튜플로 묶이게끔 나오는 것을 확인함
- 그래서 해당 튜플들을 unpack하고 각각의 object로 불러오는 로직으로 수정함