### PR TITLE
fix: add sensory at register info

### DIFF
--- a/test-web/src/components/DataDetailPage/AgingInfoRegister.js
+++ b/test-web/src/components/DataDetailPage/AgingInfoRegister.js
@@ -5,15 +5,21 @@ import Form from 'react-bootstrap/Form';
 import InputGroup from 'react-bootstrap/InputGroup';
 import addDeepAgingRegister from '../../API/add/addDeepAging';
 import DeepInfoCompleteModal from './DeepInfoCompleteModal';
+import addSensoryProcessedData from '../../API/add/addSensoryProcessedData';
 
-const AgingInfoRegister = ({ handleClose, processed_data_seq, meatId }) => {
+const AgingInfoRegister = ({
+  handleClose,
+  processed_data_seq,
+  meatId,
+  userId,
+}) => {
   const [isLoading, setIsLoading] = useState(false);
   const [validated, setValidated] = useState(false);
   const [date, setDate] = useState('');
   const [time, setTime] = useState('');
   const [showCompletionModal, setShowCompletionModal] = useState(false);
   const [seqno, setSeqno] = useState('');
-  
+
   const handleCompletionModalClose = () => {
     setShowCompletionModal(false);
     handleClose();
@@ -41,8 +47,29 @@ const AgingInfoRegister = ({ handleClose, processed_data_seq, meatId }) => {
       };
       const registerResponse = await addDeepAgingRegister(req);
       if (registerResponse.ok) {
-        console.log('Success to register DeepInfo');
-        setShowCompletionModal(true);
+        try {
+          const processedInput = {
+            marbling: null,
+            color: null,
+            texture: null,
+            surfaceMoisture: null,
+            overall: null,
+          };
+          const registerSensoryResponse = await addSensoryProcessedData(
+            processedInput,
+            seqno,
+            meatId,
+            userId,
+            true,
+            false
+          );
+          if (registerSensoryResponse.ok) {
+            console.log('Success to register DeepInfo');
+            setShowCompletionModal(true);
+          }
+        } catch (error) {
+          console.error('Error during registration', error);
+        }
       }
     } catch (error) {
       console.error('Error during registration', error);
@@ -52,14 +79,15 @@ const AgingInfoRegister = ({ handleClose, processed_data_seq, meatId }) => {
 
     setValidated(true);
   };
-  
 
   // All possible sequences
   const allSeqs = ['1회', '2회', '3회', '4회'];
 
   // Filtered nonExistSeq containing values not in processed_data_seq
-  const nonExistSeq = allSeqs.filter((seq) => !processed_data_seq.includes(seq));
- 
+  const nonExistSeq = allSeqs.filter(
+    (seq) => !processed_data_seq.includes(seq)
+  );
+
   return (
     <div>
       <div>
@@ -93,7 +121,10 @@ const AgingInfoRegister = ({ handleClose, processed_data_seq, meatId }) => {
               required
               id="SelectSeqno"
               onChange={(event) => {
-                const selectedSeq = nonExistSeq[event.target.value].replace('회', '');
+                const selectedSeq = nonExistSeq[event.target.value].replace(
+                  '회',
+                  ''
+                );
                 setSeqno(selectedSeq);
               }}
               //value={seqno}

--- a/test-web/src/components/DataDetailPage/DataView.js
+++ b/test-web/src/components/DataDetailPage/DataView.js
@@ -465,6 +465,7 @@ const DataView = ({ dataProps }) => {
             handleClose={handleInfoRegisterClose}
             processed_data_seq={processed_data_seq}
             meatId={meatId}
+            userId={userId}
           />
         </Modal.Body>
       </Modal>


### PR DESCRIPTION
### DeepAgingInfo 처리시 Sensory 생성

- 기존 로직에선 DeepAgingInfo를 생성하면 Sensory data가 생성되지 않아 DB에 Info만 생성되어 이미지를 넣으려 할 때 어느 회차인지 찾지 못했음.
- DeepAgingInfo를 Register할 때, add/sensory-eval api를 호출하는데 각 데이터를 null로 하여 DB에 null값으로 생성함.
- 관능데이터 없어도 이미지 추가 가능