### PR TITLE
hotfix: update_user에서 updatedAt 포맷 에러 수정

### DIFF
--- a/test-backend/test-flask/utils.py
+++ b/test-backend/test-flask/utils.py
@@ -326,8 +326,8 @@ def calId(id, s_id, type):
 
 
 def item_encoder(data_dict, item, input_data=None):
-    datetime0_cvr = ["filmedAt", "createdAt", "updatedAt"]
-    datetime1_cvr = ["loginAt"]
+    datetime0_cvr = ["filmedAt", "createdAt"]
+    datetime1_cvr = ["loginAt", "updatedAt"]
     datetime2_cvr = ["butcheryYmd", "birthYmd", "date"]
     str_cvr = [
         "id",


### PR DESCRIPTION
## 수정 사항
- 2개의 item_encoder()에서 두 개의 updatedAt 포맷이 서로 달라서 update_user 함수에서 포맷 에러 발생하여 datetime 포맷을 수정함