### PR TITLE
fix: model serving하는 로직 수정

### DIFF
--- a/test-backend/test-flask/ml_utils.py
+++ b/test-backend/test-flask/ml_utils.py
@@ -41,7 +41,7 @@ def predict_regression_sensory_eval(s3_image_object, meat_id, seqno):
         img = Image.open(io.BytesIO(response['Body'].read())).convert("RGB")
         print("Success to create Image Object")
     except Exception as e:
-        raise jsonify({"msg": f"Fail to create Image Object From S3. {str(e)}"})
+        raise Exception({"msg": f"Fail to create Image Object From S3. {str(e)}"})
     
     image_tensor = transform(img).unsqueeze(0).to(device)  # 배치 차원 추가
 
@@ -102,7 +102,7 @@ def predict_classification_grade(s3_image_object):
         img = Image.open(io.BytesIO(response['Body'].read())).convert("RGB")
         print("Success to create Image Object")
     except Exception as e:
-        raise jsonify({"msg": f"Fail to create Image Object From S3. {str(e)}"})
+        raise Exception({"msg": f"Fail to create Image Object From S3. {str(e)}"})
     
     image_tensor = transform(img).unsqueeze(0).to(device)  # 배치 차원 추가
 

--- a/test-backend/test-flask/ml_utils.py
+++ b/test-backend/test-flask/ml_utils.py
@@ -21,8 +21,8 @@ def predict_regression_sensory_eval(s3_image_object, meat_id, seqno):
         transforms.ToTensor(),
         transforms.Normalize(mean=mean, std=std),
     ])
-    model_location = "/home/ubuntu/mlflow/regression_model"
-    model = serve_mlflow(model_location)
+    model_location = "/home/ubuntu/mlflow/regression_model/data/model.pth"
+    model = load_local_model(model_location)
 
     model.eval()
 
@@ -82,8 +82,8 @@ def predict_classification_grade(s3_image_object):
         transforms.Normalize(mean=mean, std=std),
     ])
 
-    model_location = "/home/ubuntu/mlflow/classification_model"
-    model = serve_mlflow(model_location)
+    model_location = "/home/ubuntu/mlflow/classification_model/data/model.pth"
+    model = load_local_model(model_location)
 
     model.eval()
 

--- a/test-backend/test-flask/opencv_utils.py
+++ b/test-backend/test-flask/opencv_utils.py
@@ -166,7 +166,7 @@ def extract_section_image(s3_image_object, meat_id, seqno):
         img = Image.open(io.BytesIO(response['Body'].read())).convert("RGB")
         print("Success to create Image Object")
     except Exception as e:
-        raise jsonify({"msg": f"Fail to create Image Object From S3. {str(e)}"})
+        raise Exception({"msg": f"Fail to create Image Object From S3. {str(e)}"})
     
     # 이미지 변환
     img_tensor, _ = transform(img, Image.new('L', img.size))


### PR DESCRIPTION
## 주요 수정사항
### Base Exception 에러 수정
  - try-exception 구문에서 예외 처리 리턴할 때 jsonify로 반환하여 발생했던 base exception 에러 수정

### 모델 서빙 로직 수정
- 현재 모델은 로컬에 파일의 형태로 저장하여 불러오기 때문에 기존의 로직인 mlflow에 올리고, 다시 모델의 형태로 다운받는 로직이 비효율적이라고 판단하여 모델 서빙하는 함수 수정함