### PR TITLE
Hajin@error popup

### DIFF
--- a/app/structure/lib/components/custom_pop_up.dart
+++ b/app/structure/lib/components/custom_pop_up.dart
@@ -134,16 +134,14 @@ void showPopup(BuildContext context, String contentText, String btnText,
             crossAxisAlignment: CrossAxisAlignment.end,
             children: [
               Expanded(
-                child:
-                    Center(child: Text(contentText, style: Palette.h4Regular)),
+                child: Center(
+                  child: Text(contentText, style: Palette.h4Regular),
+                ),
               ),
               CustomTextButton(
                 title: btnText,
                 textStyle: Palette.h5.copyWith(color: Palette.primary),
-                onPressed: onTap ??
-                    () {
-                      context.pop();
-                    },
+                onPressed: onTap ?? () => context.pop(),
               ),
             ],
           ),
@@ -162,24 +160,29 @@ void showErrorPopup(BuildContext context, {String? error}) {
       return Dialog(
         child: Container(
           width: 640.w,
-          height: 240.h,
           padding: EdgeInsets.symmetric(horizontal: 40.w, vertical: 16.h),
           decoration: BoxDecoration(
             color: Colors.white,
             borderRadius: BorderRadius.circular(20.r),
           ),
           child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
             mainAxisSize: MainAxisSize.min,
+            mainAxisAlignment: MainAxisAlignment.center,
             crossAxisAlignment: CrossAxisAlignment.end,
             children: [
               // 에러 메시지
-              Expanded(
-                child: Center(child: Text(errorText, style: Palette.h4Regular)),
-              ),
+              Center(child: Text(errorText, style: Palette.h4Regular)),
+              SizedBox(height: 16.h),
 
               // 에러 내용
-              Center(child: Text(error ?? '', style: Palette.h4Regular)),
+              Center(
+                child: Text(
+                  error ?? '',
+                  style: Palette.h4Regular,
+                  textAlign: TextAlign.center,
+                ),
+              ),
+              SizedBox(height: 16.h),
 
               // 버튼
               CustomTextButton(

--- a/app/structure/lib/components/custom_pop_up.dart
+++ b/app/structure/lib/components/custom_pop_up.dart
@@ -7,6 +7,7 @@ import 'package:go_router/go_router.dart';
 
 String errorText = '오류가 발생했습니다.';
 String unselectedText = '선택되지 않은 항목이 있습니다.';
+String cameraPermissionText = '설정에서 카메라 권한을 먼저 허용하세요.';
 String cameraErrorText = '카메라에 문제가 생겼습니다.';
 String fileUploadFailedText = '파일 업로드에 실패했습니다.';
 String successChangeUserInfo = '정상적으로 변경되었습니다.';
@@ -23,6 +24,11 @@ String terms =
 /// 선택되지않은 popup
 void showUnselectedPopup(BuildContext context) {
   showPopup(context, unselectedText, '');
+}
+
+/// 카메라 권한 오류 popup
+void showCameraPermissionPopup(BuildContext context) {
+  showPopup(context, cameraPermissionText, '확인');
 }
 
 /// 카메라 오류 popup

--- a/app/structure/lib/dataSource/remote_data_source.dart
+++ b/app/structure/lib/dataSource/remote_data_source.dart
@@ -264,7 +264,6 @@ class RemoteDataSource {
 
       return response.statusCode;
     } catch (e) {
-      print(e);
       debugPrint('PATCH 요청 중 예외 발생: $e');
       return e;
     }

--- a/app/structure/lib/dataSource/remote_data_source.dart
+++ b/app/structure/lib/dataSource/remote_data_source.dart
@@ -8,6 +8,7 @@ import 'dart:convert';
 import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:http/http.dart' as http;
+import 'package:http/http.dart';
 import 'package:xml2json/xml2json.dart';
 
 class RemoteDataSource {
@@ -223,7 +224,6 @@ class RemoteDataSource {
   static Future<dynamic> _postApi(String endPoint, String? jsonData) async {
     String apiUrl = '$baseUrl/$endPoint';
     Map<String, String> headers = {'Content-Type': 'application/json'};
-    // String requestBody = jsonData;
     debugPrint('POST 요청: $endPoint');
 
     try {
@@ -233,13 +233,14 @@ class RemoteDataSource {
         debugPrint('POST 요청 성공');
       } else {
         debugPrint('POST 요청 실패: (${response.statusCode})${response.body}');
+        return errorMsg(response);
       }
 
       // 예외 처리를 위한 status code 반환
       return response.statusCode;
     } catch (e) {
       debugPrint('POST 요청 중 예외 발생: $e');
-      return;
+      return e;
     }
   }
 
@@ -249,7 +250,6 @@ class RemoteDataSource {
   static Future<dynamic> _patchApi(String endPoint, String? jsonData) async {
     String apiUrl = '$baseUrl/$endPoint';
     Map<String, String> headers = {'Content-Type': 'application/json'};
-    // String requestBody = jsonData;
     debugPrint('PATCH 요청: $endPoint');
 
     try {
@@ -259,12 +259,14 @@ class RemoteDataSource {
         debugPrint('PATCH 요청 성공');
       } else {
         debugPrint('PATCH 요청 실패: (${response.statusCode})${response.body}');
+        return errorMsg(response);
       }
 
       return response.statusCode;
     } catch (e) {
+      print(e);
       debugPrint('PATCH 요청 중 예외 발생: $e');
-      return;
+      return e;
     }
   }
 
@@ -283,11 +285,11 @@ class RemoteDataSource {
         return jsonDecode(response.body);
       } else {
         debugPrint('GET 요청 실패: (${response.statusCode})${response.body}');
-        return response;
+        return errorMsg(response);
       }
     } catch (e) {
       debugPrint('GET 요청 중 예외 발생: $e');
-      return;
+      return e;
     }
   }
 
@@ -305,12 +307,13 @@ class RemoteDataSource {
         debugPrint('DELETE 요청 성공');
       } else {
         debugPrint('DELETE 요청 실패: (${response.statusCode})${response.body}');
+        return errorMsg(response);
       }
 
       return response.statusCode;
     } catch (e) {
       debugPrint('DELETE 요청 중 예외 발생: $e');
-      return;
+      return e;
     }
   }
 
@@ -337,5 +340,18 @@ class RemoteDataSource {
       debugPrint('error');
       return;
     }
+  }
+
+  /// `Response`를 code - msg 형식의 에러 메시지로 변환하는 함수
+  static String errorMsg(Response response) {
+    final code = response.statusCode;
+    String msg = '';
+    try {
+      msg = json.decode(response.body)['msg'];
+    } catch (e) {
+      msg = response.body;
+      msg = msg.replaceAll('“', '');
+    }
+    return '$code: $msg';
   }
 }

--- a/app/structure/lib/screen/meat_registration/insertion_trace_num_screen.dart
+++ b/app/structure/lib/screen/meat_registration/insertion_trace_num_screen.dart
@@ -35,10 +35,12 @@ class _InsertionTraceNumScreenState extends State<InsertionTraceNumScreen> {
     super.initState();
     // 바코드 관련 사전 작업.
     _eventChannel = const EventChannel('com.example.structure/barcode');
-    _eventSubscription = _eventChannel!.receiveBroadcastStream().listen(
-          (dynamic event) =>
-              context.read<InsertionTraceNumViewModel>().getBarcodeValue(event),
-        );
+    _eventSubscription =
+        _eventChannel!.receiveBroadcastStream().listen((dynamic event) {
+      if (mounted) {
+        context.read<InsertionTraceNumViewModel>().getBarcodeValue(event);
+      }
+    });
   }
 
   @override

--- a/app/structure/lib/viewModel/data_management/normal/data_management_normal_view_model.dart
+++ b/app/structure/lib/viewModel/data_management/normal/data_management_normal_view_model.dart
@@ -117,6 +117,8 @@ class DataManagementNormalViewModel with ChangeNotifier {
             entireList.add(idStatusPair);
           }
         }
+      } else {
+        throw ErrorDescription(response);
       }
     } catch (e) {
       debugPrint('Error: $e');
@@ -448,7 +450,7 @@ class DataManagementNormalViewModel with ChangeNotifier {
 
         if (context.mounted) context.go('/home/data-manage-normal/edit');
       } else {
-        throw Error();
+        throw ErrorDescription(response);
       }
     } catch (e) {
       debugPrint('Error: $e');

--- a/app/structure/lib/viewModel/data_management/normal/edit_meat_data_view_model.dart
+++ b/app/structure/lib/viewModel/data_management/normal/edit_meat_data_view_model.dart
@@ -93,6 +93,9 @@ class EditMeatDataViewModel with ChangeNotifier {
         throw ErrorDescription(response);
       }
     } catch (e) {
+      isLoading = false;
+      notifyListeners();
+
       debugPrint('Error: $e');
       if (context.mounted) showErrorPopup(context, error: e.toString());
     }
@@ -117,6 +120,9 @@ class EditMeatDataViewModel with ChangeNotifier {
         throw ErrorDescription(response);
       }
     } catch (e) {
+      isLoading = false;
+      notifyListeners();
+
       debugPrint('Error: $e');
       if (context.mounted) showErrorPopup(context, error: e.toString());
     }

--- a/app/structure/lib/viewModel/data_management/researcher/add_deep_aging_data_view_model.dart
+++ b/app/structure/lib/viewModel/data_management/researcher/add_deep_aging_data_view_model.dart
@@ -99,7 +99,9 @@ class AddDeepAgingDataViewModel with ChangeNotifier {
         throw ErrorDescription(response);
       }
     } catch (e) {
-      print("dfsfdfs");
+      isLoading = false;
+      notifyListeners();
+
       debugPrint('Error: $e');
       if (context.mounted) showErrorPopup(context, error: e.toString());
     }

--- a/app/structure/lib/viewModel/data_management/researcher/data_add_view_model.dart
+++ b/app/structure/lib/viewModel/data_management/researcher/data_add_view_model.dart
@@ -71,10 +71,12 @@ class DataAddViewModel with ChangeNotifier {
       if (response != 200) {
         meatModel.deepAgingInfo!.removeAt(idx);
       } else {
-        // TODO : 오류 메시지 팝업
         throw ErrorDescription(response);
       }
     } catch (e) {
+      isLoading = false;
+      notifyListeners();
+
       debugPrint("Error: $e");
       if (context.mounted) showErrorPopup(context, error: e.toString());
     }

--- a/app/structure/lib/viewModel/data_management/researcher/data_management_add_additional_info_tab_view_model.dart
+++ b/app/structure/lib/viewModel/data_management/researcher/data_management_add_additional_info_tab_view_model.dart
@@ -471,7 +471,7 @@ class DataManagementAddAdditionalInfoTabViewModel with ChangeNotifier {
         meatModel.fromJson(response);
         if (context.mounted) context.go('/home/data-manage-researcher/add');
       } else {
-        throw Error();
+        throw ErrorDescription(response);
       }
     } catch (e) {
       debugPrint('Error: $e');

--- a/app/structure/lib/viewModel/data_management/researcher/insertion_heated_sensory_view_model.dart
+++ b/app/structure/lib/viewModel/data_management/researcher/insertion_heated_sensory_view_model.dart
@@ -111,7 +111,6 @@ class InsertionHeatedSensoryViewModel with ChangeNotifier {
       if (response == 200) {
         meatModel.updateHeatedSeonsory();
       } else {
-        // TODO : 입력한 데이터 초기화
         throw ErrorDescription(response);
       }
     } catch (e) {

--- a/app/structure/lib/viewModel/data_management/researcher/insertion_heated_sensory_view_model.dart
+++ b/app/structure/lib/viewModel/data_management/researcher/insertion_heated_sensory_view_model.dart
@@ -115,6 +115,9 @@ class InsertionHeatedSensoryViewModel with ChangeNotifier {
         throw ErrorDescription(response);
       }
     } catch (e) {
+      isLoading = false;
+      notifyListeners();
+
       debugPrint('Error: $e');
       if (context.mounted) showErrorPopup(context, error: e.toString());
     }

--- a/app/structure/lib/viewModel/data_management/researcher/insertion_lab_data_view_model.dart
+++ b/app/structure/lib/viewModel/data_management/researcher/insertion_lab_data_view_model.dart
@@ -184,6 +184,9 @@ class InsertionLabDataViewModel with ChangeNotifier {
         throw ErrorDescription(response);
       }
     } catch (e) {
+      isLoading = false;
+      notifyListeners();
+
       debugPrint("Error: $e");
       if (context.mounted) showErrorPopup(context, error: e.toString());
     }

--- a/app/structure/lib/viewModel/data_management/researcher/insertion_lab_data_view_model.dart
+++ b/app/structure/lib/viewModel/data_management/researcher/insertion_lab_data_view_model.dart
@@ -180,7 +180,6 @@ class InsertionLabDataViewModel with ChangeNotifier {
           meatModel.updateHeatedProbExpt();
         }
       } else {
-        // TODO: 입력한 데이터 삭제해야함
         throw ErrorDescription(response);
       }
     } catch (e) {

--- a/app/structure/lib/viewModel/data_management/researcher/insertion_tongue_data_view_model.dart
+++ b/app/structure/lib/viewModel/data_management/researcher/insertion_tongue_data_view_model.dart
@@ -147,7 +147,6 @@ class InsertionTongueDataViewModel with ChangeNotifier {
           meatModel.updateHeatedProbExpt();
         }
       } else {
-        // TODO : 입력한 데이터 초기화
         throw ErrorDescription(response);
       }
     } catch (e) {

--- a/app/structure/lib/viewModel/data_management/researcher/insertion_tongue_data_view_model.dart
+++ b/app/structure/lib/viewModel/data_management/researcher/insertion_tongue_data_view_model.dart
@@ -151,6 +151,9 @@ class InsertionTongueDataViewModel with ChangeNotifier {
         throw ErrorDescription(response);
       }
     } catch (e) {
+      isLoading = false;
+      notifyListeners();
+
       debugPrint("Error: $e");
       if (context.mounted) showErrorPopup(context, error: e.toString());
     }

--- a/app/structure/lib/viewModel/meat_registration/camera_view_model.dart
+++ b/app/structure/lib/viewModel/meat_registration/camera_view_model.dart
@@ -30,7 +30,7 @@ class CameraViewModel with ChangeNotifier {
       if (e is CameraException && e.code == 'CameraAccessDenied') {
         // 카메라 권한 설정
         debugPrint('Camera access denied');
-        // TODO : 카메라 권한 팝업
+        if (context.mounted) showCameraPermissionPopup(context);
       } else {
         // 카메라 오류
         debugPrint('Camera error: $e');

--- a/app/structure/lib/viewModel/meat_registration/creation_management_num_view_model.dart.dart
+++ b/app/structure/lib/viewModel/meat_registration/creation_management_num_view_model.dart.dart
@@ -50,6 +50,9 @@ class CreationManagementNumViewModel with ChangeNotifier {
 
         if (response != 200) throw ErrorDescription(response);
       } catch (e) {
+        isLoading = false;
+        notifyListeners();
+
         debugPrint('Error: $e');
         if (context.mounted) showErrorPopup(context, error: e.toString());
       }
@@ -174,6 +177,9 @@ class CreationManagementNumViewModel with ChangeNotifier {
         throw ErrorDescription(response2);
       }
     } catch (e) {
+      isLoading = false;
+      notifyListeners();
+
       debugPrint('Error: $e');
       if (context.mounted) context.go('/home/registration-fail');
     }

--- a/app/structure/lib/viewModel/meat_registration/insertion_meat_image_view_model.dart
+++ b/app/structure/lib/viewModel/meat_registration/insertion_meat_image_view_model.dart
@@ -225,7 +225,6 @@ class InsertionMeatImageViewModel with ChangeNotifier {
             meatModel.updateHeatedSeonsory();
           }
         } else {
-          // TODO : 입력한 데이터 초기화
           throw ErrorDescription(response);
         }
       } catch (e) {
@@ -287,7 +286,6 @@ class InsertionMeatImageViewModel with ChangeNotifier {
 
       // 이미지가 새롭게 수정된 경우에만 firebase에 업로드
       if (imgAdded) {
-        // TODO : 이미지 업데이트 확인
         await refMeatImage.putFile(
           imgFile!,
           SettableMetadata(contentType: 'image/jpeg'),

--- a/app/structure/lib/viewModel/meat_registration/insertion_meat_image_view_model.dart
+++ b/app/structure/lib/viewModel/meat_registration/insertion_meat_image_view_model.dart
@@ -229,6 +229,9 @@ class InsertionMeatImageViewModel with ChangeNotifier {
           throw ErrorDescription(response);
         }
       } catch (e) {
+        isLoading = false;
+        notifyListeners();
+
         debugPrint('Error: $e');
         if (context.mounted) showErrorPopup(context, error: e.toString());
       }

--- a/app/structure/lib/viewModel/meat_registration/insertion_meat_info_view_model.dart
+++ b/app/structure/lib/viewModel/meat_registration/insertion_meat_info_view_model.dart
@@ -80,7 +80,7 @@ class InsertionMeatInfoViewModel with ChangeNotifier {
       if (response is Map<String, dynamic>) {
         dataTable = response[speciesValue];
       } else {
-        throw Error();
+        throw ErrorDescription(response);
       }
     } catch (e) {
       debugPrint('Error getting getMeatSpecies: $e');
@@ -172,6 +172,9 @@ class InsertionMeatInfoViewModel with ChangeNotifier {
           throw ErrorDescription(response);
         }
       } catch (e) {
+        isLoading = false;
+        notifyListeners();
+
         debugPrint('Error: $e');
         if (context.mounted) showErrorPopup(context, error: e.toString());
       }

--- a/app/structure/lib/viewModel/meat_registration/insertion_sensory_eval_view_model.dart
+++ b/app/structure/lib/viewModel/meat_registration/insertion_sensory_eval_view_model.dart
@@ -195,8 +195,13 @@ class InsertionSensoryEvalViewModel with ChangeNotifier {
           meatModel.toJsonTemp(), meatModel.userId!);
       if (response == null) throw Error();
     } catch (e) {
+      isLoading = false;
+      notifyListeners();
+
       debugPrint('Error: $e');
-      // TODO : 임시저장 에러 메시지 팝업
+      if (context.mounted) {
+        showErrorPopup(context, error: '임시 저장에 실패했습니다.');
+      }
     }
   }
 }

--- a/app/structure/lib/viewModel/meat_registration/insertion_sensory_eval_view_model.dart
+++ b/app/structure/lib/viewModel/meat_registration/insertion_sensory_eval_view_model.dart
@@ -155,6 +155,9 @@ class InsertionSensoryEvalViewModel with ChangeNotifier {
           throw ErrorDescription(response);
         }
       } catch (e) {
+        isLoading = false;
+        notifyListeners();
+
         debugPrint('Error: $e');
         if (context.mounted) showErrorPopup(context, error: e.toString());
       }

--- a/app/structure/lib/viewModel/my_page/user_detail_view_model.dart
+++ b/app/structure/lib/viewModel/my_page/user_detail_view_model.dart
@@ -103,7 +103,9 @@ class UserDetailViewModel with ChangeNotifier {
         throw ErrorDescription(response);
       }
     } catch (e) {
-      print("fefe");
+      isLoading = false;
+      notifyListeners();
+
       debugPrint('Error: $e');
       if (context.mounted) showErrorPopup(context, error: e.toString());
     }

--- a/app/structure/lib/viewModel/sign_in/sign_in_view_model.dart
+++ b/app/structure/lib/viewModel/sign_in/sign_in_view_model.dart
@@ -161,6 +161,9 @@ class SignInViewModel with ChangeNotifier {
         throw ErrorDescription(userInfo);
       }
     } catch (e) {
+      isLoading = false;
+      notifyListeners();
+
       debugPrint('Error: $e');
       if (context.mounted) showErrorPopup(context, error: e.toString());
       return false;

--- a/app/structure/lib/viewModel/sign_up/insertion_user_detail_view_model.dart
+++ b/app/structure/lib/viewModel/sign_up/insertion_user_detail_view_model.dart
@@ -116,6 +116,9 @@ class InsertionUserDetailViewModel with ChangeNotifier {
 
       if (context.mounted) showErrorPopup(context, error: e.code);
     } catch (e) {
+      isLoading = false;
+      notifyListeners();
+
       debugPrint('Error: $e');
       if (context.mounted) showErrorPopup(context, error: e.toString());
     }


### PR DESCRIPTION
`RemoteDataSource`에 `errorMsg` 함수 추가
- 백엔드 서버에서 response를 받아왔을 때 msg를 추가해서 code: msg 형식으로 변환하는 함수
- 오류 발생시 에러 메시지를 반환. 기존 코드에서는 그대로 출력만 하면 되도록 수정했습니다.

각 api try-catch 문에서 catch 할 때 팝업 띄우기 전에 `isLoading = false`로 바꾸는 로직 추가
- 그러지 않으면 팝업에서 확인을 눌러서 닫아도 계속 로딩 상태가 유지됩니다.

에러 메시지가 통일돼서 오버플로우가 생길 일이 없을 것 같긴 하지만, 만약을 대비해서 그냥 고정 Height를 제거했습니다. 
- minHeight으로 바꾸려 했으나 잘 안된 관계로 걍 제거해버림. 조금 이상하긴 한데 음.. 모르겠어요

<img width="150" alt="스크린샷 2024-10-02 오전 11 39 13" src="https://github.com/user-attachments/assets/754edbab-56b3-482a-b7be-f08ab8fffbf2">

TODO 관련된 내용들 수정했습니다.
- 카메라 권한 작업했습니다.
- 관능평가/실험 데이터 입력 후 데이터 초기화해야한다고 TODO 작성한건, 아무리 생각해봐도 초기화 굳이 안해도 될 것 같아서 그냥 삭제했습니다. 만약 나중에 문제를 발견하게 되면 그때 다시 수정하는걸로 하겠습니다.