### PR TITLE
feat: segmentation model을 onnx로 최적화

### DIFF
--- a/test-backend/docker-compose.yml
+++ b/test-backend/docker-compose.yml
@@ -9,8 +9,9 @@ services:
     ports:
       - "8080:8080"
     restart: unless-stopped
-    environment:
-      - FLASK_ENV=development
+    env_file:
+      - ./test-flask/.env
+      - ./test-flask/serviceAccountKey.json
 
   prometheus:
     image: prom/prometheus:latest
@@ -29,7 +30,7 @@ services:
     image: grafana/grafana:latest
     container_name: grafana
     ports:
-      - "3000:3000"
+      - "3001:3000"
     environment:
       - GF_SECURITY_ADMIN_PASSWORD=admin
     volumes:

--- a/test-backend/test-flask/requirements-dev.txt
+++ b/test-backend/test-flask/requirements-dev.txt
@@ -22,6 +22,7 @@ cffi==1.16.0
 charset-normalizer==3.3.2
 click==8.1.7
 cloudpickle==3.0.0
+coloredlogs==15.0.1
 comm==0.2.1
 contourpy==1.3.0
 cryptography==42.0.8
@@ -49,6 +50,7 @@ firebase-admin==6.5.0
 Flask==3.0.3
 Flask-Cors==4.0.1
 Flask-SQLAlchemy==3.1.1
+flatbuffers==24.3.25
 fonttools==4.51.0
 fqdn==1.5.1
 fsspec==2024.2.0
@@ -76,6 +78,7 @@ h11==0.14.0
 httpie==3.2.2
 httplib2==0.22.0
 huggingface-hub==0.26.2
+humanfriendly==10.0
 idna==3.6
 imageio==2.35.1
 importlib-metadata==7.0.1
@@ -128,6 +131,8 @@ networkx==3.2.1
 notebook==7.0.8
 notebook_shim==0.2.3
 numpy==1.26.4
+onnx==1.17.0
+onnxruntime==1.20.1
 opencv-python==4.10.0.84
 opentelemetry-api==1.26.0
 opentelemetry-sdk==1.26.0


### PR DESCRIPTION
## 수정한 점
### 1) 단면 도출 U-Net 모델을 onnx로 최적화
  - CPU 환경으로 전환하게 되면서 U-Net은 모델의 크기가 너무 커서 cpu에서 돌아가지 않는 문제 상황이 발생했음.
  - 이를 해결하고자 onnx로 export하여 해당 모델을 로드하는 방식으로 수정
  - onnx로 export하는 것은 KT Cloud 상의 GPU 환경에서 진행

### 2) Docker compose 수정
 - 모니터링 시스템과 웹 프론트의 포트가 중복되는 것을 피하기 위해 모니터링의 포트를 수정
 - 환경 변수를 명시적으로 지정해줌