### PR TITLE
fix: 딥에이징 회차에 맞게 데이터 표시

### DIFF
--- a/test-web/src/components/DataDetailPage/DataConfirmView.js
+++ b/test-web/src/components/DataDetailPage/DataConfirmView.js
@@ -287,6 +287,7 @@ const DataView = ({ dataProps }) => {
           processedInput={processedInput}
           processed_data={processed_data}
           processedMinute={processedMinute}
+          processed_data_seq={processed_data_seq}
         />
         {/* 2. QR코드와 데이터에 대한 기본 정보*/}
         <QRInfoCard

--- a/test-web/src/components/DataDetailPage/DataView.js
+++ b/test-web/src/components/DataDetailPage/DataView.js
@@ -54,7 +54,7 @@ const DataView = ({ dataProps }) => {
     processed_img_path, // 처리육 이미지 경로
     processed_date,
   } = dataProps;
-  console.log("ddd:",dataProps)
+
 
   // console.log(`1회차 가열육 데이터: ${JSON.stringify(heated_data[1])}`);
   // console.log(`1회차 처리육 데이터: ${JSON.stringify(processed_data[0])}`);
@@ -424,7 +424,7 @@ const DataView = ({ dataProps }) => {
         centered
       >
         <Modal.Body>
-        <Modal.Title
+          <Modal.Title
             style={{
               color: '#151D48',
               fontFamily: 'Poppins',
@@ -434,7 +434,11 @@ const DataView = ({ dataProps }) => {
           >
             딥에이징 회차 추가
           </Modal.Title>
-          <AgingInfoRegister handleClose = {handleInfoRegisterClose} maxSeqno = {len} meatId = {meatId}/>
+          <AgingInfoRegister
+            handleClose={handleInfoRegisterClose}
+            maxSeqno={len}
+            meatId={meatId}
+          />
         </Modal.Body>
       </Modal>
       <div style={{ width: '100%', position: 'relative' }}>
@@ -490,6 +494,7 @@ const DataView = ({ dataProps }) => {
             processedInput={processedInput}
             processed_data={processed_data}
             processedMinute={processedMinute}
+            processed_data_seq={processed_data_seq}
           />
           {/* 2. QR코드와 데이터에 대한 기본 정보*/}
           <QRInfoCard
@@ -560,6 +565,7 @@ const DataView = ({ dataProps }) => {
                       processedToggleValue={processedToggleValue}
                       handleInputChange={handleInputChange}
                       processed_date={processed_date}
+                      processed_data_seq={processed_data_seq}
                     />
                   </>
                 ) : (
@@ -599,6 +605,7 @@ const DataView = ({ dataProps }) => {
                   heated_data={heated_data}
                   heatedToggleValue={heatedToggleValue}
                   handleInputChange={handleInputChange}
+                  processed_data_seq={processed_data_seq}
                 />
               </Tab>
               <Tab
@@ -630,6 +637,7 @@ const DataView = ({ dataProps }) => {
                   lab_data={lab_data}
                   labToggleValue={labToggleValue}
                   handleInputChange={handleInputChange}
+                  processed_data_seq={processed_data_seq}
                 />
               </Tab>
               <Tab

--- a/test-web/src/components/DataDetailPage/cardComps/MeatImgsCard.js
+++ b/test-web/src/components/DataDetailPage/cardComps/MeatImgsCard.js
@@ -28,12 +28,12 @@ const MeatImgsCard = ({
   processedInput, // 처리육 데이터
   processed_data, // 처리육 데이터
   processedMinute, // 처리 시간 (분)
+  processed_data_seq, // 회차 정보
 }) => {
   // 1.이미지 배열 만들기
   const [imgArr, setImgArr] = useState([raw_img_path]);
   useEffect(() => {
     setImgArr([...imgArr, ...processed_img_path]);
-
   }, []);
 
   // 이미지 배열 페이지네이션
@@ -149,6 +149,7 @@ const MeatImgsCard = ({
     setImgArr(newImages);
   };
 
+
   return (
     <Card
       style={{
@@ -172,7 +173,7 @@ const MeatImgsCard = ({
               <div style={style.imgTitleWrapper}>원육이미지</div>
             ) : (
               <div style={style.imgTitleWrapper}>
-                딥에이징 {currentIdx}회차 이미지
+                딥에이징 {processed_data_seq[currentIdx]}차 이미지
               </div>
             )
           }

--- a/test-web/src/components/DataDetailPage/dataProcessing.js
+++ b/test-web/src/components/DataDetailPage/dataProcessing.js
@@ -84,12 +84,13 @@ const dataProcessing = (items) => {
   let processedDataSeq = ['원육'];
   // 처리육 이미지
   let processedDataImgPath = [];
-  let processedDate=[];
+  let processedDate = [];
 
   // n회차 처리육에 대한 회차별 정보
   for (let i = 1; i < deepAgingInfo.length; i++) {
+    console.log('deeapginginfo:', deepAgingInfo);
     if (deepAgingInfo[i]) {
-      processedDataSeq = [...processedDataSeq, `${i}회`];
+      processedDataSeq = [...processedDataSeq, `${deepAgingInfo[i].seqno}회`];
       processedData = [...processedData, deepAgingInfo[i].sensory_eval || {}];
       heatedData = [
         ...heatedData,
@@ -122,7 +123,7 @@ const dataProcessing = (items) => {
     processed_data_seq: processedDataSeq,
     processed_minute: processedMinute,
     processed_img_path: processedDataImgPath,
-    processed_date : processedDate
+    processed_date: processedDate,
   };
 
   return data;

--- a/test-web/src/components/DataDetailPage/tablesComps/heatTable.js
+++ b/test-web/src/components/DataDetailPage/tablesComps/heatTable.js
@@ -14,7 +14,9 @@ const HeatTable = ({
   heated_data,
   heatedToggleValue,
   handleInputChange,
+  processed_data_seq,
 }) => {
+  const len = processed_data_seq.length - 1
   return (
     <TableContainer
       key="heatedmeat"
@@ -27,10 +29,10 @@ const HeatTable = ({
             <TableCell key={'heatedmeat-exp-col'}>{}</TableCell>
             <TableCell key={'heatedmeat-exp-col0'}>원육</TableCell>
             {Array.from(
-              { length: Number(heatedToggleValue.slice(0, -1)) },
+              { length: len },
               (_, arr_idx) => (
                 <TableCell key={'heatedmeat-exp-col' + (arr_idx + 1)}>
-                  {arr_idx + 1}회차
+                  {processed_data_seq[arr_idx + 1]}차
                 </TableCell>
               )
             )}
@@ -66,7 +68,7 @@ const HeatTable = ({
                 {
                   // 실험실 및 가열육 추가 데이터 수정
                   Array.from(
-                    { length: Number(heatedToggleValue.slice(0, -1)) },
+                    { length: len },
                     (_, arr_idx) => (
                       <TableCell key={'heated-' + arr_idx + '-col' + arr_idx}>
                         {edited ? (

--- a/test-web/src/components/DataDetailPage/tablesComps/labTable.js
+++ b/test-web/src/components/DataDetailPage/tablesComps/labTable.js
@@ -14,7 +14,9 @@ const LabTable = ({
   lab_data,
   labToggleValue,
   handleInputChange,
+  processed_data_seq,
 }) => {
+  const len = processed_data_seq.length - 1;
   return (
     <TableContainer
       key="labData"
@@ -27,11 +29,11 @@ const LabTable = ({
             <TableCell key={'labData-exp-col'}>{}</TableCell>
             <TableCell key={'labData-exp-col0'}>원육</TableCell>
             {Array.from(
-              { length: Number(labToggleValue.slice(0, -1)) },
+              { length: len},
               (_, arr_idx) => (
                 <TableCell key={'labData-exp-col' + (arr_idx + 1)}>
                   {' '}
-                  {arr_idx + 1}회차{' '}
+                  {processed_data_seq[arr_idx + 1]}차{' '}
                 </TableCell>
               )
             )}
@@ -68,7 +70,7 @@ const LabTable = ({
                 {
                   // 실험실 및 가열육 추가 데이터 수정
                   Array.from(
-                    { length: Number(labToggleValue.slice(0, -1)) },
+                    { length: len },
                     (_, arr_idx) => (
                       <TableCell key={'lab-' + arr_idx + '-col' + arr_idx}>
                         {edited ? (
@@ -121,7 +123,7 @@ const labField = [
   'bitterness',
   'umami',
   'richness',
-  'Collagen'
+  'Collagen',
 ];
 const labDBFieldToSemanticWord = {
   L: '명도',

--- a/test-web/src/components/DataDetailPage/tablesComps/processedTable.js
+++ b/test-web/src/components/DataDetailPage/tablesComps/processedTable.js
@@ -22,6 +22,7 @@ const ProcessedTable = ({
   handleInputChange,
   processed_data,
   processed_date,
+  processed_data_seq,
 }) => {
   // 처리육 딥에이징 시간 (분) input 핸들링
   const handleMinuteInputChange = (e, index) => {
@@ -30,6 +31,7 @@ const ProcessedTable = ({
       setProcessedMinute((prev) => ({ ...prev, [index]: value }));
     }
   };
+  const len = processed_data_seq.length - 2
 
   return (
     <TableContainer
@@ -42,15 +44,15 @@ const ProcessedTable = ({
           <TableRow>
             <TableCell style={{ background: '#cfd8dc' }}>{}</TableCell>
             <TableCell align="right" style={{ background: '#cfd8dc' }}>
-              1회차
+            {processed_data_seq[1]}차
             </TableCell>
             {
               // 2회차 이상부터
               Array.from(
-                { length: Number(processedToggleValue.slice(0, -1)) - 1 },
+                { length: len },
                 (_, arr_idx) => (
                   <TableCell align="right" style={{ background: '#cfd8dc' }}>
-                    {arr_idx + 2}회차
+                    {processed_data_seq[arr_idx + 2]}차
                   </TableCell>
                 )
               )
@@ -140,7 +142,7 @@ const ProcessedTable = ({
               {
                 //2회차 부터
                 Array.from(
-                  { length: Number(processedToggleValue.slice(0, -1)) - 1 },
+                  { length: len },
                   (_, arr_idx) => (
                     <TableCell align="right">
                       {f === 'minute' ? (


### PR DESCRIPTION
- 육류의 상세 데이터를 표시하는 부분에서 회차에 따라 데이터를 보여줄때, seqno에 따른 회차가 아닌, 앞에서부터 1,2,3,4회차로 되어 있어 순서가 맞지 않았음. 이를 seqno에 맞게 표시되도록 수정하였음

<img width="1789" alt="image" src="https://github.com/user-attachments/assets/d45accbb-f294-4a19-83ee-c47a5fd7a6a9">
