### PR TITLE
feat: docker compose로 prometheus, grafana monitoring 시스템 구성

### DIFF
--- a/test-backend/prometheus-grafana/docker-compose.yml
+++ b/test-backend/prometheus-grafana/docker-compose.yml
@@ -1,0 +1,42 @@
+version: '3.8'
+
+services:
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: prometheus
+    volumes:
+      - ./prometheus/config:/etc/prometheus
+      - ./prometheus/volume:/prometheus
+    ports:
+      - "9090:9090"
+    command:
+      - '--web.enable-lifecycle'
+      - '--config.file=/etc/prometheus/prometheus.yml'
+    restart: always
+
+  grafana:
+    image: grafana/grafana:latest
+    container_name: grafana
+    ports:
+      - "3000:3000"
+    environment:
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+    volumes:
+      - ./grafana/volume:/var/lib/grafana
+    restart: always
+  
+  node-exporter:
+    image: prom/node-exporter:latest
+    container_name: node-exporter
+    restart: unless-stopped
+    volumes:
+      - /proc:/host/proc:ro
+      - /sys:/host/sys:ro
+      - /:/rootfs:ro
+    command:
+      - '--path.procfs=/host/proc'
+      - '--path.rootfs=/rootfs'
+      - '--path.sysfs=/host/sys'
+      - '--collector.filesystem.mount-points-exclude=^/(sys|proc|dev|host|etc)($|/)'
+    ports:
+      - "9100:9100"

--- a/test-backend/prometheus-grafana/prometheus/config/prometheus.yml
+++ b/test-backend/prometheus-grafana/prometheus/config/prometheus.yml
@@ -18,7 +18,6 @@ scrape_configs:
   - job_name: 'monitoring' # job_name 은 모든 scrap 내에서 고유해야함
     # 실제 scrap 하는 타겟에 관한 설정
     static_configs:
-      - targets: ['localhost:9090', 'node-exporter:9100'] ## prometheus, node-exporter 
+      - targets: ['localhost:9090', '10.121.128.238:8080', 'node-exporter:9100'] ## prometheus, node-exporter 
         labels: # 옵션 - scrap 해서 가져올 metrics 들 전부에게 붙여줄 라벨
           service : 'monitor-1'
-

--- a/test-backend/prometheus-grafana/prometheus/config/prometheus.yml
+++ b/test-backend/prometheus-grafana/prometheus/config/prometheus.yml
@@ -1,0 +1,24 @@
+global:
+  scrape_interval: 15s     # scrap target의 기본 interval을 15초로 변경 / default = 1m
+  scrape_timeout: 15s      # scrap request 가 timeout 나는 길이 / default = 10s
+  evaluation_interval: 2m  # rule 을 얼마나 빈번하게 검증하는지 / default = 1m
+
+  external_labels:
+    monitor: 'codelab-monitor'       # 기본적으로 붙여줄 라벨
+  query_log_file: query_log_file.log # prometheus의 쿼리 로그들을 기록, 없으면 기록안함
+
+# 규칙을 로딩하고 'evaluation_interval' 설정에 따라 정기적으로 평가한다.
+rule_files:
+  - "rule.yml"  # 파일 위치는 prometheus.yml 이 있는 곳과 동일 위치
+
+# 매트릭을 수집할 엔드포인드로 여기선 Prometheus 서버 자신을 가리킨다.
+scrape_configs:
+  # 이 설정에서 수집한 타임시리즈에 `job=<job_name>`으로 잡의 이름을 설정한다.
+  # metrics_path의 기본 경로는 '/metrics'이고 scheme의 기본값은 `http`다
+  - job_name: 'monitoring' # job_name 은 모든 scrap 내에서 고유해야함
+    # 실제 scrap 하는 타겟에 관한 설정
+    static_configs:
+      - targets: ['localhost:9090', 'node-exporter:9100'] ## prometheus, node-exporter 
+        labels: # 옵션 - scrap 해서 가져올 metrics 들 전부에게 붙여줄 라벨
+          service : 'monitor-1'
+

--- a/test-backend/prometheus-grafana/prometheus/config/rule.yml
+++ b/test-backend/prometheus-grafana/prometheus/config/rule.yml
@@ -1,0 +1,21 @@
+groups:
+- name: monitoring-rule # 파일 내에서 unique 해야함
+  rules:
+
+  # Alert for any instance that is unreachable for >5 minutes.
+  - alert: InstanceDown
+    expr: up == 0
+    for: 5m
+    labels:
+      severity: page
+    annotations:
+      summary: "Instance {{ $labels.instance }} down"
+      description: "{{ $labels.instance }} of job {{ $labels.job }} has been down for more than 5 minutes."
+
+  # Alert for any instance that has a median request latency >1s.
+  - alert: APIHighRequestLatency
+    expr: api_http_request_latencies_second{quantile="0.5"} > 1
+    for: 10m
+    annotations:
+      summary: "High request latency on {{ $labels.instance }}"
+      description: "{{ $labels.instance }} has a median request latency above 1s (current value: {{ $value }}s)"

--- a/test-backend/test-flask/app.py
+++ b/test-backend/test-flask/app.py
@@ -12,6 +12,9 @@ from db.db_model import initialize_db
 from connection.firebase_connect import FireBase_
 from connection.s3_connect import S3_
 
+from prometheus_client import make_wsgi_app
+from werkzeug.middleware.dispatcher import DispatcherMiddleware
+
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
@@ -77,6 +80,10 @@ app.register_blueprint(predict_api, url_prefix="/meat/predict") # 예측 데이�
 def hello_world():
     return "Hello, World!"
 
-# Flask 실행
 if __name__ == "__main__":
+    # Prometheus 메트릭 엔드포인트를 위해 DispatcherMiddleware 사용
+    app.wsgi_app = DispatcherMiddleware(app.wsgi_app, {
+        '/metrics': make_wsgi_app()
+    })
+
     app.run(debug=True, port=8080, host="0.0.0.0")


### PR DESCRIPTION
## 주요 수정 사항
### 목표: 백엔드 개발 서버에 모니터링 시스템을 구축하고자 함.
- 시스템 / flask 애플리케이션 메트릭을 수집하는 오픈 소스 prometheus&node-exporter와 수집한 메트릭을 대시보드로 구성해주는 시각화 오픈소스 grafana를 docker compose로 작성하였음.
- 현재 auto scaling으로 자동 배포를 구현하였기 때문에 모니터링 시스템들 또한 자동으로 배포되는 과정에서 실행될 수 있도록 하기 위해 docker compose로 띄우는 것을 선택하였음. (이에 맞게 ec2의 시작 템플릿에 docker, docker-compose를 설치하고 실행시키는 커맨드 추가하였음)
- 현재까지 수집 중인 메트릭은 시스템 메트릭과 (CPU 사용량, 메모리 등등) flask application의 http response 메트릭까지 수집 중
- prometheus.yml 파일에서의 서비스 타겟에 flask app의 주소와 실행 포트도 추가함.

아래는 prometheus와 node-exporter를 통해 수집한 메트릭을 grafana로 시각화한 대시보드
<img width="1436" alt="image" src="https://github.com/user-attachments/assets/42d45dc3-1ae8-4b41-a231-1e6b8db12bce">
