### PR TITLE
hotfix: texture 정보 뽑을 때 roi가 존재하지 않는 경우 예외처리

### DIFF
--- a/test-backend/test-flask/opencv_utils.py
+++ b/test-backend/test-flask/opencv_utils.py
@@ -309,8 +309,13 @@ def create_texture_info(image):
     # 관심 영역만 추출 (검정색 배경 제외)
     roi = gray[mask != 0] #1차원 배열인 상태 
 
-    # GLCM 계산을 위한 형태로 변환
-    roi_reshaped = roi.reshape(-1, 1)
+    # ROI가 비어있다면 관심영역을 전체로 판단
+    if roi.size == 0:
+        roi_reshaped = gray
+    else:
+        # roi를 2차원으로 변환
+        roi_reshaped = np.zeros_like(gray)
+        roi_reshaped[mask != 0] = roi
 
     # GLCM 계산
     distances = [1]


### PR DESCRIPTION
## 주요 수정 사항
- opencv_utils: 단면 이미지의 texture를 계산하고자 할 때 만약 roi(관심영역)가 추출되지 않을 때 관심 영역을 전체로 판단하는 로직 추가
- 오류 발생 이유: 현재 임의로 이미지를 넣으면서 테스트 하는 상황이여서 검정색 이미지를 집어넣었을 때 발생가능한 에러. 실제 육류 데이터만 넣게 된다면 이런 문제는 발생하지 않을까 생각함.