### PR TITLE
hotfix: opencv 이미지 업데이트 캐시 우회 수정

### DIFF
--- a/test-web/src/components/DataDetailPage/CardComps/MeatImgsCard.js
+++ b/test-web/src/components/DataDetailPage/CardComps/MeatImgsCard.js
@@ -97,10 +97,15 @@ const MeatImgsCard = ({
     });
   };
 
-  //데이터 전처리
+  // 데이터 전처리
   useEffect(() => {
     if (data !== null && data !== undefined) {
-      setTooltipImgData(data);
+      const updatedData = {
+        ...data,
+        // 캐싱 방지를 위해 segmentImage URL에 타임스탬프 추가
+        segmentImage: data.segmentImage + '?time=' + new Date().getTime(),
+      };
+      setTooltipImgData(updatedData);
     }
   }, [data]);
 


### PR DESCRIPTION
segmentImg 이미지 자체가 업데이트 돼도,  url 자체는 그대로라 캐시된 이미지가 사용되어 업데이트 되지 않던 오류 수정하였습니다.