### PR TITLE
feat: meatId의 일부분으로 조회하는 API 추가

### DIFF
--- a/test-backend/test-flask/api/get_api.py
+++ b/test-backend/test-flask/api/get_api.py
@@ -13,7 +13,8 @@ from db.db_controller import (
     _getMeatDataByRangeStatusType,
     _getTexanomyData,
     _getPredictionData,
-    get_OpenCVresult
+    get_OpenCVresult,
+    get_meat_by_partial_id
 )
 from utils import *
 
@@ -69,30 +70,25 @@ def getMeatDataById():
 
 
 # ID를 부분적으로 포함하는 육류 데이터 출력
-@get_api.route("/by-partial-id", methods=["GET", "POST"])
+@get_api.route("/by-partial-id", methods=["GET"])
 def getMeatDataByPartialId():
     try:
-        if request.method == "GET":
-            db_session = current_app.db_session
-            part_id = request.args.get("part_id")
-            meats_with_statusType_2 = (
-                db_session.query(Meat).filter_by(statusType=2).all()
-            )
-            meat_list = []
-            for meat in meats_with_statusType_2:
-                meat_list.append(meat.id)
+        db_session = current_app.db_session
+        partial_id = request.args.get("meatId")
+        if partial_id is None:
+            return jsonify({"msg": "Invalid Meat Id"}), 400
+        meats = get_meat_by_partial_id(db_session, partial_id)
 
-            part_id_meat_list = [meat for meat in meat_list if part_id in meat]
-            return jsonify({part_id: part_id_meat_list})
-        else:
-            return jsonify({"msg": "Invalid Route, Please Try Again."}), 404
+        part_id_meat_list = [get_meat(meat) for meat in meats]
+        logger.log(meats)
+        return jsonify(part_id_meat_list)
     except Exception as e:
         logger.exception(str(e))
         return (
             jsonify(
                 {"msg": "Server Error", "time": datetime.now().strftime("%H:%M:%S")}
             ),
-            505,
+            500,
         )
 
 

--- a/test-backend/test-flask/api/get_api.py
+++ b/test-backend/test-flask/api/get_api.py
@@ -75,13 +75,19 @@ def getMeatDataByPartialId():
     try:
         db_session = current_app.db_session
         partial_id = request.args.get("meatId")
+        offset = request.args.get("offset")
+        count = request.args.get("count")
+        start = request.args.get("start")
+        end = request.args.get("end")
+        specie = request.args.get("specieValue")
+        if specie == '전체':
+            specie_value = 2
+        else:
+            specie_value = species.index(specie)
         if partial_id is None:
             return jsonify({"msg": "Invalid Meat Id"}), 400
-        meats = get_meat_by_partial_id(db_session, partial_id)
-
-        part_id_meat_list = [get_meat(meat) for meat in meats]
-        logger.log(meats)
-        return jsonify(part_id_meat_list)
+        meats = get_meat_by_partial_id(db_session, partial_id, offset, count, start, end, specie_value)
+        return jsonify(meats)
     except Exception as e:
         logger.exception(str(e))
         return (

--- a/test-backend/test-flask/db/db_controller.py
+++ b/test-backend/test-flask/db/db_controller.py
@@ -791,6 +791,10 @@ def get_range_meat_data(
     db_session.close()
     return result
 
+def get_meat_by_partial_id(db_session, partial_id):
+    meats = db_session.query(Meat).filter(Meat.id.like(f"{partial_id}/%"))
+    logger.log(meats)
+    return meats
 
 # UPDATE
 

--- a/test-backend/test-flask/db/db_controller.py
+++ b/test-backend/test-flask/db/db_controller.py
@@ -791,10 +791,62 @@ def get_range_meat_data(
     db_session.close()
     return result
 
-def get_meat_by_partial_id(db_session, partial_id):
-    meats = db_session.query(Meat).filter(Meat.id.like(f"{partial_id}/%"))
-    logger.log(meats)
-    return meats
+def get_meat_by_partial_id(
+    db_session,
+    partial_id,
+    offset,
+    count,
+    start=None,
+    end=None,
+    specie_value=None
+):
+    if (count is not None) and (offset is not None):
+        count = safe_int(count)
+        offset = safe_int(offset)
+        offset = offset * count
+    start = convert2datetime(start, 0)
+    end = convert2datetime(end, 0)
+
+    # Base Query
+    query = db_session.query(Meat.id).filter(Meat.id.like(f"{partial_id}%"))
+
+    if specie_value != 2:
+        query = query.join(CategoryInfo).filter(CategoryInfo.speciesId == specie_value)
+
+    # 기간 설정 쿼리
+    db_total_len = query.count()
+    if start is not None and end is not None:
+        query = query.filter(Meat.createdAt.between(start, end))
+        db_total_len = query.filter(Meat.createdAt.between(start, end)).count()
+    query = query.order_by(Meat.createdAt.desc())
+    if (count is not None) and (offset is not None):
+        query = query.offset(offset).limit(count)
+
+    # 탐색
+    meat_data = query.all()
+    meat_result = {}
+    id_result = [data.id for data in meat_data]
+    for id in id_result:
+        meat_result[id] = get_meat(db_session, id)
+        userTemp = get_user(db_session, meat_result[id].get("userId"))
+        if userTemp:
+            meat_result[id]["userName"] = userTemp.name
+            meat_result[id]["company"] = userTemp.company
+            meat_result[id]["userType"] = usrType[userTemp.type]
+        else:
+            meat_result[id]["userName"] = userTemp
+            meat_result[id]["company"] = userTemp
+            meat_result[id]["userType"] = userTemp
+        del meat_result[id]["deepAgingInfo"]
+
+    result = {
+        "DB Total len": db_total_len,
+        "id_list": id_result,
+        "meat_dict": meat_result,
+    }
+    
+    db_session.close()
+    return result
 
 # UPDATE
 


### PR DESCRIPTION
## 추가한 점
- `meat/get/by-partial-id` API 생성
  - 기존 육류 전체 조회 로직을 수정하여 일부 아이디만으로 육류를 조회할 수 있도록 API 작성
  - 따라서 기존 대시보드처럼 pagination이 진행되는 것으로 판단하면 됨
  - `meatId`, `offset`, `count`, `start`, `end`, `specieValue` 값을 쿼리로 전달