### PR TITLE
fix: API 맞추어 단면, 팔레트 연동

### DIFF
--- a/test-web/src/API/get/getOpencvImageDataSWR.js
+++ b/test-web/src/API/get/getOpencvImageDataSWR.js
@@ -3,11 +3,11 @@ import useSWR from 'swr';
 import { apiIP } from '../../config';
 import fetcher from '../fetcher';
 
-export const useOpencvImageData = (meatId) => {
+export const useOpencvImageData = (meatId, seqno) => {
   //id에 대항하는 육류 상세 데이터를 AmI 서버로 부터 fetch
   const { data, error } = useSWR(
     //query parameter : id
-    `http://${apiIP}/meat/get/opencv-image?meatId=${meatId}`,
+    `http://${apiIP}/meat/get/opencv-image?meatId=${meatId}&seqno=${seqno}`,
     //fetcher 함수 사용
     fetcher
   );

--- a/test-web/src/components/DataDetailPage/CardComps/ColorPaletteMaker.js
+++ b/test-web/src/components/DataDetailPage/CardComps/ColorPaletteMaker.js
@@ -27,9 +27,7 @@ const ColorPaletteMaker = ({ colors, showPercentage = false }) => {
           />
           {/* 퍼센트 표시 여부 */}
           {showPercentage && (
-            <span style={{ marginTop: '5px' }}>
-              {(color[1] * 100).toFixed(2)}
-            </span>
+            <span style={{ marginTop: '5px' }}>{color[1].toFixed(2)}</span>
           )}
         </div>
       ))}

--- a/test-web/src/components/DataDetailPage/CardComps/ColorPaletteMaker.js
+++ b/test-web/src/components/DataDetailPage/CardComps/ColorPaletteMaker.js
@@ -2,9 +2,14 @@
 import React from 'react';
 
 const ColorPaletteMaker = ({ colors, showPercentage = false }) => {
+  // 퍼센테이지 표시 여부에 따라 정렬된 컬러 배열 생성
+  const sortedColors = showPercentage
+    ? [...colors].sort((a, b) => b[1] - a[1])
+    : colors;
+
   return (
     <div style={{ display: 'flex' }}>
-      {colors.map((color, index) => (
+      {sortedColors.map((color, index) => (
         <div
           key={index}
           style={{
@@ -20,7 +25,7 @@ const ColorPaletteMaker = ({ colors, showPercentage = false }) => {
               backgroundColor: `rgb(${color[0].join(',')})`,
             }}
           />
-          {/* Conditionally show the percentage */}
+          {/* 퍼센트 표시 여부 */}
           {showPercentage && (
             <span style={{ marginTop: '5px' }}>
               {(color[1] * 100).toFixed(2)}

--- a/test-web/src/components/DataDetailPage/CardComps/MeatImgsCard.js
+++ b/test-web/src/components/DataDetailPage/CardComps/MeatImgsCard.js
@@ -94,8 +94,7 @@ const MeatImgsCard = ({
   };
 
   const [tooltipImgData, setTooltipImgData] = useState([]);
-  const { data: fetchedData, isLoading, isError } = useOpencvImageData(id);
-  const data = id === '3c80e807e2b5' ? dummyOpencvData : fetchedData;
+  const { data, isLoading, isError } = useOpencvImageData(id, currentIdx);
 
   //데이터 전처리
   useEffect(() => {
@@ -184,13 +183,30 @@ const MeatImgsCard = ({
                 {' '}
                 {isLoading ? (
                   <div style={style.overlayNotExistWrapper}>Loading...</div>
-                ) : data === undefined || data === null || isError ? (
+                ) : isError || !data || data.msg ? (
+                  // 데이터가 없는 경우
                   <div style={style.overlayNotExistWrapper}>
                     단면, 컬러팔레트 이미지가 없습니다
                   </div>
-                ) : tooltipImgData ? (
-                  <OpencvImgMaker data={tooltipImgData} />
+                ) : data.segmentImage &&
+                  data.fatColorPalette &&
+                  data.proteinColorPalette &&
+                  data.totalColorPalette ? (
+                  // 올바른 데이터인지 검사
+                  data.fatColorPalette.every(
+                    (color) =>
+                      color[0] === 0 && color[1] === 0 && color[2] === 0
+                  ) ? (
+                    // 컬러가 모두 0인 경우
+                    <div style={style.overlayNotExistWrapper}>
+                      올바르지 않은 데이터입니다
+                    </div>
+                  ) : (
+                    // 데이터가 있는 경우
+                    <OpencvImgMaker data={tooltipImgData} />
+                  )
                 ) : (
+                  // 그 외
                   <div style={style.overlayNotExistWrapper}>
                     오류로 인해 단면, 컬러팔레트 이미지를 불러올 수 없습니다
                   </div>


### PR DESCRIPTION
 * **API 맞추어 단면, 팔레트 연동하였습니다.**
불러오는 데이터 중, 육류가 아닌 이미지 등에 대해서는 컬러팔레트나 단면의 데이터가 제대로 나오지 않는 것 같아요.
우선 단면, 팔레트 모두 검은 화면만 나오는 경우를 임의로 '올바르지 않은 데이터입니다' 로 뺐는데, 이 방법이 괜찮을지 한 번 봐주시면 좋겠습니다.
* 그리고 openCV 데이터가 극단적인 경우가 존재하고, total palette는 전체를 대표하는 색 10개를 비율로 뽑아야할 것 같은데 지방, 단백질 둘을 붙인 팔레트가 지금은 출력되고 있습니다. 이 부분에 대해서도 생각해봐야할 것 같습니당 
* 이어서 웹에서 이미지 수정 시, openCV 데이터 요청하는 작업 하겠습니다.
![화면 캡처 2024-10-02 232347](https://github.com/user-attachments/assets/85d92106-1506-4575-95f9-24c1b658c801)
![화면 캡처 2024-10-02 233419](https://github.com/user-attachments/assets/7bf9bf7e-d91f-4aec-b36f-fcf4ebd80521)
![화면 캡처 2024-10-02 233645](https://github.com/user-attachments/assets/f7b87f1d-8528-4634-ae86-cb42fa65b8e5)
