### PR TITLE
fix: opencv patch 요청 추가 및 기능 분리

### DIFF
--- a/test-backend/test-flask/api/predict_api.py
+++ b/test-backend/test-flask/api/predict_api.py
@@ -70,14 +70,9 @@ def create_meat_opencv_info_for_model():
         sensory_info = get_SensoryEval(db_session, meat_id, seqno)
         if not sensory_info:
             return {"msg": f"Sensory Info Does Not Exist: {meat_id} - {seqno}"}, 400
-        
-        segment_img_object = extract_section_image(f"sensory_evals/{meat_id}-{seqno}.png", meat_id, seqno)
-        
-        if segment_img_object:
-            result = process_opencv_image_for_learning(db_session, s3_conn, meat_id, seqno, segment_img_object)
-            return jsonify({"msg": result["msg"], "code": result["code"]})
-        
-        return jsonify({"msg": f"Fail to Create or Update OpenCV data for Learning"}), 400
+    
+        result = process_opencv_image_for_learning(db_session, s3_conn, meat_id, seqno)
+        return jsonify({"msg": result["msg"], "code": result["code"]})
     except Exception as e:
         logging.exception(str(e))
         return (

--- a/test-backend/test-flask/api/predict_api.py
+++ b/test-backend/test-flask/api/predict_api.py
@@ -13,9 +13,9 @@ predict_api = Blueprint("predict_api", __name__)
 logger = logging.getLogger(__name__)
 
 
-# 원육 이미지에 대해서 opencv 전처리 진행 (컬러팔레트, 텍스쳐 정보, lbp-gabor, 단면 이미지)
-@predict_api.route("/process-image", methods=["POST", "PATCH"])
-def create_raw_meat_opencv_info():
+# 원육 및 처리육 이미지에 대해서 "웹에 보여주기 위한" opencv 전처리 진행 (단면 이미지, 컬러팔레트)
+@predict_api.route("/process-opencv", methods=["POST", "PATCH"])
+def create_meat_opencv_info():
     try:
         db_session = current_app.db_session
         s3_conn = current_app.s3_conn
@@ -31,18 +31,18 @@ def create_raw_meat_opencv_info():
         if not sensory_info:
             return {"msg": f"Sensory Info Does Not Exist: {meat_id} - {seqno}"}, 400
         
-        # 해당 육류 - 회차의 opencv 데이터가 존재할 때
-        opencv_info = get_OpenCVresult(db_session, meat_id, seqno)
-        if opencv_info:
-            return {"msg": f"OpenCV Result Already Exists"}, 400
-        
         segment_img_object = extract_section_image(f"sensory_evals/{meat_id}-{seqno}.png", meat_id, seqno)
         
         if segment_img_object:
-            result = process_opencv_image(db_session, s3_conn, meat_id, seqno, segment_img_object)
-            return jsonify({"msg": f"Success to create OpenCV Info"}), 200
-        else:
-            return jsonify({"msg": f"Fail to create OpenCV data"}), 400
+            # POST 요청
+            if request.method == "POST":
+                result = process_opencv_image_for_web(db_session, s3_conn, meat_id, seqno, segment_img_object, is_post=1)
+            # PATCH 요청
+            else: 
+                result = process_opencv_image_for_web(db_session, s3_conn, meat_id, seqno, segment_img_object, is_post=0)
+            return jsonify({"msg": result["msg"], "code": result["code"]})
+        
+        return jsonify({"msg": f"Fail to Create or Update OpenCV data"}), 400
     except Exception as e:
         logging.exception(str(e))
         return (
@@ -52,7 +52,42 @@ def create_raw_meat_opencv_info():
             500,
         )
         
-
+        
+# 원육 및 처리육 이미지에 대해서 "모델 학습을 위한" opencv 전처리 진행 (texture, lbp, gabor filter)
+@predict_api.route("/process-opencv-training", methods=["PATCH"])
+def create_meat_opencv_info_for_model():
+    try:
+        db_session = current_app.db_session
+        s3_conn = current_app.s3_conn
+        meat_id = request.args.get("meatId")
+        seqno = request.args.get("seqno")
+        
+        # Invalid parameter
+        if (meat_id or seqno) is None:
+            return {"msg": "Invalid id or seqno parameter"}, 404 
+        
+        # 해당 육류 - 회차의 관능 데이터가 존재하지 않을 때
+        sensory_info = get_SensoryEval(db_session, meat_id, seqno)
+        if not sensory_info:
+            return {"msg": f"Sensory Info Does Not Exist: {meat_id} - {seqno}"}, 400
+        
+        segment_img_object = extract_section_image(f"sensory_evals/{meat_id}-{seqno}.png", meat_id, seqno)
+        
+        if segment_img_object:
+            result = process_opencv_image_for_learning(db_session, s3_conn, meat_id, seqno, segment_img_object)
+            return jsonify({"msg": result["msg"], "code": result["code"]})
+        
+        return jsonify({"msg": f"Fail to Create or Update OpenCV data for Learning"}), 400
+    except Exception as e:
+        logging.exception(str(e))
+        return (
+            jsonify(
+                {"msg": "Server Error", "time": datetime.now().strftime("%H:%M:%S")}
+            ),
+            500,
+        )        
+        
+        
 # 예측 실행 (예측 관능 평가, 예측 등급)
 @predict_api.route("/sensory-eval", methods=["POST"])
 def predict_sensory_eval():

--- a/test-backend/test-flask/db/db_controller.py
+++ b/test-backend/test-flask/db/db_controller.py
@@ -5,6 +5,7 @@ import uuid
 from sqlalchemy import func
 import json
 from utils import *
+import pprint
 
 from .db_model import *
 from opencv_utils import *
@@ -2169,37 +2170,90 @@ def get_OpenCVresult(db_session, meat_id, seqno):
         raise Exception("Something Wrong with DB" + str(e))
     
     
-def process_opencv_image(db_session, s3_conn, meat_id, seqno, segment_object):
+def process_opencv_image_for_web(db_session, s3_conn, meat_id, seqno, segment_object, is_post):
     try:
+        opencv_info = db_session.query(OpenCVImagesInfo).filter(
+            OpenCVImagesInfo.id == meat_id, OpenCVImagesInfo.seqno == seqno
+            ).first()
         segment_img = s3_conn.download_image(segment_object)
-        opencv_data = {}
+        new_opencv_data = {}
         
-        # 단면 이미지 url 불러오기
-        segment_image_path = f"https://{s3_conn.bucket}.s3.ap-northeast-2.amazonaws.com/{segment_object}"
-        opencv_data["section_imagePath"] = segment_image_path
-        opencv_data["createdAt"] = convert2string(datetime.now(), 1)
-        opencv_data["id"] = meat_id
-        opencv_data["seqno"] = seqno
-        
-        # openCV 전처리 순서대로 진행
-        color_palette = display_palette_with_ratios(segment_img)
-        texture_result = create_texture_info(segment_img)
-        lbp_result = lbp_calculate(s3_conn, segment_img, meat_id, seqno=seqno)
-        gabor_result = gabor_texture_analysis(s3_conn, segment_img, meat_id, seqno=seqno)
-        
-        # opencv DB에 저장
-        opencv_data = {**opencv_data, **color_palette, **texture_result, **lbp_result, **gabor_result}
-        new_opencv = OpenCVImagesInfo(**opencv_data)
-        db_session.add(new_opencv)
-        db_session.commit()
-        
-        db_session.close()
-        return opencv_data
+        # POST 요청
+        if is_post == 1: 
+            if opencv_info:
+                return {"msg": f"OpenCV Result Already Exists", "code": 400}
+            
+            # 단면 이미지 url 불러오기
+            segment_image_path = f"https://{s3_conn.bucket}.s3.ap-northeast-2.amazonaws.com/{segment_object}"
+            new_opencv_data["section_imagePath"] = segment_image_path
+            new_opencv_data["createdAt"] = convert2string(datetime.now(), 1)
+            new_opencv_data["id"] = meat_id
+            new_opencv_data["seqno"] = seqno
+            
+            # openCV 전처리 순서대로 진행
+            color_palette = display_palette_with_ratios(segment_img)
+            
+            # opencv DB에 저장
+            new_opencv_data = {**new_opencv_data, **color_palette}
+            new_opencv = OpenCVImagesInfo(**new_opencv_data)
+            db_session.add(new_opencv)
+            db_session.commit()
+            
+            db_session.close()
+            return {"msg": f"Success to Create OpenCV Result {meat_id}-{seqno}", "code": 200}
+        # PATCH 요청
+        else:
+            if not opencv_info:
+                return {"msg": f"OpenCV Result Does Not Exist. Create OpenCV Data First.", "code": 400}
+            
+            new_color_palette = display_palette_with_ratios(segment_img)
+            
+            opencv_info.createdAt = convert2string(datetime.now(), 1)
+            new_color_palette = display_palette_with_ratios(segment_img)
+            
+            for key, value in new_color_palette.items():
+                setattr(opencv_info, key, value)
+                
+            db_session.merge(opencv_info)
+            db_session.commit()
+            return {"msg": f"Success to Update OpenCV Result {meat_id}-{seqno}", "code": 200}
+            
     except Exception as e:
         db_session.rollback()
         db_session.close()
         raise Exception("Something Wrong with DB" + str(e))
     
+
+def process_opencv_image_for_learning(db_session, s3_conn, meat_id, seqno, segment_object):
+    try:
+        opencv_info = db_session.query(OpenCVImagesInfo).filter(
+            OpenCVImagesInfo.id == meat_id, OpenCVImagesInfo.seqno == seqno
+            ).first()
+        segment_img = s3_conn.download_image(segment_object)
+        
+        # PATCH 요청만 존재
+        if not opencv_info:
+            return {"msg": f"OpenCV Result Does Not Exist", "code": 400}
+            
+        texture_result = create_texture_info(segment_img)
+        lbp_result = lbp_calculate(s3_conn, segment_img, meat_id, seqno=seqno)
+        gabor_result = gabor_texture_analysis(s3_conn, segment_img, meat_id, seqno=seqno)
+        new_opencv_data = {**texture_result, **lbp_result, **gabor_result}
+            
+        opencv_info.createdAt = convert2string(datetime.now(), 1)
+        
+        for key, value in new_opencv_data.items():
+            setattr(opencv_info, key, value)
+                
+        db_session.merge(opencv_info)
+        db_session.commit()
+        return {"msg": f"Success to Update OpenCV Result for Learning {meat_id}-{seqno}", "code": 200}
+
+    except Exception as e:
+        db_session.rollback()
+        db_session.close()
+        raise Exception("Something Wrong with DB" + str(e))
+        
 
 def process_predict_sensory_eval(db_session, s3_conn, meat_id, seqno):
     try:

--- a/test-backend/test-flask/db/db_controller.py
+++ b/test-backend/test-flask/db/db_controller.py
@@ -2224,17 +2224,20 @@ def process_opencv_image_for_web(db_session, s3_conn, meat_id, seqno, segment_ob
         raise Exception("Something Wrong with DB" + str(e))
     
 
-def process_opencv_image_for_learning(db_session, s3_conn, meat_id, seqno, segment_object):
+def process_opencv_image_for_learning(db_session, s3_conn, meat_id, seqno):
     try:
         opencv_info = db_session.query(OpenCVImagesInfo).filter(
             OpenCVImagesInfo.id == meat_id, OpenCVImagesInfo.seqno == seqno
             ).first()
-        segment_img = s3_conn.download_image(segment_object)
         
         # PATCH 요청만 존재
         if not opencv_info:
             return {"msg": f"OpenCV Result Does Not Exist", "code": 400}
-            
+        
+        segment_object = opencv_info.section_imagePath.split('.com/')[1]
+        segment_img = s3_conn.download_image(segment_object)
+        
+        # 모델 학습에 필요한 데이터들 전처리
         texture_result = create_texture_info(segment_img)
         lbp_result = lbp_calculate(s3_conn, segment_img, meat_id, seqno=seqno)
         gabor_result = gabor_texture_analysis(s3_conn, segment_img, meat_id, seqno=seqno)

--- a/test-backend/test-flask/opencv_utils.py
+++ b/test-backend/test-flask/opencv_utils.py
@@ -31,7 +31,11 @@ def ndarray_to_image(s3_conn, response, image_name):
     # Min-Max scaling을 통해 값을 [0, 255] 범위로 조정
     min_val = response.min()
     max_val = response.max()
-    scaled_array = (response - min_val) / (max_val - min_val) * 255
+    if min_val == max_val:
+        scaled_array = np.zeros_like(response)
+    else:
+        scaled_array = (response - min_val) / (max_val - min_val) * 255
+
     image = Image.fromarray(scaled_array.astype(np.uint8))
 
     # 이미지 데이터를 바이트 배열로 변환
@@ -366,7 +370,7 @@ def lbp_calculate(s3_conn, image, meat_id, seqno):
     n_points = 8 * radius
     lbp2 = local_binary_pattern(image, n_points, radius, method='uniform')
     
-    print("Success to create gabor_texture")
+    print("Success to create lbp images")
     
     # Save the LBP image
     image_name1 = f'openCV_images/{meat_id}-{seqno}-lbp1-{i+1}.png'
@@ -425,7 +429,7 @@ def gabor_texture_analysis(s3_conn, image, id, seqno):
     kernels = create_gabor_kernels(ksize, sigma, lambd, gamma, psi, num_orientations)
     responses = apply_gabor_kernels(img, kernels)
     features = compute_texture_features(responses)
-    print("Success to create gabor_texture")
+    print("Success to create gabor filter images")
     
     tmp = {}
     final_result = {}


### PR DESCRIPTION
## 주요 수정 사항
### 1. process_opencv_image_for_web()
- 기존 `meat/predict/process-image` -> `meat/predict/process-opencv` api endpoint 변경
  -  원육, 처리육 이미지 등록 시에 단면 이미지 도출+컬러팔레트 및 지방 단백질 비율 생성하는 api
  - PATCH 로직 추가

### 2. process_opencv_image_for_model()
- `meat/predict/process-opencv-training` -> 새로운 api로 분리
  - 예측 단계에서 모델 학습에 필요한 추가 데이터들(lbp, gabor, texture) 전처리하는 api
  - 기존에 opencv 결과가 존재해야만 데이터들을 DB에 삽입할 수 있기 때문에 **PATCH 요청**만 존재
  - 기존 Opencv 결과가 존재하지 않으면 400 에러

### 3. opencv_utils.py
- lbp 생성 시 print 문구 수정
- numpy.array를 image로 변환할 때 발생할 수 있는 예외 처리 로직 추가
  