### PR TITLE
fix: 페이지네이션에서 count 바꾸면 offset 1로 가도록

### DIFF
--- a/test-web/src/components/DataListView/DataListComp.js
+++ b/test-web/src/components/DataListView/DataListComp.js
@@ -43,12 +43,11 @@ const DataListComp = ({
     setMeatList(meatData);
   };
 
-  // useEffect(() => {
-  //   if (pageOffset) {
-  //     setCurrentPage(pageOffset + 1);
-  //   }
-  //   console.log(currentPage, 'asd');
-  // }, [pageOffset]);
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [count]);
+
+  
 
   // API fetch
   const { data, isLoading, isError } = useMeatList(

--- a/test-web/src/components/DataListView/PADataListComp.js
+++ b/test-web/src/components/DataListView/PADataListComp.js
@@ -3,7 +3,7 @@ import { Box, FormControl, InputLabel, Select, MenuItem } from '@mui/material';
 import DataList from './DataList';
 import Pagination from './Children/Pagination';
 import Spinner from 'react-bootstrap/Spinner';
-import {usePredictedMeatList} from '../../API/get/getPredictedMeatListSWR';
+import { usePredictedMeatList } from '../../API/get/getPredictedMeatListSWR';
 import style from './style/padatalistcompstyle';
 
 // 데이터 예측 페이지 목록 컴포넌트
@@ -16,7 +16,6 @@ const PADataListComp = ({ startDate, endDate, pageOffset, specieValue }) => {
   const [currentPage, setCurrentPage] = useState(1);
   // 한페이지당 보여줄 개수
   const [count, setCount] = useState(5);
-  
 
   // API fetch 데이터 전처리
   const processPAMeatDatas = (data) => {
@@ -43,7 +42,9 @@ const PADataListComp = ({ startDate, endDate, pageOffset, specieValue }) => {
 
     setMeatList(meatData);
   };
-
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [count]);
   // API fetch
   const { data, isLoading, isError } = usePredictedMeatList(
     currentPage - 1,
@@ -139,4 +140,3 @@ const PADataListComp = ({ startDate, endDate, pageOffset, specieValue }) => {
 };
 
 export default PADataListComp;
-


### PR DESCRIPTION
대시보드 페이지네이션에서 count(보여질 데이터의 개수)를 바꾸면 첫페이지로 돌아가도록 했습니다.
예측은 다른 pr로 올릴게요(깜빡함)