### PR TITLE
fix: XAI Img 처리

### DIFF
--- a/test-web/src/components/DataDetailPage/DataPAView.js
+++ b/test-web/src/components/DataDetailPage/DataPAView.js
@@ -78,9 +78,9 @@ const DataPAView = ({ dataProps }) => {
     } catch (error) {
       // 데이터를 불러오는 데 실패한 경우 모든 data를 null로 설정
       console.error('Error fetching data seqno ', seqno, ':', error);
+      setDataXAIImg(null);
+      setGradeXAIImg(null);
       setDataPA(null);
-      //setDataXAIImg(null);
-      //setGradeXAIImg(null);
     }
   };
 


### PR DESCRIPTION
### XAI Img 회차 변경에 따른 이미지 변경

- 기존 XAI 이미지가 없는 회차의 경우 다른 회차에서 이미지가 존재했다면 그 이미지가 보여졌음 -> 없는 회차는 없다고 나옴
- 모두 XAI 이미지가 있을 때 변경되는 예시 : a6b845dcbee5
- XAI 이미지가 없을 때 안나오는 예시 : 03c2e27823cd (2회차가 없습니다)



