### PR TITLE
refactor: heatedmeat 관련 테이블에 tenderness의 타입변경 후 validation 함수 추가

### DIFF
--- a/test-backend/test-flask/db/db_model.py
+++ b/test-backend/test-flask/db/db_model.py
@@ -12,7 +12,7 @@ from sqlalchemy import (
 )
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.dialects.postgresql import JSONB
-from sqlalchemy.orm import relationship, scoped_session, sessionmaker
+from sqlalchemy.orm import relationship, scoped_session, sessionmaker, validates
 
 from utils import *
 
@@ -415,7 +415,7 @@ class HeatedmeatSensoryEval(Base):
     # 3. 관능검사 측정 데이터
     flavor = Column(Float)
     juiciness = Column(Float)
-    tenderness = Column(Float)
+    tenderness = Column(JSONB)
     umami = Column(Float)
     palatability = Column(Float)
     
@@ -436,10 +436,27 @@ class HeatedmeatSensoryEval(Base):
         CheckConstraint('"period" >= 0', name="check_period_value"),
         CheckConstraint('"flavor" >= 1 and "flavor" <= 10', name="check_flavor_stat"),
         CheckConstraint('"juiciness" >= 1 and "juiciness" <= 10', name="check_juiciness_stat"),
-        CheckConstraint('"tenderness" >= 1 and "tenderness" <= 10', name="check_tenderness_stat"),
         CheckConstraint('"umami" >= 1 and "umami" <= 10', name="check_umami_stat"),
         CheckConstraint('"palatability" >= 1 and "palatability" <= 10', name="check_palatability_stat")
     )
+    
+    @validates('tenderness')
+    def validate_tenderness(self, key, value):
+        required_keys = {'0', '3', '7', '14', '21'}
+        if not isinstance(value, dict):
+            raise ValueError("Tenderness must be a JSON object")
+        
+        keys = set(value.keys())
+        if not keys.issubset(required_keys):
+            raise ValueError(f"Invalid keys in tenderness: {keys - required_keys}")
+        
+        for k, v in value.items():
+            if not isinstance(v, (int, float)):
+                raise ValueError(f"Tenderness value for key {k} must be a number")
+            if not (1 <= v <= 10):
+                raise ValueError(f"Tenderness value for key {k} must be between 1 and 10")
+        
+        return value
 
 
 class AI_HeatedmeatSeonsoryEval(Base):
@@ -455,7 +472,7 @@ class AI_HeatedmeatSeonsoryEval(Base):
     # 3. 관능검사 AI 예측 데이터
     flavor = Column(Float)
     juiciness = Column(Float)
-    tenderness = Column(Float)
+    tenderness = Column(JSONB)
     umami = Column(Float)
     palatability = Column(Float)
     
@@ -469,10 +486,27 @@ class AI_HeatedmeatSeonsoryEval(Base):
         ),
         CheckConstraint('"flavor" >= 1 and "flavor" <= 10', name="check_flavor_stat"),
         CheckConstraint('"juiciness" >= 1 and "juiciness" <= 10', name="check_juiciness_stat"),
-        CheckConstraint('"tenderness" >= 1 and "tenderness" <= 10', name="check_tenderness_stat"),
         CheckConstraint('"umami" >= 1 and "umami" <= 10', name="check_umami_stat"),
         CheckConstraint('"palatability" >= 1 and "palatability" <= 10', name="check_palatability_stat")
     )
+    
+    @validates('tenderness')
+    def validate_tenderness(self, key, value):
+        required_keys = {'0', '3', '7', '14', '21'}
+        if not isinstance(value, dict):
+            raise ValueError("Tenderness must be a JSON object")
+        
+        keys = set(value.keys())
+        if not keys.issubset(required_keys):
+            raise ValueError(f"Invalid keys in tenderness: {keys - required_keys}")
+        
+        for k, v in value.items():
+            if not isinstance(v, (int, float)):
+                raise ValueError(f"Tenderness value for key {k} must be a number")
+            if not (1 <= v <= 10):
+                raise ValueError(f"Tenderness value for key {k} must be between 1 and 10")
+        
+        return value
 
 
 class ProbexptData(Base):


### PR DESCRIPTION
## 수정한 사항
- heatedmeat과 관련한 테이블들의 tenderness는 duration별로 저장하는 것이 필요하기 때문에 jsonb의 타입으로 변경함
- jsonb로 넣을 때 딕셔너리의 key와 value 값의 validation 검사를 위해 validates 데코레이터 추가함
   - check constraint에서는 하위 쿼리를 작성할 수 없기 때문에 사용 불가한 상황이었음
- 실제 딕셔너리의 값을 Insert 하는 경우에도 제대로 동작하는 것 확인하였음
- 추후에 jsonb 형식을 사용하는 opencv 관련 테이블에서도 유효성 데코레이터 적용 예정