### PR TITLE
hotfix: get_AI_SensoryEval에서 테이블 필드명 수정

### DIFF
--- a/test-backend/test-flask/db/db_controller.py
+++ b/test-backend/test-flask/db/db_controller.py
@@ -1139,7 +1139,7 @@ def get_AI_SensoryEval(db_session, id, seqno):
             "meatId": ai_sensoryEval.id,
             "seqno": ai_sensoryEval.seqno,
             "createdAt": ai_sensoryEval.createdAt,
-            "xaiGrade": gradeNum[ai_sensoryEval.xaiGradeNum],
+            "xaiGrade": gradeNum[ai_sensoryEval.xai_gradeNum],
             "xaiGradeImagePath": ai_sensoryEval.xai_gradeNum_imagePath,
             "xaiImagePath": ai_sensoryEval.xai_imagePath,
             "marbling": ai_sensoryEval.marbling,


### PR DESCRIPTION
## 주요 수정 사항
- get_AI_SensoryEval에서 xaiGradeNum -> xai_gradeNum으로 필드명 수정