### PR TITLE
hotfix: meat/get/opencv-image에서 DTO에 맞게 결과 반환

### DIFF
--- a/test-backend/test-flask/api/get_api.py
+++ b/test-backend/test-flask/api/get_api.py
@@ -333,7 +333,7 @@ def getOpenCVData():
         if meat_id:
             result = get_OpenCVresult(db_session, meat_id)
             if result:
-                return jsonify({"msg": "Success to get OpenCV Result", "result": result}), 200
+                return jsonify(result), 200
             else:
                 return jsonify({"msg": "There Does Not Exist OpenCV Result"}), 404
         return jsonify({"msg": f"Meat Data {meat_id} Does Not Exist"}), 400

--- a/test-backend/test-flask/db/db_controller.py
+++ b/test-backend/test-flask/db/db_controller.py
@@ -2089,10 +2089,20 @@ def get_timeseries_of_cattle_data(db_session, start, end, meat_value, seqno):
 
 def get_OpenCVresult(db_session, meat_id):
     try:
+        result = {}
         opencv_result = db_session.query(OpenCVImagesInfo).filter_by(id=meat_id).first()
         if opencv_result:
+            result["meatId"] = meat_id
+            result["createdAt"] = convert2string(opencv_result.createdAt, 1)
+            result["segmentImage"] = opencv_result.section_imagePath
+            result["proteinColorPalette"] = opencv_result.protein_palette
+            result["fatColorPalette"] = opencv_result.fat_palette
+            result["totalColorPalette"] = opencv_result.full_palette
+            result["proteinRate"] = opencv_result.protein_rate
+            result["fatRate"] = opencv_result.fat_rate
+            
             db_session.close()
-            return opencv_result
+            return result
 
     except Exception as e:
         db_session.close()


### PR DESCRIPTION
## 주요 수정 사항
1) meat/get/opencv-image
- DTO에 맞게 필요한 결과만 반환하도록 수정
- 전체 결과는 노션에 ResDTO 페이지 참고
<img width="611" alt="image" src="https://github.com/user-attachments/assets/fdbe356f-a48e-4171-8d02-0f1c3ce316da">
