### PR TITLE
feat: process-opencv 연동

### DIFF
--- a/test-web/src/API/get/getPredictedData.js
+++ b/test-web/src/API/get/getPredictedData.js
@@ -1,0 +1,19 @@
+import { apiIP } from '../../config';
+
+export const getPredictedData = async (meatId, seqno) => {
+  try {
+    const response = await fetch(
+      `http://${apiIP}/meat/get/predict-data?meatId=${meatId}&seqno=${seqno}`
+    );
+    if (!response.ok) {
+      throw new Error('Network response was not ok', meatId, '-', seqno);
+    }
+    const json = await response.json();
+    return json;
+  } catch (error) {
+    console.error('Error fetching data seqno ', seqno, ':', error);
+    return null;
+  }
+};
+
+export default getPredictedData;

--- a/test-web/src/API/predict/predictOpencvImageData.js
+++ b/test-web/src/API/predict/predictOpencvImageData.js
@@ -1,0 +1,28 @@
+import { apiIP } from '../../config';
+
+// 가열육 수정 POST API
+export const predictOpencvImageData = async (
+  meatId, // 이력번호
+  seqno,
+  isPost
+) => {
+  try {
+    const response = await fetch(
+      `http://${apiIP}/meat/predict/process-opencv?meatId=${meatId}&seqno=${seqno}`,
+      {
+        method: `${isPost ? 'POST' : 'PATCH'}`,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        // body: JSON.stringify(req),
+      }
+    );
+
+    if (!response.ok) {
+      throw new Error('opencv image processing request failed');
+    }
+  } catch (error) {
+    console.error('Error during prediction:', error);
+  }
+};
+export default predictOpencvImageData;

--- a/test-web/src/API/predict/predictOpencvTrainingData.js
+++ b/test-web/src/API/predict/predictOpencvTrainingData.js
@@ -1,0 +1,28 @@
+import { apiIP } from '../../config';
+
+export const predictOpencvTrainingData = async (meatId, seqno) => {
+  try {
+    // let req = {
+    //   ['meatId']: meatId,
+    //   ['seqno']: parseInt(processedToggleValue),
+    // };
+    const response = await fetch(
+      `http://${apiIP}/meat/predict/process-opencv-training?meatId=${meatId}&seqno=${seqno}`,
+      {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        // body: JSON.stringify(req),
+      }
+    );
+
+    if (!response.ok) {
+      throw new Error('opencv training data processing request failed');
+    }
+  } catch (error) {
+    console.error('Error during prediction:', error);
+  }
+};
+
+export default predictOpencvTrainingData;

--- a/test-web/src/API/predict/predictSensoryData.js
+++ b/test-web/src/API/predict/predictSensoryData.js
@@ -1,0 +1,28 @@
+import { apiIP } from '../../config';
+
+export const predictSensoryData = async (meatId, seqno) => {
+  try {
+    // let req = {
+    //   ['meatId']: meatId,
+    //   ['seqno']: parseInt(processedToggleValue),
+    // };
+    const response = await fetch(
+      `http://${apiIP}/meat/predict/sensory-eval?meatId=${meatId}&seqno=${seqno}`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        // body: JSON.stringify(req),
+      }
+    );
+
+    if (!response.ok) {
+      throw new Error('Prediction request failed');
+    }
+  } catch (error) {
+    console.error('Error during prediction:', error);
+  }
+};
+
+export default predictSensoryData;

--- a/test-web/src/components/DataDetailPage/CardComps/MeatImgsCard.js
+++ b/test-web/src/components/DataDetailPage/CardComps/MeatImgsCard.js
@@ -12,7 +12,6 @@ import handleImgChange from './handleImgChange';
 import style from '../style/meatimgscardstyle';
 import { Tooltip } from '@mui/material';
 import useOpencvImageData from '../../../API/get/getOpencvImageDataSWR';
-import { dummyOpencvData } from './dummyOpencvData';
 import OpencvImgMaker from './OpencvImgMaker';
 
 const navy = '#0F3659';
@@ -72,6 +71,10 @@ const MeatImgsCard = ({
     setImgArr(newImages);
   };
 
+  // 툴팁 이미지 데이터
+  const [tooltipImgData, setTooltipImgData] = useState([]);
+  const { data, isLoading, isError } = useOpencvImageData(id, currentIdx);
+
   const handleFileChange = (e) => {
     handleImgChange({
       newImgFile: e.target.files[0],
@@ -90,11 +93,9 @@ const MeatImgsCard = ({
       processedMinute,
       butcheryYmd,
       isPost,
+      data,
     });
   };
-
-  const [tooltipImgData, setTooltipImgData] = useState([]);
-  const { data, isLoading, isError } = useOpencvImageData(id, currentIdx);
 
   //데이터 전처리
   useEffect(() => {

--- a/test-web/src/components/DataDetailPage/CardComps/OpencvImgMaker.js
+++ b/test-web/src/components/DataDetailPage/CardComps/OpencvImgMaker.js
@@ -37,6 +37,16 @@ const OpencvImgMaker = ({ data }) => {
               style={style.imgWrapper}
             />
           </div>
+          <div style={{ marginTop: '6vh' }}>
+            <div style={style.imgTitleWrapper}>
+              {data.proteinRate
+                ? ` 단백질 비율 (${data.proteinRate.toFixed(2)}%)`
+                : ''}
+            </div>
+            <div style={style.imgTitleWrapper}>
+              {data.fatRate ? ` 지방 비율 (${data.fatRate.toFixed(2)}%)` : ''}
+            </div>
+          </div>
         </div>
       )}
 

--- a/test-web/src/components/DataDetailPage/CardComps/handleImgChange.js
+++ b/test-web/src/components/DataDetailPage/CardComps/handleImgChange.js
@@ -2,6 +2,7 @@ import { computePeriod } from '../computeTime';
 import addSensoryRawImg from '../../../API/add/addSensoryRawImg';
 import addSensoryProcessedData from '../../../API/add/addSensoryProcessedData';
 import uploadNewImgToFirebase from '../../../API/firebase/uploadNewImgToFirebase';
+import predictOpencvImageData from '../../../API/predict/predictOpencvImageData';
 import { TIME_ZONE } from '../../../config';
 
 const handleImgChange = async ({
@@ -21,6 +22,7 @@ const handleImgChange = async ({
   processedMinute,
   butcheryYmd,
   isPost,
+  data,
 }) => {
   if (newImgFile) {
     const existSeq = processed_data_seq
@@ -53,6 +55,8 @@ const handleImgChange = async ({
           } else {
             updatePreviews(reader);
             setIsImgChanged(true);
+            // 원육 이미지는 항상 수정이므로 PATCH로 OpenCV 데이터 처리
+            predictOpencvImageData(id, 0, false);
           }
           setIsUploadingDone(true);
         });
@@ -70,6 +74,12 @@ const handleImgChange = async ({
           .then((response) => {
             updatePreviews(reader);
             setIsImgChanged(true);
+            // OpenCV 데이터가 없으면 POST로, 있으면 PATCH로 처리
+            if (!data || data.msg) {
+              isPost = true;
+            }
+            // 처리육은 isPost 값에 따라 생성/수정 구분하여 OpenCV 데이터 처리
+            predictOpencvImageData(id, existSeq[i], isPost);
           })
           .catch((error) => {
             console.error('처리육 이미지 수정 POST 요청 오류:', error);

--- a/test-web/src/components/DataDetailPage/DataPAView.js
+++ b/test-web/src/components/DataDetailPage/DataPAView.js
@@ -19,6 +19,9 @@ import { computePeriod } from './computeTime';
 import { apiIP } from '../../config';
 import { useUser } from '../../Utils/UserContext';
 
+import { predictSensoryData } from '../../API/predict/predictSensoryData';
+// import { getPredictedData } from '../../API/get/getPredictedData';
+
 const DataPAView = ({ dataProps }) => {
   //데이터 받아오기
   const {
@@ -96,24 +99,8 @@ const DataPAView = ({ dataProps }) => {
     try {
       // 로딩 화면 표시 시작
       SetIsPredictedDone(false);
-      let req = {
-        ['meatId']: meatId,
-        ['seqno']: parseInt(processedToggleValue),
-      };
-      const response = await fetch(
-        `http://${apiIP}/meat/predict/sensory-eval?meatId=${meatId}&seqno=${seqno}`,
-        {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify(req),
-        }
-      );
 
-      if (!response.ok) {
-        throw new Error('Prediction request failed');
-      }
+      await predictSensoryData(meatId, seqno);
 
       // 예측이 성공한 후 즉시 데이터를 가져오기
       const predictedData = await getPredictedData(seqno);
@@ -204,13 +191,15 @@ const DataPAView = ({ dataProps }) => {
         </div>
       )}
       <div style={style.editBtnWrapper}>
-        {((dataPA && dataPA.seqno === nowSeqno) || (imgPath === 'null')) ? (
+        {(dataPA && dataPA.seqno === nowSeqno) ||
+        imgPath === 'null' ||
+        imgPath === null ? (
           // 예측할 이미지가 없거나 이미 예측된 데이터가 존재하면, 버튼 비활성화 후 툴팁 표시
           <OverlayTrigger
             placement="top"
             delay={{ show: 250, hide: 400 }}
             overlay={
-              imgPath === 'null' ? (
+              imgPath === 'null' || imgPath === null ? (
                 <Tooltip id="no-image-tooltip">
                   예측할 이미지가 존재하지 않습니다
                 </Tooltip>

--- a/test-web/src/components/DataDetailPage/DataPAView.js
+++ b/test-web/src/components/DataDetailPage/DataPAView.js
@@ -20,6 +20,7 @@ import { apiIP } from '../../config';
 import { useUser } from '../../Utils/UserContext';
 
 import { predictSensoryData } from '../../API/predict/predictSensoryData';
+import { predictOpencvTrainingData } from '../../API/predict/predictOpencvTrainingData';
 // import { getPredictedData } from '../../API/get/getPredictedData';
 
 const DataPAView = ({ dataProps }) => {
@@ -100,6 +101,7 @@ const DataPAView = ({ dataProps }) => {
       // 로딩 화면 표시 시작
       SetIsPredictedDone(false);
 
+      await predictOpencvTrainingData(meatId, seqno);
       await predictSensoryData(meatId, seqno);
 
       // 예측이 성공한 후 즉시 데이터를 가져오기

--- a/test-web/src/components/DataDetailPage/DataView.js
+++ b/test-web/src/components/DataDetailPage/DataView.js
@@ -78,7 +78,7 @@ const DataView = ({ dataProps }) => {
 
   // 처리육 및 실험 회차 토글
   const [processed_toggle, setProcessedToggle] = useState('1회');
-  const [processedToggleValue,setProcessedToggleValue] = useState('1회');
+  const [processedToggleValue, setProcessedToggleValue] = useState('1회');
   const [heatedToggle, setHeatedToggle] = useState(options[0]);
   const [heatedToggleValue, setHeatedToggleValue] = useState('');
   const [labToggle, setLabToggle] = useState(options[0]);
@@ -313,6 +313,7 @@ const DataView = ({ dataProps }) => {
       isMethodPostPro = isMethodPost;
     }
     setIsProcessedPosted({ ...isProcessedPosted, ...dict });
+    window.location.reload();
   };
 
   // 처리육 이미지 먼저 업로드 경고 창 필요 여부


### PR DESCRIPTION
### 변경점 : 
**1.process-opencv**
process-opencv-training 모두 연동 하였습니다.

이제 이미지 새로 삽입/변경하면, 해당 이미지에 대한 단면/팔레트 이미지 생성되고 볼 수 있습니다. (편의상 수정 완료시 새로고침 하게 수정)

예측 시 process-opencv-training 먼저 진행하고 예측 진행합니다. 
**2. 단백질, 지방 비율 정보 추가하였습니다.**
![화면 캡처 2024-10-03 135141](https://github.com/user-attachments/assets/9e378198-ccb6-424d-8466-42255ebea3c7)

---
### 고려/수정할 점

* XAI 이미지가 변하지 않을 때 있음 (예: a6b845dcbee5)
(seqno에 맞춰 변하지 않고, 이미지가 없다가 한 번 이미지가 들어오면, 고정됨)

* ** 예측 여러번 할 소요!!**
기존 예측 데이터가 있어도 업데이트할 필요성 있어보임.
-> 이미지 변경된 경우 재예측 필요.

* 컬러팔레트 경우
전체 팔레트 외 단백질, 지방 팔레트 내의 색상에 대한 비율을 알 수 있을지, 아니면 비율이 큰 색상대로 정렬해서 데이터로 보내줄 수 있을 지 궁금합니다. 지금은 단백질/지방 팔레트는 비율순 정렬이 안 되어 있어, 전체 팔레트랑 순서가 차이 남.
