### PR TITLE
fix: 이미지 페이지네이션 및 pa 데이터 fetch 오류 수정

### DIFF
--- a/test-web/src/components/DataDetailPage/CardComps/MeatImgsCard.js
+++ b/test-web/src/components/DataDetailPage/CardComps/MeatImgsCard.js
@@ -242,7 +242,7 @@ const MeatImgsCard = ({
             <div style={style.imgContainer}>
               {
                 // 실제 이미지
-                imgArr[currentIdx] ? (
+                imgArr[currentIdx] !== null && imgArr[currentIdx] !== 'null' ? (
                   isImgChanged === true ? (
                     /*이미지 미리 보기*/
                     <img
@@ -259,7 +259,7 @@ const MeatImgsCard = ({
                   )
                 ) : (
                   <div style={style.imgNotExistWrapper}>
-                    이미지가 존재하지 않습니다.
+                    이미지가 존재하지 않습니다. <br /> 이미지를 업로드해주세요!
                   </div>
                 )
               }

--- a/test-web/src/components/DataDetailPage/CardComps/MeatImgsCard.js
+++ b/test-web/src/components/DataDetailPage/CardComps/MeatImgsCard.js
@@ -33,13 +33,32 @@ const MeatImgsCard = ({
   isPost,
 }) => {
   // 1.이미지 배열 만들기
-  const [imgArr, setImgArr] = useState([raw_img_path]);
+  // 이미지 배열 초기화
+  const [imgArr, setImgArr] = useState([]);
+  // 이미지 배열을 한 번만 설정하고, processed_img_path가 변경될 때만 업데이트
   useEffect(() => {
-    setImgArr([...imgArr, ...processed_img_path]);
-  }, []);
+    // 원육 이미지는 항상 포함
+    const newImgArr = [raw_img_path];
 
-  // 이미지 배열 페이지네이션
+    // processed_img_path가 배열이고 비어있지 않은 경우에만 처리
+    if (Array.isArray(processed_img_path) && processed_img_path.length > 0) {
+      // 최대 4회차까지만 처리육 이미지 추가
+      const processedImages = processed_img_path.slice(0, 4);
+      newImgArr.push(...processedImages);
+    }
+
+    setImgArr(newImgArr);
+  }, [raw_img_path, processed_img_path]); // 의존성 배열에 이미지 경로들 추가
+
+  // 현재 이미지 인덱스 상태
   const [currentIdx, setCurrIdx] = useState(0);
+
+  // 이미지 인덱스가 배열 범위를 벗어나지 않도록 보정
+  useEffect(() => {
+    if (currentIdx >= imgArr.length) {
+      setCurrIdx(Math.max(0, imgArr.length - 1));
+    }
+  }, [imgArr.length, currentIdx]);
 
   // 1) 이미지 페이지네이션 '>' 버튼 클릭
   const handleNextClick = () => {

--- a/test-web/src/components/DataDetailPage/DataPAView.js
+++ b/test-web/src/components/DataDetailPage/DataPAView.js
@@ -69,6 +69,7 @@ const DataPAView = ({ dataProps }) => {
       if (!response.ok) {
         throw new Error('Network response was not ok', meatId, '-', seqno);
       }
+
       const json = await response.json();
       setDataPA(json);
 
@@ -121,66 +122,33 @@ const DataPAView = ({ dataProps }) => {
     }
   };
 
-  //탭 변환에 맞는 데이터 로드
+  //탭 변환
   const handleSelect = async (key) => {
-    // 예측 데이터 로드
-    await getPredictedData(key);
     setTab(key);
-
-    const target = processedToggleValue; // n회
-    const targetIndex = processed_data_seq.indexOf(target) - 1;
-
-    // 원본 이미지 바꾸기
-    key === '0'
-      ? setPreviewImage(raw_img_path)
-      : setPreviewImage(
-          processed_img_path[targetIndex]
-            ? processed_img_path[targetIndex]
-            : null
-        );
   };
-
-  // useEffect(() => {
-  //   console.log('seqno : ', nowSeqno);
-  // }, [nowSeqno]);
-
-  useEffect(() => {
-    if (tab === '0' || tab === 0) {
-      setNowSeqno(parseInt(tab));
-    } else {
-      setNowSeqno(parseInt(processedToggleValue));
-    }
-  }, [processedToggleValue, tab]);
-
-  // 처리육 탭에서 회차가 바뀜에 따라 다른 예측 결과 load
-  useEffect(() => {
-    getPredictedData(parseInt(processedToggleValue));
-  }, [processedToggleValue]);
-
+  //원육&처리육 탭, 처리육 회차 변경에 맞추어 seqno, 이미지 변경
   useEffect(() => {
     const target = processedToggleValue; //n회
     const targetIndex = processed_data_seq.indexOf(target) - 1;
     if (tab === '0' || tab === 0) {
+      setNowSeqno(parseInt(tab));
       setImgPath(raw_img_path);
+      setPreviewImage(raw_img_path);
     } else {
+      setNowSeqno(parseInt(processedToggleValue));
       setImgPath(
+        processed_img_path[targetIndex] ? processed_img_path[targetIndex] : null
+      );
+      setPreviewImage(
         processed_img_path[targetIndex] ? processed_img_path[targetIndex] : null
       );
     }
   }, [processedToggleValue, tab]);
 
-  // 초기에 원육 예측 데이터 로드
+  // 회차 따라 예측 데이터 로드
   useEffect(() => {
-    getPredictedData(0);
-  }, []);
-
-  useEffect(() => {
-    const target = processedToggleValue; //n회
-    const targetIndex = processed_data_seq.indexOf(target) - 1;
-    setPreviewImage(
-      processed_img_path[targetIndex] ? processed_img_path[targetIndex] : null
-    );
-  }, [processedToggleValue, tab]);
+    getPredictedData(nowSeqno);
+  }, [nowSeqno]);
 
   return (
     <div style={{ width: '100%' }}>
@@ -242,7 +210,7 @@ const DataPAView = ({ dataProps }) => {
               <Card.Text>
                 <div style={style.imgTextWrapper}>원본이미지</div>
                 <div style={style.imgWrapper}>
-                  {imgPath ? (
+                  {imgPath !== 'null' && imgPath !== null ? (
                     <img
                       src={imgPath} //{previewImage + '?n=' + Math.random()}
                       style={style.imgWrapperContextImg}

--- a/test-web/src/components/DataDetailPage/style/meatimgscardstyle.js
+++ b/test-web/src/components/DataDetailPage/style/meatimgscardstyle.js
@@ -30,6 +30,7 @@ const style = {
     display: 'flex',
     justifyContent: 'center',
     alignItems: 'center',
+    textAlign: 'center',
   },
   imgUploadWrapper: {
     height: '40px',


### PR DESCRIPTION
1. 데이터 상세뷰에서 imgArr가 렌더링시 무한정 추가되어, 상세 페이지 중 작업하면 사진 페이지가 무한정 늘던 오류 수정 
-> 의존성 배열을 통해 정말 원육 및 처리육 이미지가 변경되었을 때만 업데이트 되도록 수정 총 5 페이지 이하(원육, 처리육 1-4회차)로 반영하도록 변경.

2. pa에서 이미 있는 예측 데이터를 가져올 때, 원육 데이터가 없어도 처리육 데이터를 원육 테이블에서 불러오던 오류 수정. 
-> useEffect가 여러개 겹쳐있어 오류 발생하였기에 기능에 맞게 변경

3. 상세 페이지 이미지가 없을 경우 깨지는 경우를 제대로 이미지 없습니다 로 표시하도록 로직 수정.
_**(이미지 경로가 없을 경우에, 데이터가 안와서 해당칸이 null이 되는 경우가 있고, 'null' 데이터가 와서 채워지는 경우가 있습니다)**_
![Screenshot 2024-10-03 at 20 03 16](https://github.com/user-attachments/assets/ec8d648f-fe64-4cd9-8802-5d68cb62c6cc)
![Screenshot 2024-10-03 at 20 02 39](https://github.com/user-attachments/assets/c319b24a-aa33-408e-ada4-88344a0e098f)
