### PR TITLE
refac: error msg 형식 통일 및 opencv 지방, 단백질 비율 로직 수정

### DIFF
--- a/test-backend/test-flask/api/delete_api.py
+++ b/test-backend/test-flask/api/delete_api.py
@@ -71,7 +71,7 @@ def deleteDeepAgingData():
             delete_deep_aging_data = _deleteSpecificDeepAgingData(db_session, s3_conn, id, seqno)
             return jsonify({"msg": delete_deep_aging_data["msg"]}), delete_deep_aging_data["code"]
         else:
-            return jsonify("Invalid id and seqno"), 400
+            return jsonify({"msg": "Invalid id and seqno"}), 400
     except Exception as e:
         logger.exception(str(e))
         return (

--- a/test-backend/test-flask/api/get_api.py
+++ b/test-backend/test-flask/api/get_api.py
@@ -154,7 +154,7 @@ def getMeatDataByUserId():
         start = request.args.get("start")
         end = request.args.get("end")
         if not (userId and start and end) or offset is None or count is None:
-            return jsonify("Invalid parameter"), 400
+            return jsonify({"msg": "Invalid parameter"}), 400
         meat_by_user = _getMeatDataByUserId(db_session, userId, offset, count, start, end)
         return jsonify(meat_by_user), 200
     except Exception as e:
@@ -178,7 +178,7 @@ def getMeatDataByUserType():
                 return _getMeatDataByUserType(db_session, userType)
 
             else:
-                return jsonify("No userType in parameter"), 401
+                return jsonify({"msg": "No userType in parameter"}), 400
         else:
             return jsonify({"msg": "Invalid Route, Please Try Again."}), 404
     except Exception as e:
@@ -258,7 +258,7 @@ def getMeatDataByRangeStatusType():
                 db_session, status_type, offset, count, specie_value, start, end
             )
         else:
-            return jsonify("Invalid statusType or specieValue in parameter"), 400
+            return jsonify({"msg": "Invalid statusType or specieValue in parameter"}), 400
     except Exception as e:
         logger.exception(str(e))
         return (
@@ -315,7 +315,7 @@ def getPredictionData():
         if meat_id and seqno is not None:
             return _getPredictionData(db_session, meat_id, seqno)
         else:
-            return jsonify("Invalid id or seqno parameter"), 404
+            return jsonify({"msg": "Invalid id or seqno parameter"}), 404
     except Exception as e:
         logger.exception(str(e))
         return (
@@ -339,7 +339,7 @@ def getOpenCVData():
                 return jsonify(result), 200
             else:
                 return jsonify({"msg": "OpenCV Result Does Not Exist"}), 400
-        return jsonify("Invalid id or seqno parameter"), 404
+        return jsonify({"msg": "Invalid id or seqno parameter"}), 404
     except Exception as e:
         logger.exception(str(e))
         return (

--- a/test-backend/test-flask/api/predict_api.py
+++ b/test-backend/test-flask/api/predict_api.py
@@ -24,12 +24,12 @@ def create_meat_opencv_info():
         
         # Invalid parameter
         if (meat_id or seqno) is None:
-            return {"msg": "Invalid id or seqno parameter"}, 404 
+            return jsonify({"msg": "Invalid id or seqno parameter"}), 404 
         
         # 해당 육류 - 회차의 관능 데이터가 존재하지 않을 때
         sensory_info = get_SensoryEval(db_session, meat_id, seqno)
         if not sensory_info:
-            return {"msg": f"Sensory Info Does Not Exist: {meat_id} - {seqno}"}, 400
+            return jsonify({"msg": f"Sensory Info Does Not Exist: {meat_id} - {seqno}"}), 400
         
         segment_img_object = extract_section_image(f"sensory_evals/{meat_id}-{seqno}.png", meat_id, seqno)
         
@@ -40,7 +40,7 @@ def create_meat_opencv_info():
             # PATCH 요청
             else: 
                 result = process_opencv_image_for_web(db_session, s3_conn, meat_id, seqno, segment_img_object, is_post=0)
-            return jsonify({"msg": result["msg"], "code": result["code"]})
+            return jsonify({"msg": result["msg"]}), result["code"]
         
         return jsonify({"msg": f"Fail to Create or Update OpenCV data"}), 400
     except Exception as e:
@@ -64,15 +64,15 @@ def create_meat_opencv_info_for_model():
         
         # Invalid parameter
         if (meat_id or seqno) is None:
-            return {"msg": "Invalid id or seqno parameter"}, 404 
+            return jsonify({"msg": "Invalid id or seqno parameter"}), 404 
         
         # 해당 육류 - 회차의 관능 데이터가 존재하지 않을 때
         sensory_info = get_SensoryEval(db_session, meat_id, seqno)
         if not sensory_info:
-            return {"msg": f"Sensory Info Does Not Exist: {meat_id} - {seqno}"}, 400
+            return jsonify({"msg": f"Sensory Info Does Not Exist: {meat_id} - {seqno}"}), 400
     
         result = process_opencv_image_for_learning(db_session, s3_conn, meat_id, seqno)
-        return jsonify({"msg": result["msg"], "code": result["code"]})
+        return jsonify({"msg": result["msg"]}), result["code"]
     except Exception as e:
         logging.exception(str(e))
         return (
@@ -94,17 +94,17 @@ def predict_sensory_eval():
         
         # Invalid parameter
         if (meat_id or seqno) is None:
-            return {"msg": "Invalid id or seqno parameter"}, 404 
+            return jsonify({"msg": "Invalid id or seqno parameter"}), 404 
         
         # 해당 육류 - 회차의 관능 데이터가 존재하지 않을 때
         sensory_info = get_SensoryEval(db_session, meat_id, seqno)
         if not sensory_info:
-            return {"msg": f"Sensory Info Does Not Exist: {meat_id} - {seqno}"}, 400
+            return jsonify({"msg": f"Sensory Info Does Not Exist: {meat_id} - {seqno}"}), 400
         
         # 해당 육류 - 회차의 예측 관능, 등급 데이터가 존재할 때
         ai_sensory_info = get_AI_SensoryEval(db_session, meat_id, seqno)
         if ai_sensory_info:
-            return {"msg": f"AI Sensory Info Already Exists"}, 400
+            return jsonify({"msg": f"AI Sensory Info Already Exists"}), 400
         
         ai_sensory_data = process_predict_sensory_eval(db_session, s3_conn, meat_id, seqno)
         if ai_sensory_data:

--- a/test-backend/test-flask/api/statistic_api.py
+++ b/test-backend/test-flask/api/statistic_api.py
@@ -36,7 +36,7 @@ def getRatioFreshAndProcessed():
             jsonify(
                 {"msg": "Server Error", "time": datetime.now().strftime("%H:%M:%S")}
             ),
-            505,
+            500,
         )
 
 
@@ -270,7 +270,7 @@ def getTimeSeriesData():
             timeseries_data = get_timeseries_of_cattle_data(db_session, start, end, meat_value, seqno)
             return jsonify(timeseries_data), 200
         else:
-            return jsonify("Invalid parameter"), 400
+            return jsonify({"msg": "Invalid parameter"}), 400
     except Exception as e:
         logger.exception(str(e))
         return (

--- a/test-backend/test-flask/api/update_api.py
+++ b/test-backend/test-flask/api/update_api.py
@@ -18,7 +18,7 @@ def updateConfirmData():
         if meat_id:
             return _updateConfirmData(db_session, meat_id)
         else:
-            return jsonify("No meatId parameter"), 400
+            return jsonify({"msg": "No meatId parameter"}), 400
     except Exception as e:
         # logger.exception(str(e))
         return (
@@ -37,7 +37,7 @@ def updateRejectData():
         if meat_id:
             return _updateRejectData(db_session, meat_id)
         else:
-            return jsonify("No meatId parameter"), 400
+            return jsonify({"msg": "No meatId parameter"}), 400
     except Exception as e:
         # logger.exception(str(e))
         return (

--- a/test-backend/test-flask/opencv_utils.py
+++ b/test-backend/test-flask/opencv_utils.py
@@ -275,29 +275,41 @@ def extract_palette_and_ratios(image, colors):
     
     return palette_and_ratios
 
+def normalize_ratios(palette_and_ratios):
+    ratios = [item[1] for item in palette_and_ratios]
+    total_ratio = sum(ratios)
+    normalized_palette_and_ratios = [
+        (color, (ratio / total_ratio) * 100) for color, ratio in palette_and_ratios
+    ]
+    return normalized_palette_and_ratios
+
 #총합 비율과 컬러팔레트(리스트)를 구하는 함수
 def display_palette_with_ratios(image):
     red_palette_and_ratios = extract_palette_and_ratios(image, red_colors)
     white_palette_and_ratios = extract_palette_and_ratios(image, white_colors)
     total_palette = red_palette_and_ratios + white_palette_and_ratios
+    
+    normalized_palette = normalize_ratios(total_palette)
+    
     red_proportion = []
     white_proportion = []
-    for red_color in total_palette[:5]:
-        sum = 0
-        sum += red_color[1]
+    red_sum = 0
+    white_sum = 0
+    
+    for red_color in normalized_palette[:5]:
+        red_sum += red_color[1]
         red_proportion.append(red_color)
-    red_ratio = sum
-    for white_color in total_palette[5:]:
-        sum = 0
-        sum += white_color[1]
+        
+    for white_color in normalized_palette[5:]:
+        white_sum += white_color[1]
         white_proportion.append(white_color)
-    white_ratio = sum
+        
     result = {
-        "protein_rate": red_ratio,
-        "fat_rate": white_ratio,
+        "protein_rate": red_sum,
+        "fat_rate": white_sum,
         "protein_palette": [red[0] for red in red_proportion],
         "fat_palette": [white[0] for white in white_proportion],
-        "full_palette": total_palette
+        "full_palette": normalized_palette
     }
     return result
 


### PR DESCRIPTION
## 주요 수정 사항
### api/*
- 에러 메시지 형식을 `{"msg": "error message"}, code`의 형태로 통일

### opencv_utils.py
- opencv 중 컬러팔레트 생성 후 지방, 단백질 비율을 생성할 때 계산하는 로직 수정