### PR TITLE
mod: 로그인/자동 로그인 로직 변경

### DIFF
--- a/app/structure/lib/config/user_router.dart
+++ b/app/structure/lib/config/user_router.dart
@@ -80,6 +80,27 @@ class UserRouter {
   static GoRouter getRouter(MeatModel meatModel, UserModel userModel) {
     return GoRouter(
       initialLocation: '/sign-in',
+      redirect: (context, state) {
+        // 자동 로그인이 설정되어있지 않으면 로그인 화면으로 이동
+        if (userModel.userId == null) {
+          // 회원가입, 비밀번호 변경, 비밀번호 변경 완료, 회원가입 완료 페이지로 이동은 허용
+          if (state.fullPath == '/sign-in/sign-up' ||
+              state.fullPath == '/sign-in/sign-up/user-detail' ||
+              state.fullPath == '/sign-in/password_reset' ||
+              state.fullPath == '/sign-in/complete_password_reset' ||
+              state.fullPath == '/sign-in/complete-sign-up') {
+            return null;
+          }
+
+          return '/sign-in';
+        } else if (state.fullPath == '/sign-in') {
+          // 로그인 화면에서 자동 로그인 설정시 home으로 이동
+          return '/home';
+        } else {
+          // 그 외 나머지 화면은 모두 허용
+          return null;
+        }
+      },
       routes: [
         // 로그인
         GoRoute(

--- a/app/structure/lib/screen/sign_in/sign_in_screen.dart
+++ b/app/structure/lib/screen/sign_in/sign_in_screen.dart
@@ -17,13 +17,6 @@ class SignInScreen extends StatefulWidget {
 
 class _SignInScreenState extends State<SignInScreen> {
   @override
-  void initState() {
-    super.initState();
-    // Future.delayed(Duration.zero, () {});
-    context.read<SignInViewModel>().autoLoginCheck(context);
-  }
-
-  @override
   Widget build(BuildContext context) {
     SignInViewModel signInViewModel = context.watch<SignInViewModel>();
 

--- a/app/structure/lib/viewModel/sign_in/sign_in_view_model.dart
+++ b/app/structure/lib/viewModel/sign_in/sign_in_view_model.dart
@@ -24,12 +24,6 @@ class SignInViewModel with ChangeNotifier {
   bool isLoading = false;
   bool isAutoLogin = false;
 
-  void autoLoginCheck(BuildContext context) {
-    if (userModel.auto) {
-      context.go('/home');
-    }
-  }
-
   final formKey = GlobalKey<FormState>();
 
   // firbase authentic


### PR DESCRIPTION
- signin 페이지에서 usermodel 확인 후 home으로 이동시키는 것이 아니라, GoRouter의 redirect 기능을 사용해서 바로 이동하도록 변경
- UserRouter에 `redirect` 함수 로직 추가
- 로그인/회원가입 관련 화면들은 UserModel이 `null`이어도 이동이 가능하도록 수정
- `userId`가 `null`이라면 로그인 화면으로 이동되도록 구현
- `SignInViewModel`에서 자동 로그인 확인하는 로직 제거