### PR TITLE
feat: 예측 API 작성

### DIFF
--- a/test-backend/test-flask/api/get_api.py
+++ b/test-backend/test-flask/api/get_api.py
@@ -338,8 +338,8 @@ def getOpenCVData():
             if result:
                 return jsonify(result), 200
             else:
-                return jsonify({"msg": "OpenCV Result Does Not Exist"}), 404
-        return jsonify({"msg": f"OpenCV Data {meat_id}-{seqno} Does Not Exist"}), 400
+                return jsonify({"msg": "OpenCV Result Does Not Exist"}), 400
+        return jsonify("Invalid id or seqno parameter"), 404
     except Exception as e:
         logger.exception(str(e))
         return (

--- a/test-backend/test-flask/api/get_api.py
+++ b/test-backend/test-flask/api/get_api.py
@@ -339,7 +339,7 @@ def getOpenCVData():
                 return jsonify(result), 200
             else:
                 return jsonify({"msg": "OpenCV Result Does Not Exist"}), 404
-        return jsonify({"msg": f"Meat Data {meat_id} Does Not Exist"}), 400
+        return jsonify({"msg": f"OpenCV Data {meat_id}-{seqno} Does Not Exist"}), 400
     except Exception as e:
         logger.exception(str(e))
         return (

--- a/test-backend/test-flask/api/get_api.py
+++ b/test-backend/test-flask/api/get_api.py
@@ -296,7 +296,7 @@ def getTexanomyData():
         db_session = current_app.db_session
         return _getTexanomyData(db_session)
     except Exception as e:
-        # logger.exception(str(e))
+        logger.exception(str(e))
         return (
             jsonify(
                 {"msg": "Server Error", "time": datetime.now().strftime("%H:%M:%S")}
@@ -332,12 +332,13 @@ def getOpenCVData():
     try:
         db_session = current_app.db_session
         meat_id = safe_str(request.args.get("meatId"))
-        if meat_id:
-            result = get_OpenCVresult(db_session, meat_id)
+        seqno = safe_int(request.args.get("seqno"))
+        if meat_id and (seqno is not None):
+            result = get_OpenCVresult(db_session, meat_id, seqno)
             if result:
                 return jsonify(result), 200
             else:
-                return jsonify({"msg": "There Does Not Exist OpenCV Result"}), 404
+                return jsonify({"msg": "OpenCV Result Does Not Exist"}), 404
         return jsonify({"msg": f"Meat Data {meat_id} Does Not Exist"}), 400
     except Exception as e:
         logger.exception(str(e))

--- a/test-backend/test-flask/api/predict_api.py
+++ b/test-backend/test-flask/api/predict_api.py
@@ -5,26 +5,28 @@ import pprint
 
 from opencv_utils import *
 from db.db_controller import *
+from ml_utils import *
 
 
 predict_api = Blueprint("predict_api", __name__)
 
+logger = logging.getLogger(__name__)
 
-# 특정 육류의 컬러팔레트 도출
-@predict_api.route("/color_palette", methods=["GET"])
+
+# 특정 육류의 컬러팔레트 조회
+@predict_api.route("/color-palette", methods=["GET"])
 def create_meat_palette():
     s3_conn = current_app.s3_conn
     meat_id = request.args.get("meatId")
     seqno = request.args.get("seqno")
     
     img = s3_conn.download_image(f"sensory_evals/{meat_id}-{seqno}.png")
-    print("Success to Download Image From S3")
     result = display_palette_with_ratios(img)
     return jsonify({"meatId": meat_id, "seqno": seqno, "result": result})
 
 
-# 특정 육류의 텍스쳐 정보 도출
-@predict_api.route("/texture_info", methods=["GET"])
+# 특정 육류의 텍스쳐 정보 조회
+@predict_api.route("/texture-info", methods=["GET"])
 def create_meat_texture_info():
     s3_conn = current_app.s3_conn
     meat_id = request.args.get("meatId")
@@ -32,12 +34,11 @@ def create_meat_texture_info():
     
     img = s3_conn.download_image(f"sensory_evals/{meat_id}-{seqno}.png")
     texture_result = create_texture_info(img)
-    print(texture_result)
     return texture_result
 
 
-# 특정 육류의 텍스쳐 정보 도출
-@predict_api.route("/lbp_gabor", methods=["GET"])
+# 특정 육류의 텍스쳐 정보 조회
+@predict_api.route("/lbp-gabor", methods=["GET"])
 def create_meat_lbp_garbor_images():
     s3_conn = current_app.s3_conn
     meat_id = request.args.get("meatId")
@@ -46,26 +47,37 @@ def create_meat_lbp_garbor_images():
     img = s3_conn.download_image(f"sensory_evals/{meat_id}-{seqno}.png")
     
     lbp_result = lbp_calculate(s3_conn, img, meat_id, seqno)
-    print(lbp_result)
     gabor_result = gabor_texture_analysis(s3_conn, img, meat_id, seqno)
     pprint.pprint(gabor_result)
     return lbp_result, gabor_result
 
 
-# 원육 이미지에 대해서 opencv 전처리 진행
+# 원육 이미지에 대해서 opencv 전처리 진행 (컬러팔레트, 텍스쳐 정보, lbp-gabor, 단면 이미지)
 @predict_api.route("/process-image", methods=["POST", "PATCH"])
 def create_raw_meat_opencv_info():
     try:
         db_session = current_app.db_session
         s3_conn = current_app.s3_conn
         meat_id = request.args.get("meatId")
-        segment_img_object = extract_section_image(f"sensory_evals/{meat_id}-0.png", meat_id)
+        seqno = request.args.get("seqno")
+        
+        # 해당 육류 - 회차의 관능 데이터가 존재하지 않을 때
+        sensory_info = get_SensoryEval(db_session, meat_id, seqno)
+        if not sensory_info:
+            return {"msg": f"Sensory Info Does Not Exist: {meat_id} - {seqno}"}, 400
+        
+        # 해당 육류 - 회차의 opencv 데이터가 존재할 때
+        opencv_info = get_OpenCVresult(db_session, meat_id, seqno)
+        if opencv_info:
+            return {"msg": f"OpenCV Result Already Exists"}, 400
+        
+        segment_img_object = extract_section_image(f"sensory_evals/{meat_id}-{seqno}.png", meat_id, seqno)
         
         if segment_img_object:
-            result = process_opencv_image(db_session, s3_conn, meat_id, segment_img_object)
+            result = process_opencv_image(db_session, s3_conn, meat_id, seqno, segment_img_object)
             return jsonify({"msg": f"Success to create OpenCV Info"}), 200
         else:
-            return jsonify({"msg": f"Fail to create Segmentation Images"}), 400
+            return jsonify({"msg": f"Fail to create OpenCV data"}), 400
     except Exception as e:
         logging.exception(str(e))
         return (
@@ -76,7 +88,7 @@ def create_raw_meat_opencv_info():
         )
         
 
-# 예측 실행
+# 예측 실행 (예측 관능 평가, 예측 등급)
 @predict_api.route("/sensory-eval", methods=["POST"])
 def predict_sensory_eval():
     try:
@@ -84,12 +96,25 @@ def predict_sensory_eval():
         s3_conn = current_app.s3_conn
         meat_id = safe_str(request.args.get("meatId"))
         seqno = safe_int(request.args.get("seqno"))
-        img = s3_conn.download_image(f"sensory_evals/{meat_id}-{seqno}.png")
-        segment_img_object = extract_section_image(f"sensory_evals/{meat_id}-{seqno}.png", meat_id)
         
-
+        # 해당 육류 - 회차의 관능 데이터가 존재하지 않을 때
+        sensory_info = get_SensoryEval(db_session, meat_id, seqno)
+        if not sensory_info:
+            return {"msg": f"Sensory Info Does Not Exist: {meat_id} - {seqno}"}, 400
+        
+        # 해당 육류 - 회차의 예측 관능, 등급 데이터가 존재할 때
+        ai_sensory_info = get_AI_SensoryEval(db_session, meat_id, seqno)
+        if ai_sensory_info:
+            return {"msg": f"AI Sensory Info Already Exists"}, 400
+        
+        ai_sensory_data = process_predict_sensory_eval(db_session, s3_conn, meat_id, seqno)
+        if ai_sensory_data:
+            return jsonify({"msg": f"Success to create Predict Data"}), 200
+        else:
+            return jsonify({"msg": f"Fail to create Predict Data"}), 400
 
     except Exception as e:
+        logger.exception(str(e))
         return (
             jsonify(
                 {"msg": "Server Error", "time": datetime.now().strftime("%H:%M:%S")}

--- a/test-backend/test-flask/api/predict_api.py
+++ b/test-backend/test-flask/api/predict_api.py
@@ -13,45 +13,6 @@ predict_api = Blueprint("predict_api", __name__)
 logger = logging.getLogger(__name__)
 
 
-# 특정 육류의 컬러팔레트 조회
-@predict_api.route("/color-palette", methods=["GET"])
-def create_meat_palette():
-    s3_conn = current_app.s3_conn
-    meat_id = request.args.get("meatId")
-    seqno = request.args.get("seqno")
-    
-    img = s3_conn.download_image(f"sensory_evals/{meat_id}-{seqno}.png")
-    result = display_palette_with_ratios(img)
-    return jsonify({"meatId": meat_id, "seqno": seqno, "result": result})
-
-
-# 특정 육류의 텍스쳐 정보 조회
-@predict_api.route("/texture-info", methods=["GET"])
-def create_meat_texture_info():
-    s3_conn = current_app.s3_conn
-    meat_id = request.args.get("meatId")
-    seqno = request.args.get("seqno")
-    
-    img = s3_conn.download_image(f"sensory_evals/{meat_id}-{seqno}.png")
-    texture_result = create_texture_info(img)
-    return texture_result
-
-
-# 특정 육류의 텍스쳐 정보 조회
-@predict_api.route("/lbp-gabor", methods=["GET"])
-def create_meat_lbp_garbor_images():
-    s3_conn = current_app.s3_conn
-    meat_id = request.args.get("meatId")
-    seqno = request.args.get("seqno")
-    
-    img = s3_conn.download_image(f"sensory_evals/{meat_id}-{seqno}.png")
-    
-    lbp_result = lbp_calculate(s3_conn, img, meat_id, seqno)
-    gabor_result = gabor_texture_analysis(s3_conn, img, meat_id, seqno)
-    pprint.pprint(gabor_result)
-    return lbp_result, gabor_result
-
-
 # 원육 이미지에 대해서 opencv 전처리 진행 (컬러팔레트, 텍스쳐 정보, lbp-gabor, 단면 이미지)
 @predict_api.route("/process-image", methods=["POST", "PATCH"])
 def create_raw_meat_opencv_info():

--- a/test-backend/test-flask/api/predict_api.py
+++ b/test-backend/test-flask/api/predict_api.py
@@ -22,6 +22,10 @@ def create_raw_meat_opencv_info():
         meat_id = request.args.get("meatId")
         seqno = request.args.get("seqno")
         
+        # Invalid parameter
+        if (meat_id or seqno) is None:
+            return {"msg": "Invalid id or seqno parameter"}, 404 
+        
         # 해당 육류 - 회차의 관능 데이터가 존재하지 않을 때
         sensory_info = get_SensoryEval(db_session, meat_id, seqno)
         if not sensory_info:
@@ -57,6 +61,10 @@ def predict_sensory_eval():
         s3_conn = current_app.s3_conn
         meat_id = safe_str(request.args.get("meatId"))
         seqno = safe_int(request.args.get("seqno"))
+        
+        # Invalid parameter
+        if (meat_id or seqno) is None:
+            return {"msg": "Invalid id or seqno parameter"}, 404 
         
         # 해당 육류 - 회차의 관능 데이터가 존재하지 않을 때
         sensory_info = get_SensoryEval(db_session, meat_id, seqno)

--- a/test-backend/test-flask/app.py
+++ b/test-backend/test-flask/app.py
@@ -81,9 +81,5 @@ def hello_world():
     return "Hello, World!"
 
 if __name__ == "__main__":
-    # Prometheus 메트릭 엔드포인트를 위해 DispatcherMiddleware 사용
-    app.wsgi_app = DispatcherMiddleware(app.wsgi_app, {
-        '/metrics': make_wsgi_app()
-    })
 
     app.run(debug=True, port=8080, host="0.0.0.0")

--- a/test-backend/test-flask/connection/s3_connect.py
+++ b/test-backend/test-flask/connection/s3_connect.py
@@ -44,6 +44,15 @@ class S3_:
             print(f"No such file in Flask Server: {type}/{item_id}.png")
             return False
         
+    def get_object(self, bucket, object_key):
+        try:
+            response = self.s3.get_object(Bucket=bucket, Key=object_key)
+            data = response['Body'].read()  # Read the entire content of the object
+            return data  # Return the binary data
+        except Exception as e:
+            print(f"Error downloading image from S3: {e}")
+            return None
+        
     def download_image(self, object_key):
         """S3에서 이미지를 다운로드하고 OpenCV 이미지로 변환 (최적화 버전)"""
         try:

--- a/test-backend/test-flask/db/db_controller.py
+++ b/test-backend/test-flask/db/db_controller.py
@@ -2208,7 +2208,7 @@ def process_predict_sensory_eval(db_session, s3_conn, meat_id, seqno):
         if segment_img:
             segment_img_object = segment_img
         else:
-            segment_img_object = extract_section_image(f"sensory_evals/{meat_id}-{seqno}.png", meat_id)
+            segment_img_object = extract_section_image(f"sensory_evals/{meat_id}-{seqno}.png", meat_id, seqno)
         
         ai_sensory_data = {}
         

--- a/test-backend/test-flask/db/db_controller.py
+++ b/test-backend/test-flask/db/db_controller.py
@@ -2147,7 +2147,9 @@ def get_timeseries_of_cattle_data(db_session, start, end, meat_value, seqno):
 def get_OpenCVresult(db_session, meat_id, seqno):
     try:
         result = {}
-        opencv_result = db_session.query(OpenCVImagesInfo).filter_by(id=meat_id).first()
+        opencv_result = db_session.query(OpenCVImagesInfo).filter(
+            OpenCVImagesInfo.id == meat_id, OpenCVImagesInfo.seqno == seqno
+            ).first()
         if opencv_result:
             result["meatId"] = meat_id
             result["seqno"] = seqno

--- a/test-backend/test-flask/ml_utils.py
+++ b/test-backend/test-flask/ml_utils.py
@@ -1,0 +1,120 @@
+import torch
+from torch import nn
+from torchvision import transforms, models
+from PIL import Image
+import mlflow
+
+from opencv_utils import *
+
+
+def predict_regression_sensory_eval(s3_image_object, meat_id, seqno):    
+    # 설정
+    image_resize = 256  # 이미지 리사이즈 크기
+    input_size = 224    # 입력 이미지 크기
+    mean = [0.4834, 0.3656, 0.3474]  # 데이터셋의 mean
+    std = [0.2097, 0.2518, 0.2559]   # 데이터셋의 std
+
+    # 전처리 파이프라인 정의
+    transform = transforms.Compose([
+        transforms.Resize(image_resize),
+        transforms.CenterCrop(input_size),
+        transforms.ToTensor(),
+        transforms.Normalize(mean=mean, std=std),
+    ])
+    model_location = "/home/ubuntu/mlflow/regression_model"
+    model = serve_mlflow(model_location)
+
+    model.eval()
+
+    # 이미지 불러오기 및 전처리
+    try:
+        s3_bucket = os.getenv("S3_BUCKET_NAME")
+        s3 = boto3.client(
+                service_name="s3",
+                region_name=os.getenv("S3_REGION_NAME"),
+                aws_access_key_id=os.getenv("AWS_ACCESS_KEY_ID"),
+                aws_secret_access_key=os.getenv("AWS_SECRET_ACCESS_KEY"),
+            )
+        object_key = s3_image_object
+
+        response = s3.get_object(Bucket=s3_bucket, Key=object_key)
+        img = Image.open(io.BytesIO(response['Body'].read())).convert("RGB")
+        print("Success to create Image Object")
+    except Exception as e:
+        raise jsonify({"msg": f"Fail to create Image Object From S3. {str(e)}"})
+    
+    image_tensor = transform(img).unsqueeze(0).to(device)  # 배치 차원 추가
+
+    # 예측 수행
+    with torch.no_grad():
+        output = model(image_tensor)
+
+    # 예측 결과 출력
+    predict_result = {}
+    predict_data = output.squeeze().tolist()
+    
+    predict_result["marbling"] = predict_data[0]
+    predict_result["color"] = predict_data[0]
+    predict_result["texture"] = predict_data[0]
+    predict_result["surfaceMoisture"] = predict_data[0]
+    predict_result["overall"] = predict_data[0]
+    predict_result["xai_imagePath"] = None
+    print(f"Predicted values: {predict_result}")
+    
+    # RDS에 저장 로직 추가하기
+    return predict_result
+
+
+def predict_classification_grade(s3_image_object):
+    # 설정
+    image_resize = 256  # 이미지 리사이즈 크기
+    input_size = 224    # 입력 이미지 크기
+    mean = [0.4694, 0.3536, 0.3339] # 데이터셋의 mean과 std 
+    std = [0.2051, 0.2459, 0.2498]
+
+    grade_to_label = {0: '1++', 1: '1+', 2: '1', 3: '2', 4: '3'}
+
+    # 전처리 파이프라인 정의
+    transform = transforms.Compose([
+        transforms.Resize(image_resize),
+        transforms.CenterCrop(input_size),
+        transforms.ToTensor(),
+        transforms.Normalize(mean=mean, std=std),
+    ])
+
+    model_location = "/home/ubuntu/mlflow/classification_model"
+    model = serve_mlflow(model_location)
+
+    model.eval()
+
+    # 이미지 불러오기 및 전처리
+    try:
+        s3_bucket = os.getenv("S3_BUCKET_NAME")
+        s3 = boto3.client(
+                service_name="s3",
+                region_name=os.getenv("S3_REGION_NAME"),
+                aws_access_key_id=os.getenv("AWS_ACCESS_KEY_ID"),
+                aws_secret_access_key=os.getenv("AWS_SECRET_ACCESS_KEY"),
+            )
+        object_key = s3_image_object
+
+        response = s3.get_object(Bucket=s3_bucket, Key=object_key)
+        img = Image.open(io.BytesIO(response['Body'].read())).convert("RGB")
+        print("Success to create Image Object")
+    except Exception as e:
+        raise jsonify({"msg": f"Fail to create Image Object From S3. {str(e)}"})
+    
+    image_tensor = transform(img).unsqueeze(0).to(device)  # 배치 차원 추가
+
+    # 예측 수행
+    with torch.no_grad():
+        output = model(image_tensor)
+
+    # 예측 결과 처리
+    _, predicted_class = torch.max(output, 1)
+    predicted_index = predicted_class.item()
+    # predicted_grade = grade_to_label[predicted_index]
+    grade_data = {}
+    grade_data["xai_gradeNum"] = predicted_index
+    grade_data["xai_gradeNum_imagePath"] = None
+    return grade_data

--- a/test-backend/test-flask/opencv_utils.py
+++ b/test-backend/test-flask/opencv_utils.py
@@ -141,7 +141,7 @@ def apply_mask(image, mask):
     return image * mask.to(device)
 
 
-def extract_section_image(s3_image_object, meat_id):
+def extract_section_image(s3_image_object, meat_id, seqno):
     # 데이터셋 및 DataLoader 설정
     transform = SegmentationTransform(output_size=(448, 448))
     
@@ -194,7 +194,7 @@ def extract_section_image(s3_image_object, meat_id):
     img = Image.fromarray(img)
 
     # output_key를 설정
-    output_key = os.path.join('section_images', f"{meat_id}-0.png")
+    output_key = os.path.join('section_images', f"{meat_id}-{seqno}.png")
 
     # 이미지 데이터를 바이트 스트림으로 변환
     img_byte_arr = io.BytesIO()

--- a/test-backend/test-flask/requirements.txt
+++ b/test-backend/test-flask/requirements.txt
@@ -23,7 +23,7 @@ charset-normalizer==3.3.2
 click==8.1.7
 cloudpickle==3.0.0
 comm==0.2.1
-contourpy==1.2.1
+contourpy==1.3.0
 cryptography==42.0.8
 cycler==0.12.1
 databricks-sdk==0.30.0
@@ -51,6 +51,7 @@ Flask-Cors==4.0.1
 Flask-SQLAlchemy==3.1.1
 fonttools==4.51.0
 fqdn==1.5.1
+fsspec==2024.2.0
 gitdb==4.0.11
 GitPython==3.1.43
 google-api-core==2.19.1
@@ -109,22 +110,35 @@ Mako==1.3.5
 Markdown==3.5.2
 markdown-it-py==3.0.0
 MarkupSafe==2.1.3
-matplotlib==3.8.4
-matplotlib-inline==0.1.6
+matplotlib==3.9.2
+matplotlib-inline==0.1.7
 mdurl==0.1.2
 mistune==3.0.2
 mlflow==2.15.1
 mlflow-skinny==2.15.1
+mpmath==1.3.0
 msgpack==1.0.8
 multidict==6.0.5
 nbclient==0.9.0
 nbconvert==7.16.0
 nbformat==5.9.2
 nest-asyncio==1.6.0
-networkx==3.3
+networkx==3.2.1
 notebook==7.0.8
 notebook_shim==0.2.3
 numpy==1.26.4
+nvidia-cublas-cu12==12.1.3.1
+nvidia-cuda-cupti-cu12==12.1.105
+nvidia-cuda-nvrtc-cu12==12.1.105
+nvidia-cuda-runtime-cu12==12.1.105
+nvidia-cudnn-cu12==8.9.2.26
+nvidia-cufft-cu12==11.0.2.54
+nvidia-curand-cu12==10.3.2.106
+nvidia-cusolver-cu12==11.4.5.107
+nvidia-cusparse-cu12==12.1.0.106
+nvidia-nccl-cu12==2.20.5
+nvidia-nvjitlink-cu12==12.1.105
+nvidia-nvtx-cu12==12.1.105
 opencv-python==4.10.0.84
 opentelemetry-api==1.26.0
 opentelemetry-sdk==1.26.0
@@ -132,7 +146,7 @@ opentelemetry-semantic-conventions==0.47b0
 outcome==1.3.0.post0
 overrides==7.7.0
 packaging==23.2
-pandas==2.2.1
+pandas==2.2.2
 pandocfilters==1.5.1
 parso==0.8.3
 pexpect==4.9.0
@@ -177,9 +191,8 @@ rpds-py==0.17.1
 rsa==4.9
 s3transfer==0.10.0
 scikit-image==0.24.0
-scikit-learn==1.5.1
-scipy==1.14.1
-seaborn==0.13.2
+scikit-learn==1.5.2
+scipy==1.13.1
 selenium==4.4.3
 Send2Trash==1.8.2
 six==1.16.0
@@ -190,22 +203,21 @@ soupsieve==2.5
 SQLAlchemy==2.0.31
 sqlparse==0.4.4
 stack-data==0.6.3
+sympy==1.12
 terminado==0.18.0
 threadpoolctl==3.5.0
-tifffile==2024.8.10
+tifffile==2024.8.30
 tinycss2==1.2.1
 tomli==2.0.1
-# torch==1.12.1+cu113
-# torchaudio==0.12.1+cu113
-# torchvision==0.13.1+cu113
-# tornado==6.4
-torch==2.4.0
-torchvision==0.19.0
-tornado==6.4
+torch==2.3.0+cu121
+torchaudio==2.3.0+cu121
+torchvision==0.18.0+cu121
+tornado==6.4.1
 tqdm==4.66.2
 traitlets==5.14.1
 trio==0.25.0
 trio-websocket==0.11.1
+triton==2.3.0
 types-python-dateutil==2.8.19.20240106
 typing_extensions==4.9.0
 tzdata==2024.1

--- a/test-backend/test-flask/requirements.txt
+++ b/test-backend/test-flask/requirements.txt
@@ -209,10 +209,10 @@ threadpoolctl==3.5.0
 tifffile==2024.8.30
 tinycss2==1.2.1
 tomli==2.0.1
-torch==2.3.0+cu121
-torchaudio==2.3.0+cu121
-torchvision==0.18.0+cu121
-tornado==6.4.1
+# torch==2.3.0+cu121
+# torchaudio==2.3.0+cu121
+# torchvision==0.18.0+cu121
+# tornado==6.4.1
 tqdm==4.66.2
 traitlets==5.14.1
 trio==0.25.0


### PR DESCRIPTION
## 주요 수정 사항
### 1. /meat/predict/sensory-eval
- 관능 데이터, 등급 예측 수행하는 API
- 예외 처리
   - 해당 회차의 관능 데이터가 존재하지 않을 때: 400 에러
   - 해당 회차의 opencv 결과가 이미 존재할 때: 400 에러
   - 해당 회차의 이미지가 존재하지 않을 때: 500 에러
<img width="500" alt="스크린샷 2024-09-21 오후 12 19 42" src="https://github.com/user-attachments/assets/a564532e-5e26-4353-86ff-ac935e75fc35">

  
### 2. /meat/predict/process-image
- opencv 관련 전처리를 모두 수행하는 API
  - 컬러팔레트, 단면 도출, 텍스쳐 정보 도출, lbp-gabor filter 모두 수행
 - 예외 처리
   - 해당 회차의 관능 데이터가 존재하지 않을 때: 400 에러
   - 해당 회차의 opencv 결과가 이미 존재할 때: 400 에러
   - 해당 회차의 이미지가 존재하지 않을 때: 500 에러
 
<img width="500" alt="스크린샷 2024-09-21 오후 12 15 57" src="https://github.com/user-attachments/assets/04106484-01ac-4a69-9475-0838d4072684">
  
### 3. /meat/get/opencv-image
- opencv 데이터 조회하는 API
  - 자세한 DTO는 노션 참고
- 예외 처리
  - 해당 회차의 opencv 결과가 존재하지 않을 때 400 에러
  - Invalid parameter: 404 에러
 <img width="500" alt="스크린샷 2024-09-21 오후 12 20 24" src="https://github.com/user-attachments/assets/c60005c8-f53d-43f0-babf-b814f0d04a2a">

### 4. /meat/get/predict-data
- 예측 데이터 조회하는 API
  - 자세한 DTO는 노션 참고
- 예외 처리
  - 해당 회차의 예측 결과가 존재하지 않을 때 400 에러
  - Invalid parameter: 404 에러
 
<img width="500" alt="스크린샷 2024-09-21 오후 12 20 14" src="https://github.com/user-attachments/assets/918b9390-d2dd-472f-bd7c-64bbc8e5b884">
