### PR TITLE
fix: meat 테이블에 updatedAt 필드 추가 및 관련 API 수정

### DIFF
--- a/test-backend/test-flask/db/db_controller.py
+++ b/test-backend/test-flask/db/db_controller.py
@@ -552,6 +552,7 @@ def get_meat(db_session, id):
     result["gradeNum"] = gradeNum.value
     result["statusType"] = statusType.value
     result["createdAt"] = convert2string(result["createdAt"], 1)
+    result["updatedAt"] = convert2string(result["updatedAt"], 1)
     result["butcheryYmd"] = convert2string(result["butcheryYmd"], 2)
     result["birthYmd"] = convert2string(result["birthYmd"], 2)
 
@@ -924,6 +925,7 @@ def _getMeatDataByUserId(db_session, userId, offset, count, start, end):
                 result.append({
                     "meatId": meat_obj.id,
                     "createdAt": convert2string(meat_obj.createdAt, 1),
+                    "updatedAt": convert2string(meat_obj.updatedAt, 1),
                     "statusType": statusType[meat_obj.statusType],
                     "specieValue": species[specie_id]
                 })
@@ -1129,6 +1131,7 @@ def _updateRejectData(db_session, id):
     meat = db_session.query(Meat).get(id)  # DB에 있는 육류 정보
     if meat and meat.statusType != 1:
         meat.statusType = 1
+        meat.updatedAt = datetime.now()
         db_session.merge(meat)
         db_session.commit()
         return jsonify({"msg": "Success to update StatusType"}), 200

--- a/test-backend/test-flask/db/db_model.py
+++ b/test-backend/test-flask/db/db_model.py
@@ -250,6 +250,7 @@ class Meat(Base):
 
     # 2. 육류 Open API 정보
     createdAt = Column(DateTime, nullable=False)  # 육류 관리번호 생성 시간
+    updatedAt = Column(DateTime) # 대기 중인 상태에서 반려한 시간
     traceNum = Column(String(255), nullable=False)  # 이력번호(혹은 묶은 번호)
     farmAddr = Column(String(255))  # 농장 주소
     farmerName = Column(String(255))  # 농장주 이름

--- a/test-backend/test-flask/utils.py
+++ b/test-backend/test-flask/utils.py
@@ -312,8 +312,8 @@ def calId(id, s_id, type):
 
 
 def item_encoder(data_dict, item, input_data=None):
-    datetime0_cvr = ["filmedAt", "createdAt"]
-    datetime1_cvr = ["loginAt", "updatedAt"]
+    datetime0_cvr = ["filmedAt", "createdAt", "updatedAt"]
+    datetime1_cvr = ["loginAt"]
     datetime2_cvr = ["butcheryYmd", "birthYmd", "date"]
     str_cvr = [
         "id",


### PR DESCRIPTION
## 주요 수정 사항
- meat 테이블에 updatedAt 필드를 추가하게 되면서 관련 API에 updatedAt 필드를 추가함
- 현재 서버 상의 DB는 직접 DB에서 필드를 추가함으로써 드랍 없이 진행할 예정.