### PR TITLE
fix: PA table 수정 & refac: 서치필터 상세 페이지에서 뒤로가기 시 작동

### DIFF
--- a/test-web/src/components/DataDetailPage/DataPAView.js
+++ b/test-web/src/components/DataDetailPage/DataPAView.js
@@ -252,38 +252,48 @@ const DataPAView = ({ dataProps }) => {
               title="처리육"
               style={{ backgroundColor: 'white' }}
             >
-              <Autocomplete
-                id={'controllable-states-processed'}
-                label="처리상태"
-                value={processed_toggle}
-                onChange={(event, newValue) => {
-                  setProcessedToggle(newValue);
-                }}
-                inputValue={processedToggleValue}
-                onInputChange={(event, newInputValue) => {
-                  setProcessedToggleValue(newInputValue);
-                  /*이미지 변경 */
-                  setPreviewImage(
-                    processed_img_path[parseInt(newInputValue) - 1]
-                      ? processed_img_path[parseInt(newInputValue) - 1]
-                      : null
-                  );
-                }}
-                options={options.slice(1)}
-                size="small"
-                sx={{ width: 300, marginBottom: '10px' }}
-                renderInput={(params) => <TextField {...params} />}
-              />
-              <ProcessedTableStatic
-                processedMinute={processed_minute}
-                processedToggleValue={processedToggleValue}
-                processed_data={processed_data}
-              />
-              <PredictedProcessedTablePA
-                seqno={parseInt(processedToggleValue)}
-                processed_data={processed_data}
-                dataPA={dataPA}
-              />
+              {processed_data && processed_data.length > 0 ? (
+                <>
+                  <Autocomplete
+                    id={'controllable-states-processed'}
+                    label="처리상태"
+                    value={processed_toggle}
+                    onChange={(event, newValue) => {
+                      setProcessedToggle(newValue);
+                    }}
+                    inputValue={processedToggleValue}
+                    onInputChange={(event, newInputValue) => {
+                      setProcessedToggleValue(newInputValue);
+                      /*이미지 변경 */
+                      setPreviewImage(
+                        processed_img_path[parseInt(newInputValue) - 1]
+                          ? processed_img_path[parseInt(newInputValue) - 1]
+                          : null
+                      );
+                    }}
+                    options={options.slice(1)}
+                    size="small"
+                    sx={{ width: 300, marginBottom: '10px' }}
+                    renderInput={(params) => <TextField {...params} />}
+                  />
+                  <ProcessedTableStatic
+                    processedMinute={processed_minute}
+                    processedToggleValue={processedToggleValue}
+                    processed_data={processed_data}
+                    processed_data_seq={processed_data_seq}
+                  />
+                  <PredictedProcessedTablePA
+                    seqno={parseInt(processedToggleValue)}
+                    processed_data={processed_data}
+                    processed_data_seq={processed_data_seq}
+                    dataPA={dataPA}
+                  />
+                </>
+              ) : (
+                <div style={divStyle.errorContainer}>
+                  <div style={divStyle.errorText}>처리육 데이터가 없습니다</div>
+                </div>
+              )}
             </Tab>
           </Tabs>
         </Card>
@@ -410,6 +420,18 @@ const divStyle = {
   },
   loadingText: {
     fontSize: '25px',
+    textAlign: 'center',
+  },
+  errorContainer: {
+    height: '65vh',
+    minHeight: '500px',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    height: '100%',
+  },
+  errorText: {
+    fontSize: '16px',
     textAlign: 'center',
   },
 };

--- a/test-web/src/components/DataDetailPage/TablesComps/PredictedProcessedTablePA.js
+++ b/test-web/src/components/DataDetailPage/TablesComps/PredictedProcessedTablePA.js
@@ -12,8 +12,14 @@ import {
   deepAgingPADBFieldToSemanticWord,
 } from '../constants/infofield';
 
-const PredictedProcessedTablePA = ({ seqno, processed_data, dataPA }) => {
+const PredictedProcessedTablePA = ({
+  seqno,
+  processed_data,
+  processed_data_seq,
+  dataPA,
+}) => {
   const processedDataIdx = seqno - 1;
+  const len = processed_data_seq.length - 2;
   return (
     <TableContainer
       key="processedmeat"
@@ -25,8 +31,16 @@ const PredictedProcessedTablePA = ({ seqno, processed_data, dataPA }) => {
           <TableRow>
             <TableCell style={{ background: '#cfd8dc' }}>{}</TableCell>
             <TableCell align="right" style={{ background: '#cfd8dc' }}>
-              {seqno}회차
+              1회차
             </TableCell>
+            {
+              // 2회차 이상부터
+              Array.from({ length: len }, (_, arr_idx) => (
+                <TableCell align="right" style={{ background: '#cfd8dc' }}>
+                  {arr_idx + 2}회차
+                </TableCell>
+              ))
+            }
           </TableRow>
         </TableHead>
         <TableBody>
@@ -39,66 +53,130 @@ const PredictedProcessedTablePA = ({ seqno, processed_data, dataPA }) => {
                 {deepAgingPADBFieldToSemanticWord[f]}
               </TableCell>
               <TableCell align="right">
-                <div style={{ display: 'flex' }}>
-                  <div>
-                    {
-                      // 1회차
-                      dataPA
-                        ? f === 'xai_gradeNum'
-                          ? dataPA['xai_gradeNum'] === 0
-                            ? '0'
-                            : dataPA[f]
-                          : dataPA[f]
-                            ? dataPA[f].toFixed(2)
-                            : ''
-                        : ''
-                    }
-                  </div>
-
+                <div>
                   {
-                    // 오차 계산
-                    f !== 'xai_gradeNum' && f !== 'seqno' && f !== 'period' && (
-                      <div style={{ marginLeft: '10px' }}>
-                        {dataPA ? (
-                          dataPA[f] ? (
-                            <span
-                              style={
-                                dataPA[f].toFixed(2) -
-                                  processed_data[processedDataIdx]?.[f] >
-                                0
-                                  ? { color: 'red' }
-                                  : { color: 'blue' }
-                              }
-                            >
-                              {
-                                dataPA[f].toFixed(2) -
-                                  processed_data[processedDataIdx]?.[f] >
-                                0
-                                  ? '(+' +
-                                    (
-                                      dataPA[f].toFixed(2) -
-                                      processed_data[processedDataIdx]?.[f]
-                                    ).toFixed(2) +
-                                    ')' /*플러스인 경우 */
-                                  : '(' +
-                                    (
-                                      dataPA[f].toFixed(2) -
-                                      processed_data[processedDataIdx]?.[f]
-                                    ).toFixed(2) +
-                                    ')' /*미이너스인 경우 */
-                              }
-                            </span>
-                          ) : (
-                            <span></span>
-                          )
-                        ) : (
-                          ''
-                        )}
-                      </div>
-                    )
+                    // 1회차
+                    dataPA
+                      ? f === 'xai_gradeNum'
+                        ? dataPA['xai_gradeNum'] === 0
+                          ? '0'
+                          : dataPA[f]
+                        : dataPA[f]
+                          ? dataPA[f].toFixed(2)
+                          : ''
+                      : ''
                   }
                 </div>
+
+                {
+                  // 오차 계산
+                  f !== 'xai_gradeNum' && f !== 'seqno' && f !== 'period' && (
+                    <div style={{ marginLeft: '10px' }}>
+                      {dataPA ? (
+                        dataPA[f] ? (
+                          <span
+                            style={
+                              dataPA[f].toFixed(2) -
+                                processed_data[processedDataIdx]?.[f] >
+                              0
+                                ? { color: 'red' }
+                                : { color: 'blue' }
+                            }
+                          >
+                            {
+                              dataPA[f].toFixed(2) -
+                                processed_data[processedDataIdx]?.[f] >
+                              0
+                                ? '(+' +
+                                  (
+                                    dataPA[f].toFixed(2) -
+                                    processed_data[processedDataIdx]?.[f]
+                                  ).toFixed(2) +
+                                  ')' /*플러스인 경우 */
+                                : '(' +
+                                  (
+                                    dataPA[f].toFixed(2) -
+                                    processed_data[processedDataIdx]?.[f]
+                                  ).toFixed(2) +
+                                  ')' /*미이너스인 경우 */
+                            }
+                          </span>
+                        ) : (
+                          <span></span>
+                        )
+                      ) : (
+                        ''
+                      )}
+                    </div>
+                  )
+                }
               </TableCell>
+              {
+                //2회차 부터
+                Array.from({ length: len }, (_, arr_idx) => (
+                  <TableCell align="right">
+                    <div>
+                      {
+                        // 1회차
+                        dataPA
+                          ? f === 'xai_gradeNum'
+                            ? dataPA['xai_gradeNum'] === 0
+                              ? '0'
+                              : dataPA[arr_idx]
+                            : dataPA[arr_idx]
+                              ? dataPA[arr_idx].toFixed(2)
+                              : ''
+                          : ''
+                      }
+                    </div>
+
+                    {
+                      // 오차 계산
+                      f !== 'xai_gradeNum' &&
+                        f !== 'seqno' &&
+                        f !== 'period' && (
+                          <div style={{ marginLeft: '10px' }}>
+                            {dataPA ? (
+                              dataPA[arr_idx] ? (
+                                <span
+                                  style={
+                                    dataPA[arr_idx].toFixed(2) -
+                                      processed_data[processedDataIdx]?.[f] >
+                                    0
+                                      ? { color: 'red' }
+                                      : { color: 'blue' }
+                                  }
+                                >
+                                  {
+                                    dataPA[f].toFixed(2) -
+                                      processed_data[processedDataIdx]?.[f] >
+                                    0
+                                      ? '(+' +
+                                        (
+                                          dataPA[f].toFixed(2) -
+                                          processed_data[processedDataIdx]?.[f]
+                                        ).toFixed(2) +
+                                        ')' /*플러스인 경우 */
+                                      : '(' +
+                                        (
+                                          dataPA[f].toFixed(2) -
+                                          processed_data[processedDataIdx]?.[f]
+                                        ).toFixed(2) +
+                                        ')' /*미이너스인 경우 */
+                                  }
+                                </span>
+                              ) : (
+                                <span></span>
+                              )
+                            ) : (
+                              ''
+                            )}
+                          </div>
+                        )
+                    }
+                  </TableCell>
+                ))
+              }
             </TableRow>
           ))}
         </TableBody>

--- a/test-web/src/components/DataDetailPage/TablesComps/PredictedRawTable.js
+++ b/test-web/src/components/DataDetailPage/TablesComps/PredictedRawTable.js
@@ -17,7 +17,6 @@ const PredictedRawTable = ({ raw_data, dataPA }) => {
       sx={{ width: 'fitContent', overflow: 'auto', marginTop: '40px' }}
     >
       <Table sx={{ minWidth: 300 }} size="small" aria-label="a dense table">
-        <TableHead></TableHead>
         <TableBody>
           {rawPAField.map((f, idx) => {
             return (
@@ -25,10 +24,7 @@ const PredictedRawTable = ({ raw_data, dataPA }) => {
                 <TableCell key={'raw-' + idx + 'col1'}>
                   {rawPADBFieldToSematicWord[f]}
                 </TableCell>
-                <TableCell
-                  key={'raw-' + idx + 'col2'}
-                  style={{ display: 'flex' }}
-                >
+                <TableCell key={'raw-' + idx + 'col2'}>
                   <div>
                     {dataPA
                       ? f === 'xai_gradeNum'

--- a/test-web/src/components/DataDetailPage/TablesComps/ProcessedTableStatic.js
+++ b/test-web/src/components/DataDetailPage/TablesComps/ProcessedTableStatic.js
@@ -16,7 +16,10 @@ const ProcessedTableStatic = ({
   processedMinute,
   processedToggleValue,
   processed_data,
+  processed_data_seq,
 }) => {
+  const len = processed_data_seq.length - 2;
+
   return (
     <TableContainer
       key="processedmeat"
@@ -32,14 +35,11 @@ const ProcessedTableStatic = ({
             </TableCell>
             {
               // 2회차 이상부터
-              Array.from(
-                { length: Number(processedToggleValue.slice(0, -1)) - 1 },
-                (_, arr_idx) => (
-                  <TableCell align="right" style={{ background: '#cfd8dc' }}>
-                    {arr_idx + 2}회차
-                  </TableCell>
-                )
-              )
+              Array.from({ length: len }, (_, arr_idx) => (
+                <TableCell align="right" style={{ background: '#cfd8dc' }}>
+                  {arr_idx + 2}회차
+                </TableCell>
+              ))
             }
           </TableRow>
         </TableHead>
@@ -66,20 +66,17 @@ const ProcessedTableStatic = ({
               </TableCell>
               {
                 //2회차 부터
-                Array.from(
-                  { length: Number(processedToggleValue.slice(0, -1)) - 1 },
-                  (_, arr_idx) => (
-                    <TableCell align="right">
-                      {f === 'minute'
+                Array.from({ length: len }, (_, arr_idx) => (
+                  <TableCell align="right">
+                    {f === 'minute'
+                      ? processedMinute[arr_idx + 1]
                         ? processedMinute[arr_idx + 1]
-                          ? processedMinute[arr_idx + 1]
-                          : ''
-                        : processed_data[arr_idx + 1]?.[f]
-                          ? processed_data[arr_idx + 1]?.[f]
-                          : ''}
-                    </TableCell>
-                  )
-                )
+                        : ''
+                      : processed_data[arr_idx + 1]?.[f]
+                        ? processed_data[arr_idx + 1]?.[f]
+                        : ''}
+                  </TableCell>
+                ))
               }
             </TableRow>
           ))}

--- a/test-web/src/components/DataDetailPage/dataProcessing.js
+++ b/test-web/src/components/DataDetailPage/dataProcessing.js
@@ -40,7 +40,6 @@ const convertToApiData = (
     userName: userName,
     userType: userType,
   };
-  console.log('apidata2 : ', apiData);
   return apiData;
 };
 

--- a/test-web/src/components/DataListView/DataList.js
+++ b/test-web/src/components/DataListView/DataList.js
@@ -62,7 +62,6 @@ const DataList = ({
     }
   };
 
-
   return (
     <Box
       style={{ backgroundColor: 'white', borderRadius: '5px', height: '100%' }}
@@ -145,18 +144,18 @@ const DataList = ({
                         pageProp === 'pa'
                           ? {
                               pathname: `/dataPA/${content.meatId}`,
-                              search: `?pageOffset=${offset}&startDate=${startDate}&endDate=${endDate}`,
+                              search: `?pageOffset=${offset}&start=${startDate}&end=${endDate}`,
                             }
                           : (pageProp === 'list' || 'reject') &&
                               (content.statusType === '대기중' ||
                                 content.statusType === '반려')
                             ? {
                                 pathname: `/DataConfirm/${content.meatId}`,
-                                search: `?pageOffset=${offset}&startDate=${startDate}&endDate=${endDate}`,
+                                search: `?pageOffset=${offset}&start=${startDate}&end=${endDate}`,
                               }
                             : {
                                 pathname: `/dataView/${content.meatId}`,
-                                search: `?pageOffset=${offset}&startDate=${startDate}&endDate=${endDate}`,
+                                search: `?pageOffset=${offset}&start=${startDate}&end=${endDate}`,
                               }
                       }
                     >

--- a/test-web/src/components/Search/SearchFilterBar.js
+++ b/test-web/src/components/Search/SearchFilterBar.js
@@ -1,5 +1,5 @@
 // import react
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 // import mui
 import {
@@ -112,18 +112,6 @@ const SearchFilterBar = () => {
 
   const open = Boolean(anchorEl);
   const id = open ? 'simple-popover' : undefined;
-
-  useEffect(() => {
-    const durationFromURL = searchParams.get('duration');
-    if (durationFromURL) {
-      setDuration(durationFromURL);
-      setIsDur(true);
-    } else if (searchParams.get('start') && searchParams.get('end')) {
-      setCalenderStart(dayjs(searchParams.get('start')));
-      setCalenderEnd(dayjs(searchParams.get('end')));
-      setIsDur(false);
-    }
-  }, [location.search]);
 
   return (
     <div>

--- a/test-web/src/routes/DataConfirm.js
+++ b/test-web/src/routes/DataConfirm.js
@@ -11,8 +11,8 @@ const DataConfirm = () => {
   // 쿼리스트링 추출
   const searchParams = useLocation().search;
   const pageOffset = new URLSearchParams(searchParams).get('pageOffset');
-  const startDate = new URLSearchParams(searchParams).get('startDate');
-  const endDate = new URLSearchParams(searchParams).get('endDate');
+  const startDate = new URLSearchParams(searchParams).get('start');
+  const endDate = new URLSearchParams(searchParams).get('end');
   return (
     <Box
       style={{
@@ -30,7 +30,7 @@ const DataConfirm = () => {
           <Link
             to={{
               pathname: '/DataManage',
-              search: `?pageOffset=${pageOffset}&startDate=${startDate}&endDate=${endDate}`,
+              search: `?pageOffset=${pageOffset}&start=${startDate}&end=${endDate}`,
             }}
             style={{
               textDecorationLine: 'none',

--- a/test-web/src/routes/DataEdit.js
+++ b/test-web/src/routes/DataEdit.js
@@ -11,8 +11,8 @@ const DataEdit = () => {
   // 쿼리스트링 추출
   const searchParams = useLocation().search;
   const pageOffset = new URLSearchParams(searchParams).get('pageOffset');
-  const startDate = new URLSearchParams(searchParams).get('startDate');
-  const endDate = new URLSearchParams(searchParams).get('endDate');
+  const startDate = new URLSearchParams(searchParams).get('start');
+  const endDate = new URLSearchParams(searchParams).get('end');
   console.log('수정 및 조회', { pageOffset, startDate, endDate });
 
   //관리번호
@@ -32,7 +32,7 @@ const DataEdit = () => {
           <Link
             to={{
               pathname: '/DataManage',
-              search: `?pageOffset=${pageOffset}&startDate=${startDate}&endDate=${endDate}`,
+              search: `?pageOffset=${pageOffset}&start=${startDate}&end=${endDate}`,
             }}
             style={{
               textDecorationLine: 'none',

--- a/test-web/src/routes/DataPredict.js
+++ b/test-web/src/routes/DataPredict.js
@@ -12,8 +12,8 @@ const DataPredict = () => {
   // 쿼리스트링 추출
   const searchParams = useLocation().search;
   const pageOffset = new URLSearchParams(searchParams).get('pageOffset');
-  const startDate = new URLSearchParams(searchParams).get('startDate');
-  const endDate = new URLSearchParams(searchParams).get('endDate');
+  const startDate = new URLSearchParams(searchParams).get('start');
+  const endDate = new URLSearchParams(searchParams).get('end');
   console.log('예측', { pageOffset, startDate, endDate });
 
   return (
@@ -24,7 +24,7 @@ const DataPredict = () => {
           <Link
             to={{
               pathname: '/PA',
-              search: `?pageOffset=${pageOffset}&startDate=${startDate}&endDate=${endDate}`,
+              search: `?pageOffset=${pageOffset}&start=${startDate}&end=${endDate}`,
             }}
             style={{
               textDecorationLine: 'none',


### PR DESCRIPTION
PA 페이지의 테이블이 깨지던 것에서 정상적으로 작동하도록,
그리고 회차 정보에 상관없이 처리육 전체 회차를 가져오도록 수정하였습니다.
처리육 데이터가 없으면 없다고 나오도록 수정했습니다.
![화면 캡처 2024-08-21 135845](https://github.com/user-attachments/assets/b6453508-6946-4c9a-8d8d-408e92f93988)
![화면 캡처 2024-08-21 135711](https://github.com/user-attachments/assets/1337d864-ceeb-4f0e-ac72-db6f5fde46ef)
![화면 캡처 2024-08-21 135745](https://github.com/user-attachments/assets/ace300c2-5748-4562-b653-344e4831558e)

또한 서치필터를 수정하면서, 상세페이지에서 나갈 때, 필터 구간이 유지되지 않던 문제 해결했습니다.